### PR TITLE
feat(cuentas): página de movimientos con paginación (Issue #42)

### DIFF
--- a/backend/src/main/java/com/tufondo/ahorros/api/controller/AhorroController.java
+++ b/backend/src/main/java/com/tufondo/ahorros/api/controller/AhorroController.java
@@ -3,6 +3,7 @@ package com.tufondo.ahorros.api.controller;
 
 import com.tufondo.ahorros.application.dto.*;
 import com.tufondo.ahorros.application.usecase.*;
+import com.tufondo.ahorros.domain.model.enums.TipoMovimiento;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -136,15 +137,16 @@ public class AhorroController {
     public ResponseEntity<MovimientosListResponse> listarMovimientos(
             @PathVariable String numeroCuenta,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaInicio,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaFin,
+            @RequestParam(required = false) TipoMovimiento tipo,
             Authentication authentication) {
         UUID socioIdToken = extraerSocioId(authentication);
         boolean isAdmin = esAdmin(authentication);
-        
+
         MovimientosListResponse response = listarMovimientosUseCase.ejecutar(
-                numeroCuenta, socioIdToken, isAdmin, page, size, fechaInicio, fechaFin, null);
+                numeroCuenta, socioIdToken, isAdmin, page, size, fechaInicio, fechaFin, tipo);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/tufondo/ahorros/api/controller/AhorroController.java
+++ b/backend/src/main/java/com/tufondo/ahorros/api/controller/AhorroController.java
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -136,12 +138,15 @@ public class AhorroController {
     @Operation(summary = "Listar movimientos de cuenta")
     public ResponseEntity<MovimientosListResponse> listarMovimientos(
             @PathVariable String numeroCuenta,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "0") @Min(value = 0, message = "page debe ser >= 0") int page,
+            @RequestParam(defaultValue = "10") @Min(value = 1, message = "size debe ser >= 1") @Max(value = 100, message = "size debe ser <= 100") int size,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaInicio,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaFin,
             @RequestParam(required = false) TipoMovimiento tipo,
             Authentication authentication) {
+        if (fechaInicio != null && fechaFin != null && fechaFin.isBefore(fechaInicio)) {
+            throw new IllegalArgumentException("fechaFin debe ser mayor o igual a fechaInicio");
+        }
         UUID socioIdToken = extraerSocioId(authentication);
         boolean isAdmin = esAdmin(authentication);
 

--- a/backend/src/main/java/com/tufondo/ahorros/application/usecase/ListarMovimientosUseCase.java
+++ b/backend/src/main/java/com/tufondo/ahorros/application/usecase/ListarMovimientosUseCase.java
@@ -49,11 +49,18 @@ public class ListarMovimientosUseCase {
         Pageable pageable = PageRequest.of(page, safeSize);
 
         Page<Movimiento> movimientos;
-        if (fechaInicio != null && fechaFin != null) {
+        boolean tieneFechas = fechaInicio != null && fechaFin != null;
+        boolean tieneTipo = tipo != null;
+
+        if (tieneFechas && tieneTipo) {
+            LocalDateTime ini = fechaInicio.atStartOfDay();
+            LocalDateTime fin = fechaFin.plusDays(1).atStartOfDay();
+            movimientos = movimientoRepository.buscarPorCuentaYRangoFechasYTipo(cuenta.getId(), ini, fin, tipo, pageable);
+        } else if (tieneFechas) {
             LocalDateTime ini = fechaInicio.atStartOfDay();
             LocalDateTime fin = fechaFin.plusDays(1).atStartOfDay();
             movimientos = movimientoRepository.buscarPorCuentaYRangoFechas(cuenta.getId(), ini, fin, pageable);
-        } else if (tipo != null) {
+        } else if (tieneTipo) {
             movimientos = movimientoRepository.buscarPorCuentaYTipo(cuenta.getId(), tipo, pageable);
         } else {
             movimientos = movimientoRepository.buscarPorCuentaAhorroId(cuenta.getId(), pageable);

--- a/backend/src/main/java/com/tufondo/ahorros/domain/repository/MovimientoRepository.java
+++ b/backend/src/main/java/com/tufondo/ahorros/domain/repository/MovimientoRepository.java
@@ -48,7 +48,13 @@ public interface MovimientoRepository {
      * Lista movimientos por cuenta y tipo.
      */
     Page<Movimiento> buscarPorCuentaYTipo(UUID cuentaAhorroId, TipoMovimiento tipo, Pageable pageable);
-    
+
+    /**
+     * Lista movimientos por cuenta, rango de fechas y tipo.
+     */
+    Page<Movimiento> buscarPorCuentaYRangoFechasYTipo(UUID cuentaAhorroId,
+            LocalDateTime fechaInicio, LocalDateTime fechaFin, TipoMovimiento tipo, Pageable pageable);
+
     /**
      * Lista movimientos por socio.
      */

--- a/backend/src/main/java/com/tufondo/ahorros/infrastructure/persistence/adapter/MovimientoRepositoryImpl.java
+++ b/backend/src/main/java/com/tufondo/ahorros/infrastructure/persistence/adapter/MovimientoRepositoryImpl.java
@@ -64,6 +64,13 @@ public class MovimientoRepositoryImpl implements MovimientoRepository {
     }
 
     @Override
+    public Page<Movimiento> buscarPorCuentaYRangoFechasYTipo(UUID cuentaAhorroId,
+            LocalDateTime fechaInicio, LocalDateTime fechaFin, TipoMovimiento tipo, Pageable pageable) {
+        return jpaRepository.findByCuentaYRangoFechasYTipo(cuentaAhorroId, fechaInicio, fechaFin, tipo, pageable)
+                .map(this::toDomain);
+    }
+
+    @Override
     public Page<Movimiento> buscarPorSocioId(UUID socioId, Pageable pageable) {
         return jpaRepository.findBySocioIdOrderByFechaMovimientoDesc(socioId, pageable)
                 .map(this::toDomain);

--- a/backend/src/main/java/com/tufondo/ahorros/infrastructure/persistence/jpa/MovimientoJpaRepository.java
+++ b/backend/src/main/java/com/tufondo/ahorros/infrastructure/persistence/jpa/MovimientoJpaRepository.java
@@ -37,7 +37,18 @@ public interface MovimientoJpaRepository extends JpaRepository<MovimientoEntity,
     
     Page<MovimientoEntity> findByCuentaAhorroIdAndTipoOrderByFechaMovimientoDesc(
             UUID cuentaAhorroId, TipoMovimiento tipo, Pageable pageable);
-    
+
+    @Query("SELECT m FROM MovimientoEntity m WHERE m.cuentaAhorroId = :cuentaId " +
+           "AND m.fechaMovimiento BETWEEN :fechaInicio AND :fechaFin " +
+           "AND m.tipo = :tipo " +
+           "ORDER BY m.fechaMovimiento DESC")
+    Page<MovimientoEntity> findByCuentaYRangoFechasYTipo(
+            @Param("cuentaId") UUID cuentaAhorroId,
+            @Param("fechaInicio") LocalDateTime fechaInicio,
+            @Param("fechaFin") LocalDateTime fechaFin,
+            @Param("tipo") TipoMovimiento tipo,
+            Pageable pageable);
+
     Page<MovimientoEntity> findBySocioIdOrderByFechaMovimientoDesc(UUID socioId, Pageable pageable);
 
     @Query("SELECT COALESCE(SUM(m.monto), 0) FROM MovimientoEntity m " +

--- a/frontend-web/src/app/(dashboard)/dashboard/cuentas/[numero]/movimientos/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/cuentas/[numero]/movimientos/page.tsx
@@ -1,0 +1,376 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useParams } from 'next/navigation';
+import { useAuthStore } from '@/stores/auth-store';
+import { cuentasApi } from '@/lib/api/client';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Loader2 } from 'lucide-react';
+import Link from 'next/link';
+
+interface Movimiento {
+  id: string;
+  numeroOperacion: string;
+  cuentaAhorroId: string;
+  socioId: string;
+  tipo: string;
+  monto: number;
+  saldoAnterior: number;
+  saldoPosterior: number;
+  descripcion: string | null;
+  referencia: string | null;
+  canalOrigen: string;
+  estado: string;
+  fechaMovimiento: string;
+  fechaValor: string;
+}
+
+interface MovimientosResponse {
+  numeroCuenta: string;
+  pagina: number;
+  tamanio: number;
+  totalElementos: number;
+  totalPaginas: number;
+  movimientos: Movimiento[];
+}
+
+interface CuentaInfo {
+  id: string;
+  numeroCuenta: string;
+  tipoCuenta: string;
+  moneda: string;
+  saldoActual: number;
+}
+
+export default function MovimientosPage() {
+  const params = useParams();
+  const numeroCuenta = params.numero as string;
+
+  const user = useAuthStore((state) => state.user);
+  const isLoading = useAuthStore((state) => state.isLoading);
+
+  const [cuenta, setCuenta] = useState<CuentaInfo | null>(null);
+  const [movimientos, setMovimientos] = useState<Movimiento[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingMovimientos, setLoadingMovimientos] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [totalElements, setTotalElements] = useState(0);
+
+  const [tipoFiltro, setTipoFiltro] = useState<string>('');
+  const [fechaInicio, setFechaInicio] = useState<string>('');
+  const [fechaFin, setFechaFin] = useState<string>('');
+
+  const [totales, setTotales] = useState({ depositos: 0, retiros: 0 });
+
+  useEffect(() => {
+    if (!numeroCuenta || isLoading) return;
+
+    async function cargarCuenta() {
+      try {
+        const res = await cuentasApi.getCuenta(numeroCuenta);
+        setCuenta(res.data);
+      } catch (err) {
+        console.error('Error al cargar cuenta:', err);
+        setError('Error al cargar los datos de la cuenta');
+      }
+    }
+
+    cargarCuenta();
+  }, [numeroCuenta, isLoading]);
+
+  const cargarMovimientos = useCallback(async () => {
+    if (!numeroCuenta || isLoading) return;
+
+    setLoadingMovimientos(true);
+    try {
+      const res = await cuentasApi.getMovimientos(
+        numeroCuenta,
+        page,
+        10,
+        fechaInicio || undefined,
+        fechaFin || undefined,
+        tipoFiltro || undefined
+      );
+      const data: MovimientosResponse = res.data;
+      setMovimientos(data.movimientos || []);
+      setTotalPages(data.totalPaginas);
+      setTotalElements(data.totalElementos);
+
+      const depositos = data.movimientos
+        .filter((m: Movimiento) => m.tipo === 'DEPOSITO')
+        .reduce((acc: number, m: Movimiento) => acc + Number(m.monto), 0);
+      const retiros = data.movimientos
+        .filter((m: Movimiento) => m.tipo === 'RETIRO')
+        .reduce((acc: number, m: Movimiento) => acc + Number(m.monto), 0);
+      setTotales({ depositos, retiros });
+    } catch (err) {
+      console.error('Error al cargar movimientos:', err);
+    } finally {
+      setLoadingMovimientos(false);
+    }
+  }, [numeroCuenta, page, fechaInicio, fechaFin, tipoFiltro, isLoading]);
+
+  useEffect(() => {
+    cargarMovimientos();
+  }, [cargarMovimientos]);
+
+  const aplicarFiltros = () => {
+    setPage(0);
+    cargarMovimientos();
+  };
+
+  const limpiarFiltros = () => {
+    setTipoFiltro('');
+    setFechaInicio('');
+    setFechaFin('');
+    setPage(0);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <Loader2 className="h-8 w-8 animate-spin text-green-600" />
+      </div>
+    );
+  }
+
+  if (error || !cuenta) {
+    return (
+      <div className="space-y-4">
+        <Link href="/dashboard/cuentas">
+          <Button variant="outline">← Volver a Cuentas</Button>
+        </Link>
+        <Card>
+          <CardContent className="py-8">
+            <p className="text-center text-red-600">{error || 'Cuenta no encontrada'}</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const formatMonto = (monto: number) => {
+    const simbolo = cuenta?.moneda === 'VES' ? 'Bs' : '$';
+    return `${simbolo} ${monto.toLocaleString('es-VE', { minimumFractionDigits: 2 })}`;
+  };
+
+  const formatFecha = (fecha: string) => {
+    return new Date(fecha).toLocaleDateString('es-VE', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const formatFechaCorta = (fecha: string) => {
+    return new Date(fecha).toLocaleDateString('es-VE', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Link href={`/dashboard/cuentas/${numeroCuenta}`}>
+            <Button variant="outline">← Volver a Detalle</Button>
+          </Link>
+          <div>
+            <h1 className="text-2xl font-bold">Movimientos</h1>
+            <p className="text-gray-500">{numeroCuenta} - {cuenta.tipoCuenta}</p>
+          </div>
+        </div>
+        <div className="text-right">
+          <p className="text-sm text-gray-500">Saldo Actual</p>
+          <p className="text-xl font-bold text-green-600">{formatMonto(Number(cuenta.saldoActual))}</p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Filtros</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="tipo">Tipo de Movimiento</Label>
+              <select
+                id="tipo"
+                className="w-full h-10 px-3 border rounded-md bg-white"
+                value={tipoFiltro}
+                onChange={(e) => setTipoFiltro(e.target.value)}
+              >
+                <option value="">Todos</option>
+                <option value="DEPOSITO">Depósitos</option>
+                <option value="RETIRO">Retiros</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="fecha-inicio">Fecha Inicio</Label>
+              <Input
+                id="fecha-inicio"
+                type="date"
+                value={fechaInicio}
+                onChange={(e) => setFechaInicio(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="fecha-fin">Fecha Fin</Label>
+              <Input
+                id="fecha-fin"
+                type="date"
+                value={fechaFin}
+                onChange={(e) => setFechaFin(e.target.value)}
+              />
+            </div>
+            <div className="flex items-end gap-2">
+              <Button onClick={aplicarFiltros} className="bg-green-600 hover:bg-green-700">
+                Aplicar
+              </Button>
+              <Button variant="outline" onClick={limpiarFiltros}>
+                Limpiar
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Totales del Período</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="text-center p-4 bg-green-50 rounded-lg">
+              <p className="text-sm text-gray-500">Total Depósitos</p>
+              <p className="text-xl font-bold text-green-600">{formatMonto(totales.depositos)}</p>
+            </div>
+            <div className="text-center p-4 bg-red-50 rounded-lg">
+              <p className="text-sm text-gray-500">Total Retiros</p>
+              <p className="text-xl font-bold text-red-600">{formatMonto(totales.retiros)}</p>
+            </div>
+            <div className="text-center p-4 bg-blue-50 rounded-lg">
+              <p className="text-sm text-gray-500">Neto</p>
+              <p className={`text-xl font-bold ${totales.depositos - totales.retiros >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                {formatMonto(totales.depositos - totales.retiros)}
+              </p>
+            </div>
+            <div className="text-center p-4 bg-gray-50 rounded-lg">
+              <p className="text-sm text-gray-500">Movimientos</p>
+              <p className="text-xl font-bold text-gray-600">{totalElements}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Lista de Movimientos</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loadingMovimientos ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-green-600" />
+            </div>
+          ) : movimientos.length === 0 ? (
+            <div className="text-center py-12">
+              <p className="text-gray-500 mb-4">No hay movimientos que coincidan con los filtros</p>
+              <Button variant="outline" onClick={limpiarFiltros}>
+                Limpiar filtros
+              </Button>
+            </div>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead>
+                    <tr className="border-b bg-gray-50">
+                      <th className="text-left py-3 px-3 text-sm font-medium text-gray-500">Fecha</th>
+                      <th className="text-left py-3 px-3 text-sm font-medium text-gray-500">Operación</th>
+                      <th className="text-left py-3 px-3 text-sm font-medium text-gray-500">Tipo</th>
+                      <th className="text-left py-3 px-3 text-sm font-medium text-gray-500">Descripción</th>
+                      <th className="text-right py-3 px-3 text-sm font-medium text-gray-500">Monto</th>
+                      <th className="text-right py-3 px-3 text-sm font-medium text-gray-500">Saldo</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {movimientos.map((mov) => (
+                      <tr key={mov.id} className="border-b hover:bg-gray-50">
+                        <td className="py-3 px-3 text-sm">
+                          <div>{formatFechaCorta(mov.fechaMovimiento)}</div>
+                          <div className="text-gray-400 text-xs">{mov.numeroOperacion}</div>
+                        </td>
+                        <td className="py-3 px-3 text-sm">
+                          <span className="font-medium">{mov.canalOrigen}</span>
+                        </td>
+                        <td className="py-3 px-3">
+                          <span
+                            className={`inline-block px-2 py-1 text-xs font-medium rounded-full ${
+                              mov.tipo === 'DEPOSITO'
+                                ? 'bg-green-100 text-green-800'
+                                : 'bg-red-100 text-red-800'
+                            }`}
+                          >
+                            {mov.tipo === 'DEPOSITO' ? 'Depósito' : 'Retiro'}
+                          </span>
+                        </td>
+                        <td className="py-3 px-3 text-sm text-gray-600">
+                          {mov.descripcion || '-'}
+                          {mov.referencia && (
+                            <div className="text-gray-400 text-xs">Ref: {mov.referencia}</div>
+                          )}
+                        </td>
+                        <td className={`py-3 px-3 text-right font-medium ${
+                          mov.tipo === 'DEPOSITO' ? 'text-green-600' : 'text-red-600'
+                        }`}>
+                          {mov.tipo === 'DEPOSITO' ? '+' : '-'}{formatMonto(mov.monto)}
+                        </td>
+                        <td className="py-3 px-3 text-right text-gray-600">
+                          {formatMonto(mov.saldoPosterior)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {totalPages > 1 && (
+                <div className="flex justify-center items-center gap-4 mt-6">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((p) => Math.max(0, p - 1))}
+                    disabled={page === 0}
+                  >
+                    Anterior
+                  </Button>
+                  <span className="text-sm text-gray-500">
+                    Página {page + 1} de {totalPages} ({totalElements} movimientos)
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                    disabled={page >= totalPages - 1}
+                  >
+                    Siguiente
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend-web/src/app/(dashboard)/dashboard/cuentas/[numero]/movimientos/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/cuentas/[numero]/movimientos/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useParams } from 'next/navigation';
 import { useAuthStore } from '@/stores/auth-store';
 import { cuentasApi } from '@/lib/api/client';
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Loader2 } from 'lucide-react';
 import Link from 'next/link';
+import { toast } from 'sonner';
 
 interface Movimiento {
   id: string;
@@ -44,6 +45,29 @@ interface CuentaInfo {
   moneda: string;
   saldoActual: number;
 }
+
+const formatMonto = (monto: number, moneda: string) => {
+  const simbolo = moneda === 'VES' ? 'Bs' : '$';
+  return `${simbolo} ${monto.toLocaleString('es-VE', { minimumFractionDigits: 2 })}`;
+};
+
+const formatFecha = (fecha: string) => {
+  return new Date(fecha).toLocaleDateString('es-VE', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+const formatFechaCorta = (fecha: string) => {
+  return new Date(fecha).toLocaleDateString('es-VE', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+};
 
 export default function MovimientosPage() {
   const params = useParams();
@@ -121,6 +145,10 @@ export default function MovimientosPage() {
   }, [cargarMovimientos]);
 
   const aplicarFiltros = () => {
+    if (fechaInicio && fechaFin && fechaFin < fechaInicio) {
+      toast.error('La fecha fin debe ser mayor o igual a la fecha inicio');
+      return;
+    }
     setPage(0);
     cargarMovimientos();
   };
@@ -131,6 +159,8 @@ export default function MovimientosPage() {
     setFechaFin('');
     setPage(0);
   };
+
+  const moneda = cuenta?.moneda || 'VES';
 
   if (loading) {
     return (
@@ -155,29 +185,6 @@ export default function MovimientosPage() {
     );
   }
 
-  const formatMonto = (monto: number) => {
-    const simbolo = cuenta?.moneda === 'VES' ? 'Bs' : '$';
-    return `${simbolo} ${monto.toLocaleString('es-VE', { minimumFractionDigits: 2 })}`;
-  };
-
-  const formatFecha = (fecha: string) => {
-    return new Date(fecha).toLocaleDateString('es-VE', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  };
-
-  const formatFechaCorta = (fecha: string) => {
-    return new Date(fecha).toLocaleDateString('es-VE', {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-    });
-  };
-
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -192,7 +199,7 @@ export default function MovimientosPage() {
         </div>
         <div className="text-right">
           <p className="text-sm text-gray-500">Saldo Actual</p>
-          <p className="text-xl font-bold text-green-600">{formatMonto(Number(cuenta.saldoActual))}</p>
+          <p className="text-xl font-bold text-green-600">{formatMonto(Number(cuenta.saldoActual), moneda)}</p>
         </div>
       </div>
 
@@ -206,6 +213,7 @@ export default function MovimientosPage() {
               <Label htmlFor="tipo">Tipo de Movimiento</Label>
               <select
                 id="tipo"
+                aria-label="Filtrar por tipo de movimiento"
                 className="w-full h-10 px-3 border rounded-md bg-white"
                 value={tipoFiltro}
                 onChange={(e) => setTipoFiltro(e.target.value)}
@@ -234,8 +242,19 @@ export default function MovimientosPage() {
               />
             </div>
             <div className="flex items-end gap-2">
-              <Button onClick={aplicarFiltros} className="bg-green-600 hover:bg-green-700">
-                Aplicar
+              <Button
+                onClick={aplicarFiltros}
+                className="bg-green-600 hover:bg-green-700"
+                disabled={loadingMovimientos}
+              >
+                {loadingMovimientos ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Aplicando...
+                  </>
+                ) : (
+                  'Aplicar'
+                )}
               </Button>
               <Button variant="outline" onClick={limpiarFiltros}>
                 Limpiar
@@ -253,16 +272,16 @@ export default function MovimientosPage() {
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <div className="text-center p-4 bg-green-50 rounded-lg">
               <p className="text-sm text-gray-500">Total Depósitos</p>
-              <p className="text-xl font-bold text-green-600">{formatMonto(totales.depositos)}</p>
+              <p className="text-xl font-bold text-green-600">{formatMonto(totales.depositos, moneda)}</p>
             </div>
             <div className="text-center p-4 bg-red-50 rounded-lg">
               <p className="text-sm text-gray-500">Total Retiros</p>
-              <p className="text-xl font-bold text-red-600">{formatMonto(totales.retiros)}</p>
+              <p className="text-xl font-bold text-red-600">{formatMonto(totales.retiros, moneda)}</p>
             </div>
             <div className="text-center p-4 bg-blue-50 rounded-lg">
               <p className="text-sm text-gray-500">Neto</p>
               <p className={`text-xl font-bold ${totales.depositos - totales.retiros >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                {formatMonto(totales.depositos - totales.retiros)}
+                {formatMonto(totales.depositos - totales.retiros, moneda)}
               </p>
             </div>
             <div className="text-center p-4 bg-gray-50 rounded-lg">
@@ -295,12 +314,12 @@ export default function MovimientosPage() {
                 <table className="w-full">
                   <thead>
                     <tr className="border-b bg-gray-50">
-                      <th className="text-left py-3 px-3 text-sm font-medium text-gray-500">Fecha</th>
-                      <th className="text-left py-3 px-3 text-sm font-medium text-gray-500">Operación</th>
-                      <th className="text-left py-3 px-3 text-sm font-medium text-gray-500">Tipo</th>
-                      <th className="text-left py-3 px-3 text-sm font-medium text-gray-500">Descripción</th>
-                      <th className="text-right py-3 px-3 text-sm font-medium text-gray-500">Monto</th>
-                      <th className="text-right py-3 px-3 text-sm font-medium text-gray-500">Saldo</th>
+                      <th scope="col" className="text-left py-3 px-3 text-sm font-medium text-gray-500">Fecha</th>
+                      <th scope="col" className="text-left py-3 px-3 text-sm font-medium text-gray-500">Operación</th>
+                      <th scope="col" className="text-left py-3 px-3 text-sm font-medium text-gray-500">Tipo</th>
+                      <th scope="col" className="text-left py-3 px-3 text-sm font-medium text-gray-500">Descripción</th>
+                      <th scope="col" className="text-right py-3 px-3 text-sm font-medium text-gray-500">Monto</th>
+                      <th scope="col" className="text-right py-3 px-3 text-sm font-medium text-gray-500">Saldo</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -333,10 +352,10 @@ export default function MovimientosPage() {
                         <td className={`py-3 px-3 text-right font-medium ${
                           mov.tipo === 'DEPOSITO' ? 'text-green-600' : 'text-red-600'
                         }`}>
-                          {mov.tipo === 'DEPOSITO' ? '+' : '-'}{formatMonto(mov.monto)}
+                          {mov.tipo === 'DEPOSITO' ? '+' : '-'}{formatMonto(mov.monto, moneda)}
                         </td>
                         <td className="py-3 px-3 text-right text-gray-600">
-                          {formatMonto(mov.saldoPosterior)}
+                          {formatMonto(mov.saldoPosterior, moneda)}
                         </td>
                       </tr>
                     ))}

--- a/frontend-web/src/app/(dashboard)/dashboard/cuentas/[numero]/saldo/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/cuentas/[numero]/saldo/page.tsx
@@ -327,6 +327,14 @@ export default function SaldoDetailPage() {
           )}
         </CardContent>
       </Card>
+
+      <div className="flex justify-center">
+        <Link href={`/dashboard/cuentas/${numeroCuenta}/movimientos`}>
+          <Button className="bg-blue-600 hover:bg-blue-700 text-white">
+            Ver Todos los Movimientos
+          </Button>
+        </Link>
+      </div>
     </div>
   );
 }

--- a/frontend-web/src/app/api/cuentas/[numeroCuenta]/movimientos/route.ts
+++ b/frontend-web/src/app/api/cuentas/[numeroCuenta]/movimientos/route.ts
@@ -15,13 +15,15 @@ export async function GET(
 
     const { searchParams } = new URL(request.url);
     const page = searchParams.get('page') || '0';
-    const size = searchParams.get('size') || '20';
+    const size = searchParams.get('size') || '10';
     const fechaInicio = searchParams.get('fechaInicio') || '';
     const fechaFin = searchParams.get('fechaFin') || '';
+    const tipo = searchParams.get('tipo') || '';
 
     const queryParams = new URLSearchParams({ page, size });
     if (fechaInicio) queryParams.append('fechaInicio', fechaInicio);
     if (fechaFin) queryParams.append('fechaFin', fechaFin);
+    if (tipo) queryParams.append('tipo', tipo);
 
     const backendResponse = await fetch(
       `${BACKEND_URL}/api/v1/cuentas/${params.numeroCuenta}/movimientos?${queryParams}`,

--- a/frontend-web/src/lib/api/client.ts
+++ b/frontend-web/src/lib/api/client.ts
@@ -69,10 +69,11 @@ export const cuentasApi = {
   getCuentas: (socioId: string) => apiClient.get(`/api/cuentas/socio/${socioId}`),
   getCuenta: (numeroCuenta: string) => apiClient.get(`/api/cuentas/${numeroCuenta}`),
   getSaldo: (numeroCuenta: string) => apiClient.get(`/api/cuentas/${numeroCuenta}/saldo`),
-  getMovimientos: (numeroCuenta: string, page = 0, size = 20, fechaInicio?: string, fechaFin?: string) => {
+  getMovimientos: (numeroCuenta: string, page = 0, size = 10, fechaInicio?: string, fechaFin?: string, tipo?: string) => {
     const params = new URLSearchParams({ page: String(page), size: String(size) });
     if (fechaInicio) params.append('fechaInicio', fechaInicio);
     if (fechaFin) params.append('fechaFin', fechaFin);
+    if (tipo) params.append('tipo', tipo);
     return apiClient.get(`/api/cuentas/${numeroCuenta}/movimientos?${params}`);
   },
   deposito: (numeroCuenta: string, monto: number) =>


### PR DESCRIPTION
## Resumen
Implementa Issue #42 - Página de Movimientos con paginación

## Cambios

### Frontend
- `/dashboard/cuentas/[numero]/movimientos` - Página completa de movimientos
  - Filtros: tipo de movimiento (depósito/retiro) y rango de fechas
  - Totales del período: depósitos, retiros, neto, cantidad
  - Lista paginada (10 movimientos por página)
  - Empty state cuando no hay movimientos con los filtros
  - Tabla con: fecha, operación, tipo, descripción, monto, saldo
- Link "Ver Todos los Movimientos" en página de saldo

### Backend
- `AhorroController`: expone parámetro `tipo` para filtrar movimientos
- Default size cambiado a 10 para la página de movimientos

### API
- `cuentasApi.getMovimientos()` ahora acepta parámetro `tipo`
- API proxy route actualizada para pasar `tipo` al backend

## Criterios de aceptación
- [x] Lista de movimientos con paginación
- [x] Filtros funcionales (tipo, fechas)
- [x] Empty state cuando no hay movimientos
- [x] Totales del período mostrados

## Labels
`frontend`, `module:cuentas`

## Milestone
Sprint 3: Dashboard Socio

Closes #42