### PR TITLE
docs(api): documentar y crear tipos OpenAPI (#39)

### DIFF
--- a/docs/frontend/API_CLIENT.md
+++ b/docs/frontend/API_CLIENT.md
@@ -104,20 +104,85 @@ apiClient.interceptors.response.use(
 | Beneficiarios | `/v1/beneficiarios` | CRUD |
 | Documentos | `/v1/documentos` | generar, descargar |
 
-## Tipos Generated
+## Tipos Generados (OpenAPI)
 
-Generar tipos desde Swagger:
+### Ubicación
+
+```
+frontend-web/src/types/generated/
+├── api.ts           # Todos los tipos de API
+├── base.ts          # Tipos base
+├── common.ts        # Tipos comunes
+└── configuration.ts # Configuración del generador
+```
+
+### Generación de Tipos
+
+**Requisito:** El backend debe estar corriendo en `localhost:18080`.
 
 ```bash
-npx openapi-generator-cli generate \
-  -i http://localhost:8080/v3/api-docs \
-  -g typescript-fetch \
-  -o src/types/generated \
-  --additional-properties=typescriptSingleModule=true
+# 1. Iniciar backend (desde infrastructure/)
+cd infrastructure
+docker compose up -d backend
+
+# 2. Esperar a que esté listo (~30 segundos)
+
+# 3. Generar tipos (desde frontend-web/)
+cd frontend-web
+npm run generate:types
+
+# 4. Verificar tipos generados
+ls -la src/types/generated/
 ```
 
-Los tipos se generan en `src/types/generated/` y pueden importarse directamente:
+**Script en package.json:**
+```json
+{
+  "scripts": {
+    "generate:types": "openapi-generator-cli generate -i http://localhost:18080/v3/api-docs -g typescript-fetch -o src/types/generated --additional-properties=typescriptSingleModule=true"
+  }
+}
+```
+
+### Cuándo Regenerar Tipos
+
+| Situación | Acción |
+|-----------|--------|
+| Backend agrega nuevo endpoint | Regenerar tipos |
+| Backend modifica schema existente | Regenerar tipos |
+| Nuevo módulo en backend | Regenerar tipos |
+| Changes menores en backend | Regenerar tipos |
+
+### Proceso de Actualización
+
+```
+1. Backend hace cambios → Schema en /v3/api-docs cambia
+2. Frontend ejecuta: npm run generate:types
+3. Revisar cambios: git diff src/types/generated/
+4. Incluir cambios en PR de la feature
+5. Si hay breaking changes, actualizar código frontend
+```
+
+### Importación de Tipos
 
 ```typescript
-import { CuentaAhorroResponse, MovimientoResponse } from '@/types/generated/api';
+// Tipos generados automáticamente
+import {
+  CuentaAhorroResponse,
+  MovimientoResponse,
+  SolicitudCreditoResponse,
+  BeneficiarioResponse
+} from '@/types/generated/api';
+
+// Uso con API client
+const cuenta = await apiClient.get<CuentaAhorroResponse>('/v1/cuentas/12345');
 ```
+
+### Tipos Manuales vs Generados
+
+| Tipo | Cuándo usar |
+|------|-------------|
+| **Generados** | DTOs del backend (API responses) |
+| **Manuales** | Tipos frontend específicos (UI state, forms) |
+
+Los tipos en `src/types/generated/` son **solo lectura** - no editar manualmente. Regenerar sobrescribe cambios.

--- a/frontend-web/package.json
+++ b/frontend-web/package.json
@@ -10,7 +10,8 @@
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
     "test": "vitest",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "generate:types": "openapi-generator-cli generate -i http://localhost:18080/v3/api-docs -g typescript-fetch -o src/types/generated --additional-properties=typescriptSingleModule=true"
   },
   "dependencies": {
     "next": "14.2.0",

--- a/frontend-web/src/types/generated/README.md
+++ b/frontend-web/src/types/generated/README.md
@@ -1,0 +1,51 @@
+# Tipos Generados
+
+**Estado:** ⚠️ Tipos creados manualmente
+
+Estos tipos fueron creados **manualmente** basado en `docs/base-proyecto/API_CONTRACTS.md`.
+
+El backend no estaba corriendo para generar tipos desde OpenAPI.
+
+---
+
+## Cómo regenerar tipos automáticamente
+
+### 1. Iniciar backend
+
+```bash
+cd infrastructure
+docker compose up -d backend
+# Esperar ~30 segundos
+```
+
+### 2. Generar tipos
+
+```bash
+cd frontend-web
+npm run generate:types
+```
+
+### 3. Verificar
+
+```bash
+ls -la src/types/generated/
+git diff src/types/generated/
+```
+
+---
+
+## Cuándo regenerar
+
+| Situación | Acción |
+|-----------|--------|
+| Backend agrega nuevo endpoint | Regenerar |
+| Backend modifica schema | Regenerar |
+| Breaking changes | Actualizar código que usa los tipos |
+
+---
+
+## Notas
+
+- Los tipos en `api.ts` son **solo lectura**
+- Regenerar sobrescribe todos los cambios manuales
+- Para tipos frontend específicos (no del backend), usar `src/types/`

--- a/frontend-web/src/types/generated/api.ts
+++ b/frontend-web/src/types/generated/api.ts
@@ -1,0 +1,408 @@
+/**
+ * Tipos generados desde OpenAPI del backend
+ *
+ * NOTA: Estos tipos fueron creados manualmente basado en la documentación
+ * en docs/base-proyecto/API_CONTRACTS.md
+ *
+ * Para regenerar tipos automáticamente:
+ * 1. Asegurarse que el backend esté corriendo en localhost:18080
+ * 2. Ejecutar: npm run generate:types
+ *
+ * @generated
+ */
+
+export type Rol = 'SOCIO' | 'ADMIN' | 'SUPER_ADMIN' | 'CAJERO' | 'ANALISTA_KYC';
+
+// ============ AUTH ============
+
+export interface LoginRequest {
+  identificador: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  accessToken: string;
+  refreshToken: string;
+  tokenType: 'Bearer';
+  expiresIn: 900;
+  usuario: UsuarioResponse;
+}
+
+export interface UsuarioResponse {
+  id: string;
+  nombreUsuario: string;
+  correoElectronico: string;
+  nombreCompleto: string;
+  rol: Rol;
+}
+
+export interface LogoutResponse {
+  mensaje: string;
+}
+
+export interface MeResponse extends UsuarioResponse {}
+
+export interface RecuperarPasswordRequest {
+  correoElectronico: string;
+}
+
+export interface RecuperarPasswordResponse {
+  mensaje: string;
+}
+
+export interface ResetPasswordRequest {
+  token: string;
+  nuevaPassword: string;
+  confirmarPassword: string;
+}
+
+export interface ResetPasswordResponse {
+  accessToken: string;
+  refreshToken: string;
+  tokenType: 'Bearer';
+  expiresIn: 900;
+  mensaje: string;
+}
+
+// ============ SOCIOS ============
+
+export interface Direccion {
+  calle: string;
+  ciudad: string;
+  estado: string;
+  codigoPostal: string;
+  pais: string;
+}
+
+export interface ContactoEmergencia {
+  nombreCompleto: string;
+  telefono: string;
+  parentesco: string;
+}
+
+export interface SolicitudRegistroRequest {
+  primerNombre: string;
+  segundoNombre?: string;
+  primerApellido: string;
+  segundoApellido?: string;
+  tipoDocumento: 'CEDULA_IDENTIDAD' | 'PASAPORTE' | 'CEDULA_EXTRANJERA';
+  numeroDocumento: string;
+  fechaNacimiento: string;
+  genero: 'MASCULINO' | 'FEMENINO' | 'OTRO';
+  estadoCivil: 'SOLTERO' | 'CASADO' | 'UNION_LIBRE' | 'DIVORCIADO' | 'VIUDO';
+  nacionalidad: string;
+  direccion: Direccion;
+  correoElectronico: string;
+  telefonoPrincipal: string;
+  telefonoSecundario?: string;
+  contactoEmergencia: ContactoEmergencia;
+  empresa: string;
+  departamento?: string;
+  cargo?: string;
+  tipoContrato: 'PERMANENTE' | 'TEMPORAL' | 'PRESTACION_SERVICIOS' | 'PASANTE';
+  salario: number;
+  banco: string;
+  numeroCuenta: string;
+}
+
+export interface SolicitudRegistroResponse {
+  id: string;
+  estado: 'PENDIENTE';
+  mensaje: string;
+  fechaSolicitud: string;
+}
+
+export type EstadoSolicitud = 'PENDIENTE' | 'APROBADA' | 'RECHAZADA';
+
+export interface SolicitudListItem {
+  id: string;
+  primerNombre: string;
+  primerApellido: string;
+  numeroDocumento: string;
+  correoElectronico: string;
+  empresa: string;
+  estado: EstadoSolicitud;
+  fechaSolicitud: string;
+}
+
+export interface SolicitudesListResponse {
+  content: SolicitudListItem[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+export interface RechazarSolicitudRequest {
+  motivo: string;
+}
+
+export interface RechazarSolicitudResponse {
+  id: string;
+  estado: 'RECHAZADA';
+  motivo: string;
+}
+
+export interface AprobarSolicitudResponse {
+  id: string;
+  numeroSocio: string;
+  primerNombre: string;
+  primerApellido: string;
+  correoElectronico: string;
+  empresa: string;
+  estado: 'ACTIVO';
+  mensaje: string;
+}
+
+// ============ CUENTAS ============
+
+export type TipoCuenta = 'AHORRO' | 'CORRIENTE';
+
+export type EstadoCuenta = 'ACTIVA' | 'BLOQUEADA' | 'CERRADA';
+
+export interface CuentaAhorroResponse {
+  numeroCuenta: string;
+  tipo: TipoCuenta;
+  saldo: number;
+  estado: EstadoCuenta;
+  fechaCreacion: string;
+  titular: {
+    id: string;
+    nombreCompleto: string;
+  };
+}
+
+export interface SaldoResponse {
+  numeroCuenta: string;
+  saldo: number;
+  disponible: number;
+  bloqueado: number;
+}
+
+export interface DepositoRequest {
+  monto: number;
+}
+
+export interface DepositoResponse {
+  numeroCuenta: string;
+  monto: number;
+  nuevoSaldo: number;
+  referencia: string;
+  fecha: string;
+}
+
+export interface RetiroRequest {
+  monto: number;
+}
+
+export interface RetiroResponse {
+  numeroCuenta: string;
+  monto: number;
+  nuevoSaldo: number;
+  referencia: string;
+  fecha: string;
+}
+
+export type TipoMovimiento = 'DEPOSITO' | 'RETIRO' | 'TRANSFERENCIA' | 'PAGO_CREDITO';
+
+export interface MovimientoResponse {
+  id: string;
+  tipo: TipoMovimiento;
+  monto: number;
+  saldoAnterior: number;
+  saldoNuevo: number;
+  referencia: string;
+  descripcion?: string;
+  fecha: string;
+}
+
+export interface MovimientosResponse {
+  content: MovimientoResponse[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+// ============ CRÉDITOS ============
+
+export type TipoAmortizacion = 'FRANCES' | 'AMERICANO' | 'LINEA_RECTA';
+
+export interface TipoCreditoResponse {
+  id: string;
+  nombre: string;
+  descripcion: string;
+  tasaInteres: number;
+  plazoMinimoMeses: number;
+  plazoMaximoMeses: number;
+  montoMinimo: number;
+  montoMaximo: number;
+  tipoAmortizacion: TipoAmortizacion;
+  requiereGarante: boolean;
+  activo: boolean;
+}
+
+export type EstadoSolicitudCredito = 'PENDIENTE' | 'EN_EVALUACION' | 'APROBADA' | 'RECHAZADA' | 'DESEMBOLSADA' | 'CANCELADA';
+
+export interface SolicitudCreditoRequest {
+  tipoCreditoId: string;
+  montoSolicitado: number;
+  plazoMeses: number;
+  proposito: string;
+  garanteId?: string;
+}
+
+export interface SolicitudCreditoResponse {
+  id: string;
+  numeroSolicitud: string;
+  tipoCredito: string;
+  montoSolicitado: number;
+  plazoMeses: number;
+  estado: EstadoSolicitudCredito;
+  fechaSolicitud: string;
+}
+
+export interface SolicitudCreditoListResponse {
+  content: SolicitudCreditoResponse[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+export interface CuotaResponse {
+  numeroCuota: number;
+  fechaVencimiento: string;
+  capital: number;
+  interes: number;
+  monto: number;
+  saldoCapital: number;
+  estado: 'PENDIENTE' | 'PAGADA' | 'VENCIDA' | 'MORA';
+}
+
+export interface CuotasResponse {
+  solicitudId: string;
+  cuotas: CuotaResponse[];
+  totalPendiente: number;
+}
+
+export interface PagoCuotaRequest {
+  solicitudId: string;
+  numeroCuota: number;
+  monto: number;
+}
+
+export interface PagoCuotaResponse {
+  numeroCuota: number;
+  montoPagado: number;
+  nuevoSaldo: number;
+  referencia: string;
+  fecha: string;
+}
+
+// ============ KYC ============
+
+export type TipoDocumentoKYC = 'CEDULA_ANVERSO' | 'CEDULA_REVERSO' | 'SELFIE_CEDULA' | 'COMPROBANTE_DOMICILIO';
+
+export type EstadoVerificacion = 'NO_INICIADO' | 'EN_PROCESO' | 'VERIFICADO' | 'RECHAZADO';
+
+export interface VerificacionKYCResponse {
+  estado: EstadoVerificacion;
+  porcentajeCompletado: number;
+  documentosRecibidos: number;
+  documentosRequeridos: number;
+  fechaVerificacion?: string;
+}
+
+export interface DocumentoKYCResponse {
+  id: string;
+  tipo: TipoDocumentoKYC;
+  nombreArchivo: string;
+  url: string;
+  fechaSubida: string;
+  estado: 'RECIBIDO' | 'VERIFICADO' | 'RECHAZADO';
+}
+
+export interface SubirDocumentoRequest {
+  tipo: TipoDocumentoKYC;
+  archivo: File;
+}
+
+// ============ BENEFICIARIOS ============
+
+export type Parentesco = 'CONYUGE' | 'HIJO' | 'PADRE' | 'MADRE' | 'HERMANO' | 'SOBRINO' | 'ABUELO' | 'OTRO';
+
+export interface BeneficiarioRequest {
+  nombreCompleto: string;
+  numeroDocumento: string;
+  parentesco: Parentesco;
+  porcentaje: number;
+  telefono?: string;
+  correoElectronico?: string;
+}
+
+export interface BeneficiarioResponse {
+  id: string;
+  nombreCompleto: string;
+  numeroDocumento: string;
+  parentesco: Parentesco;
+  porcentaje: number;
+  telefono?: string;
+  correoElectronico?: string;
+  fechaCreacion: string;
+}
+
+export interface BeneficiariosListResponse {
+  content: BeneficiarioResponse[];
+  totalElements: number;
+  totalPages: number;
+}
+
+// ============ DOCUMENTOS ============
+
+export type TipoDocumento = 'ESTADO_CUENTA' | 'CONSTANCIA_AFILIACION' | 'CARTA_BENEFICIARIOS' | 'CONTRATO_ADHESION' | 'PAGARE';
+
+export interface GenerarDocumentoRequest {
+  tipo: TipoDocumento;
+  parametros?: Record<string, string>;
+}
+
+export interface DocumentoResponse {
+  id: string;
+  tipo: TipoDocumento;
+  nombre: string;
+  fechaGeneracion: string;
+  url?: string;
+}
+
+export interface DocumentosListResponse {
+  content: DocumentoResponse[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+// ============ PAGINATION ============
+
+export interface PageRequest {
+  page?: number;
+  size?: number;
+}
+
+export interface PageResponse<T> {
+  content: T[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+// ============ ERROR ============
+
+export interface ApiError {
+  codigo: string;
+  mensaje: string;
+  timestamp: string;
+  path?: string;
+}


### PR DESCRIPTION
## Resumen

Implementa issue #39: Generar tipos de API desde especificación OpenAPI.

**Nota:** Backend no estaba corriendo, así que los tipos fueron creados manualmente basado en `API_CONTRACTS.md`. Pueden regenerarse automáticamente cuando el backend esté disponible.

## Cambios

### Documentación
- `docs/frontend/API_CLIENT.md` - Actualizado con:
  - Instrucciones de generación de tipos
  - Cuándo regenerar tipos
  - Proceso de actualización

### Scripts
- `package.json` - Agregado script `generate:types`:
  ```bash
  npm run generate:types
  ```

### Tipos Creados
- `src/types/generated/api.ts` - ~500 líneas de tipos TypeScript
- Tipos para: Auth, Socios, Cuentas, Créditos, KYC, Beneficiarios, Documentos
- `src/types/generated/README.md` - Explicación del proceso

## Tipos Incluidos

| Módulo | Tipos |
|--------|-------|
| Auth | LoginRequest, LoginResponse, UsuarioResponse, etc. |
| Socios | SolicitudRegistroRequest, SolicitudesListResponse, etc. |
| Cuentas | CuentaAhorroResponse, MovimientoResponse, etc. |
| Créditos | TipoCreditoResponse, SolicitudCreditoResponse, CuotaResponse, etc. |
| KYC | VerificacionKYCResponse, DocumentoKYCResponse, etc. |
| Beneficiarios | BeneficiarioRequest, BeneficiarioResponse, etc. |
| Documentos | DocumentoResponse, GenerarDocumentoRequest, etc. |

## Cómo regenerar tipos

```bash
# 1. Iniciar backend
cd infrastructure && docker compose up -d backend

# 2. Esperar ~30 segundos

# 3. Generar tipos
cd frontend-web && npm run generate:types
```

## Tipo de cambio

- [x] Nueva funcionalidad
- [x] Documentación
- [ ] Corrección de bug
- [ ] Refactorización

## Checklist

- [x] Tests (N/A - tipos)
- [x] Lint
- [x] TypeScript
- [x] Documentación