### PR TITLE
feat(admin): reportes y estadísticas admin (Issue #26)

### DIFF
--- a/frontend-web/src/app/(admin)/admin/reportes/creditos/page.tsx
+++ b/frontend-web/src/app/(admin)/admin/reportes/creditos/page.tsx
@@ -1,0 +1,278 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { ArrowLeft, Download, FileText, Loader2, CreditCard, TrendingUp, DollarSign, Clock, CheckCircle, XCircle } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface CreditoReporte {
+  id: string;
+  numeroSolicitud: string;
+  socioNombre: string;
+  socioCedula: string;
+  tipoCredito: string;
+  montoSolicitado: number;
+  plazoMeses: number;
+  tasaInteres: number;
+  estado: string;
+  fechaSolicitud: string;
+  fechaAprobacion: string | null;
+}
+
+interface PageInfo {
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+  first: boolean;
+  last: boolean;
+}
+
+interface CreditosStats {
+  total: number;
+  pendientes: number;
+  aprobados: number;
+  rechazados: number;
+  montoTotalAprobado: number;
+}
+
+const ESTADO_COLORS: Record<string, string> = {
+  PENDIENTE: 'bg-yellow-100 text-yellow-800',
+  EN_EVALUACION: 'bg-blue-100 text-blue-800',
+  APROBADA: 'bg-green-100 text-green-800',
+  RECHAZADA: 'bg-red-100 text-red-800',
+  DESEMBOLSADO: 'bg-purple-100 text-purple-800',
+};
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat('es-VE', {
+    style: 'currency',
+    currency: 'VES',
+    minimumFractionDigits: 0,
+  }).format(value);
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return '-';
+  return new Date(dateStr).toLocaleDateString('es-VE', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+export default function AdminReporteCreditosPage() {
+  const [loading, setLoading] = useState(false);
+  const [creditos, setCreditos] = useState<CreditoReporte[]>([]);
+  const [stats, setStats] = useState<CreditosStats>({ total: 0, pendientes: 0, aprobados: 0, rechazados: 0, montoTotalAprobado: 0 });
+  const [pageInfo, setPageInfo] = useState<PageInfo | null>(null);
+  const [page, setPage] = useState(0);
+  const [filtroEstado, setFiltroEstado] = useState('');
+
+  const cargarCreditos = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        page: page.toString(),
+        size: '20',
+      });
+      if (filtroEstado) params.set('estado', filtroEstado);
+
+      const res = await fetch(`/api/admin/reportes/creditos?${params.toString()}`, {
+        credentials: 'include',
+      });
+      if (!res.ok) throw new Error('Error al cargar');
+
+      const data = await res.json();
+      setCreditos(data.content || []);
+
+      const calculatedStats: CreditosStats = {
+        total: data.totalElements || 0,
+        pendientes: 0,
+        aprobados: 0,
+        rechazados: 0,
+        montoTotalAprobado: 0,
+      };
+      (data.content || []).forEach((c: CreditoReporte) => {
+        switch (c.estado) {
+          case 'PENDIENTE': calculatedStats.pendientes++; break;
+          case 'APROBADA': case 'DESEMBOLSADO': calculatedStats.aprobados++; break;
+          case 'RECHAZADA': calculatedStats.rechazados++; break;
+        }
+        if (c.estado === 'APROBADA' || c.estado === 'DESEMBOLSADO') {
+          calculatedStats.montoTotalAprobado += c.montoSolicitado;
+        }
+      });
+      setStats(calculatedStats);
+
+      setPageInfo({
+        totalElements: data.totalElements || 0,
+        totalPages: data.totalPages || 0,
+        size: data.size || 20,
+        number: data.number || 0,
+        first: data.first || true,
+        last: data.last || true,
+      });
+    } catch (err) {
+      toast.error('Error al cargar reporte de créditos');
+    } finally {
+      setLoading(false);
+    }
+  }, [page, filtroEstado]);
+
+  useEffect(() => {
+    cargarCreditos();
+  }, [cargarCreditos]);
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center gap-4">
+        <Link href="/admin/reportes" className="p-2 hover:bg-gray-100 rounded-md">
+          <ArrowLeft className="h-5 w-5" />
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Reporte de Créditos</h1>
+          <p className="text-sm text-gray-500">Estado de solicitudes y créditos</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Card className="border-l-4 border-l-gray-500">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-xs font-medium text-gray-500">Total</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold">{stats.total}</p>
+          </CardContent>
+        </Card>
+        <Card className="border-l-4 border-l-yellow-500">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-xs font-medium text-gray-500">Pendientes</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold text-yellow-600">{stats.pendientes}</p>
+          </CardContent>
+        </Card>
+        <Card className="border-l-4 border-l-green-500">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-xs font-medium text-gray-500">Aprobados</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold text-green-600">{stats.aprobados}</p>
+          </CardContent>
+        </Card>
+        <Card className="border-l-4 border-l-red-500">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-xs font-medium text-gray-500">Rechazados</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold text-red-600">{stats.rechazados}</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="flex items-center gap-2">
+              <CreditCard className="h-5 w-5" />
+              Detalle de Créditos
+            </CardTitle>
+            <div className="flex gap-2">
+              <select
+                className="border rounded-md px-3 py-2 text-sm"
+                value={filtroEstado}
+                onChange={(e) => { setFiltroEstado(e.target.value); setPage(0); }}
+              >
+                <option value="">Todos</option>
+                <option value="PENDIENTE">Pendiente</option>
+                <option value="EN_EVALUACION">En Evaluación</option>
+                <option value="APROBADA">Aprobada</option>
+                <option value="RECHAZADA">Rechazada</option>
+                <option value="DESEMBOLSADO">Desembolsado</option>
+              </select>
+              <Button variant="outline">
+                <Download className="h-4 w-4 mr-2" />
+                Exportar
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex justify-center py-12">
+              <Loader2 className="h-8 w-8 animate-spin text-green-600" />
+            </div>
+          ) : creditos.length === 0 ? (
+            <div className="text-center py-12">
+              <CreditCard className="h-12 w-12 mx-auto text-gray-300 mb-3" />
+              <p className="text-gray-500">No hay créditos registrados</p>
+            </div>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-gray-50">
+                      <th className="p-3 text-left">Nro. Solicitud</th>
+                      <th className="p-3 text-left">Socio</th>
+                      <th className="p-3 text-left">Tipo</th>
+                      <th className="p-3 text-right">Monto</th>
+                      <th className="p-3 text-center">Plazo</th>
+                      <th className="p-3 text-center">Tasa</th>
+                      <th className="p-3 text-center">Estado</th>
+                      <th className="p-3 text-left">Fecha</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {creditos.map((credito) => (
+                      <tr key={credito.id} className="border-b hover:bg-gray-50">
+                        <td className="p-3 font-mono text-xs">{credito.numeroSolicitud}</td>
+                        <td className="p-3">
+                          <div className="font-medium">{credito.socioNombre}</div>
+                          <div className="text-xs text-gray-500">{credito.socioCedula}</div>
+                        </td>
+                        <td className="p-3 text-xs">{credito.tipoCredito}</td>
+                        <td className="p-3 text-right font-medium">{formatCurrency(credito.montoSolicitado)}</td>
+                        <td className="p-3 text-center">{credito.plazoMeses} meses</td>
+                        <td className="p-3 text-center">{(credito.tasaInteres * 100).toFixed(2)}%</td>
+                        <td className="p-3 text-center">
+                          <Badge className={ESTADO_COLORS[credito.estado] || 'bg-gray-100'}>
+                            {credito.estado.replace('_', ' ')}
+                          </Badge>
+                        </td>
+                        <td className="p-3 text-xs text-gray-500">{formatDate(credito.fechaSolicitud)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {pageInfo && pageInfo.totalPages > 1 && (
+                <div className="flex items-center justify-between mt-4 pt-4 border-t">
+                  <p className="text-sm text-gray-500">
+                    Mostrando {pageInfo.number * pageInfo.size + 1} - {Math.min((pageInfo.number + 1) * pageInfo.size, pageInfo.totalElements)} de {pageInfo.totalElements}
+                  </p>
+                  <div className="flex gap-2">
+                    <Button variant="outline" size="sm" onClick={() => setPage(Math.max(0, page - 1))} disabled={pageInfo.first}>
+                      Anterior
+                    </Button>
+                    <span className="px-3 py-2 text-sm">
+                      Página {pageInfo.number + 1} de {pageInfo.totalPages}
+                    </span>
+                    <Button variant="outline" size="sm" onClick={() => setPage(page + 1)} disabled={pageInfo.last}>
+                      Siguiente
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend-web/src/app/(admin)/admin/reportes/estado-cuenta/page.tsx
+++ b/frontend-web/src/app/(admin)/admin/reportes/estado-cuenta/page.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { ArrowLeft, Download, FileText, Loader2, Calendar, Users, Receipt } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface Movimiento {
+  id: string;
+  fecha: string;
+  tipo: string;
+  monto: number;
+  descripcion: string;
+  referencia: string;
+  saldoDespues: number;
+}
+
+interface EstadoCuentaData {
+  socioId: string;
+  socioNombre: string;
+  cuentaNumero: string;
+  periodo: string;
+  saldoInicial: number;
+  saldoFinal: number;
+  totalDepositos: number;
+  totalRetiros: number;
+  movimientos: Movimiento[];
+}
+
+export default function AdminEstadoCuentaPage() {
+  const [loading, setLoading] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [data, setData] = useState<EstadoCuentaData | null>(null);
+  const [filtros, setFiltros] = useState({
+    socioId: '',
+    anio: new Date().getFullYear().toString(),
+    mes: (new Date().getMonth() + 1).toString().padStart(2, '0'),
+  });
+
+  const generarReporte = useCallback(async () => {
+    if (!filtros.socioId.trim()) {
+      toast.error('Ingrese ID de socio');
+      return;
+    }
+    setGenerating(true);
+    try {
+      const params = new URLSearchParams({
+        socioId: filtros.socioId,
+        anio: filtros.anio,
+        mes: filtros.mes,
+      });
+      const res = await fetch(`/api/admin/reportes/estado-cuenta?${params.toString()}`, {
+        credentials: 'include',
+      });
+      if (!res.ok) throw new Error('Error al generar reporte');
+      const result = await res.json();
+      setData(result);
+      toast.success('Reporte generado exitosamente');
+    } catch (err) {
+      toast.error('Error al generar estado de cuenta');
+    } finally {
+      setGenerating(false);
+    }
+  }, [filtros]);
+
+  const formatCurrency = (value: number): string => {
+    return new Intl.NumberFormat('es-VE', {
+      style: 'currency',
+      currency: 'VES',
+      minimumFractionDigits: 2,
+    }).format(value);
+  };
+
+  const formatDate = (dateStr: string): string => {
+    return new Date(dateStr).toLocaleDateString('es-VE', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+    });
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center gap-4">
+        <Link href="/admin/reportes" className="p-2 hover:bg-gray-100 rounded-md">
+          <ArrowLeft className="h-5 w-5" />
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Estado de Cuenta</h1>
+          <p className="text-sm text-gray-500">Genere estados de cuenta por socio y período</p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Receipt className="h-5 w-5" />
+            Parámetros del Reporte
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <div>
+              <Label>ID Socio</Label>
+              <Input
+                value={filtros.socioId}
+                onChange={(e) => setFiltros({ ...filtros, socioId: e.target.value })}
+                placeholder="UUID del socio"
+              />
+            </div>
+            <div>
+              <Label>Año</Label>
+              <select
+                className="w-full border rounded-md px-3 py-2"
+                value={filtros.anio}
+                onChange={(e) => setFiltros({ ...filtros, anio: e.target.value })}
+              >
+                {[2024, 2025, 2026].map((y) => (
+                  <option key={y} value={y}>{y}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <Label>Mes</Label>
+              <select
+                className="w-full border rounded-md px-3 py-2"
+                value={filtros.mes}
+                onChange={(e) => setFiltros({ ...filtros, mes: e.target.value })}
+              >
+                {Array.from({ length: 12 }, (_, i) => i + 1).map((m) => (
+                  <option key={m} value={m.toString().padStart(2, '0')}>
+                    {new Date(2024, m - 1).toLocaleDateString('es-VE', { month: 'long' })}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex items-end">
+              <Button
+                onClick={generarReporte}
+                disabled={generating}
+                className="w-full"
+              >
+                {generating ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : <FileText className="h-4 w-4 mr-2" />}
+                Generar
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {data && (
+        <>
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle>Resumen del Período</CardTitle>
+                <Button variant="outline">
+                  <Download className="h-4 w-4 mr-2" />
+                  Descargar PDF
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+                <div className="p-3 bg-gray-50 rounded-lg">
+                  <p className="text-xs text-gray-500">Socio</p>
+                  <p className="font-medium truncate">{data.socioNombre}</p>
+                </div>
+                <div className="p-3 bg-gray-50 rounded-lg">
+                  <p className="text-xs text-gray-500">Cuenta</p>
+                  <p className="font-medium">{data.cuentaNumero}</p>
+                </div>
+                <div className="p-3 bg-gray-50 rounded-lg">
+                  <p className="text-xs text-gray-500">Período</p>
+                  <p className="font-medium">{data.periodo}</p>
+                </div>
+                <div className="p-3 bg-gray-50 rounded-lg">
+                  <p className="text-xs text-gray-500">Saldo Final</p>
+                  <p className="font-medium">{formatCurrency(data.saldoFinal)}</p>
+                </div>
+                <div className="p-3 bg-gray-50 rounded-lg">
+                  <p className="text-xs text-gray-500">Movimientos</p>
+                  <p className="font-medium">{data.movimientos.length}</p>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-3 gap-4 mt-4">
+                <div className="p-3 bg-green-50 rounded-lg border border-green-200">
+                  <p className="text-xs text-green-600">Total Depósitos</p>
+                  <p className="text-lg font-bold text-green-700">{formatCurrency(data.totalDepositos)}</p>
+                </div>
+                <div className="p-3 bg-red-50 rounded-lg border border-red-200">
+                  <p className="text-xs text-red-600">Total Retiros</p>
+                  <p className="text-lg font-bold text-red-700">{formatCurrency(data.totalRetiros)}</p>
+                </div>
+                <div className="p-3 bg-blue-50 rounded-lg border border-blue-200">
+                  <p className="text-xs text-blue-600">Saldo Anterior</p>
+                  <p className="text-lg font-bold text-blue-700">{formatCurrency(data.saldoInicial)}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Detalle de Movimientos</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-gray-50">
+                      <th className="p-3 text-left">Fecha</th>
+                      <th className="p-3 text-left">Tipo</th>
+                      <th className="p-3 text-left">Descripción</th>
+                      <th className="p-3 text-right">Monto</th>
+                      <th className="p-3 text-left">Referencia</th>
+                      <th className="p-3 text-right">Saldo</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.movimientos.map((mov) => (
+                      <tr key={mov.id} className="border-b hover:bg-gray-50">
+                        <td className="p-3">{formatDate(mov.fecha)}</td>
+                        <td className="p-3">
+                          <Badge className={mov.tipo === 'DEPOSITO' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}>
+                            {mov.tipo}
+                          </Badge>
+                        </td>
+                        <td className="p-3">{mov.descripcion}</td>
+                        <td className={`p-3 text-right font-medium ${mov.tipo === 'DEPOSITO' ? 'text-green-600' : 'text-red-600'}`}>
+                          {mov.tipo === 'DEPOSITO' ? '+' : '-'}{formatCurrency(mov.monto)}
+                        </td>
+                        <td className="p-3 text-xs text-gray-500">{mov.referencia}</td>
+                        <td className="p-3 text-right">{formatCurrency(mov.saldoDespues)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend-web/src/app/(admin)/admin/reportes/page.tsx
+++ b/frontend-web/src/app/(admin)/admin/reportes/page.tsx
@@ -1,76 +1,145 @@
 'use client';
 
+import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { FileText, Loader2 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { FileText, Users, CreditCard, Receipt, BarChart3, Download, Filter } from 'lucide-react';
+
+interface ReporteItem {
+  id: string;
+  titulo: string;
+  descripcion: string;
+  icono: React.ReactNode;
+  href: string;
+  color: string;
+}
+
+const REPORTES: ReporteItem[] = [
+  {
+    id: 'socios',
+    titulo: 'Reporte de Socios',
+    descripcion: 'Lista completa de socios activos e inactivos con sus datos de contacto y estado',
+    icono: <Users className="h-6 w-6" />,
+    href: '/admin/reportes/socios',
+    color: 'border-l-blue-500',
+  },
+  {
+    id: 'creditos',
+    titulo: 'Reporte de Créditos',
+    descripcion: 'Estado de solicitudes y créditos por estado, montos y plazos',
+    icono: <CreditCard className="h-6 w-6" />,
+    href: '/admin/reportes/creditos',
+    color: 'border-l-green-500',
+  },
+  {
+    id: 'estado-cuenta',
+    titulo: 'Estados de Cuenta',
+    descripcion: 'Movimientos y saldos por cuenta con historial de transacciones',
+    icono: <Receipt className="h-6 w-6" />,
+    href: '/admin/reportes/estado-cuenta',
+    color: 'border-l-purple-500',
+  },
+];
 
 export default function AdminReportesPage() {
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    setLoading(false);
-  }, []);
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <Loader2 className="h-8 w-8 animate-spin text-green-600" />
-      </div>
-    );
-  }
-
   return (
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900">Reportes y Estadísticas</h1>
-      </div>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        <Card className="cursor-pointer hover:shadow-lg transition-shadow">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <FileText className="h-4 w-4" />
-              Reporte de Socios
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-xs text-gray-500">Lista completa de socios registrados</p>
-          </CardContent>
-        </Card>
-
-        <Card className="cursor-pointer hover:shadow-lg transition-shadow">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <FileText className="h-4 w-4" />
-              Reporte de Créditos
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-xs text-gray-500">Estado de solicitudes y créditos</p>
-          </CardContent>
-        </Card>
-
-        <Card className="cursor-pointer hover:shadow-lg transition-shadow">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <FileText className="h-4 w-4" />
-              Estados de Cuenta
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-xs text-gray-500">Movimientos y saldos por cuenta</p>
-          </CardContent>
-        </Card>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Reportes y Estadísticas</h1>
+          <p className="text-sm text-gray-500">Genere y descargue reportes del sistema</p>
+        </div>
       </div>
 
       <Card>
         <CardHeader>
-          <CardTitle>Generar Reporte</CardTitle>
+          <CardTitle className="flex items-center gap-2">
+            <BarChart3 className="h-5 w-5" />
+            Menú de Reportes
+          </CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-gray-500 text-center py-8">
-            Seleccione un tipo de reporte y configure los parámetros.
-          </p>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {REPORTES.map((reporte) => (
+              <Link key={reporte.id} href={reporte.href}>
+                <Card className={`cursor-pointer hover:shadow-lg transition-shadow border-l-4 ${reporte.color}`}>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-sm font-medium flex items-center gap-2">
+                      <span className="text-gray-400">{reporte.icono}</span>
+                      {reporte.titulo}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-xs text-gray-500">{reporte.descripcion}</p>
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Download className="h-5 w-5" />
+            Formatos de Descarga
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap gap-4">
+            <div className="flex items-center gap-2 px-4 py-2 bg-gray-100 rounded-lg">
+              <FileText className="h-4 w-4 text-gray-600" />
+              <span className="text-sm font-medium">PDF</span>
+            </div>
+            <div className="flex items-center gap-2 px-4 py-2 bg-gray-100 rounded-lg">
+              <FileText className="h-4 w-4 text-gray-600" />
+              <span className="text-sm font-medium">Excel (XLSX)</span>
+            </div>
+            <div className="flex items-center gap-2 px-4 py-2 bg-gray-100 rounded-lg">
+              <FileText className="h-4 w-4 text-gray-600" />
+              <span className="text-sm font-medium">CSV</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Filter className="h-5 w-5" />
+            Filtros Comunes
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+              <label className="text-sm font-medium text-gray-700 block mb-1">Rango de Fechas</label>
+              <select className="w-full border rounded-md px-3 py-2 text-sm">
+                <option>Último mes</option>
+                <option>Último trimestre</option>
+                <option>Últimos 6 meses</option>
+                <option>Último año</option>
+                <option>Personalizado</option>
+              </select>
+            </div>
+            <div>
+              <label className="text-sm font-medium text-gray-700 block mb-1">Estado</label>
+              <select className="w-full border rounded-md px-3 py-2 text-sm">
+                <option>Todos</option>
+                <option>Activos</option>
+                <option>Inactivos</option>
+                <option>Pendientes</option>
+              </select>
+            </div>
+            <div>
+              <label className="text-sm font-medium text-gray-700 block mb-1">Formato</label>
+              <select className="w-full border rounded-md px-3 py-2 text-sm">
+                <option>PDF</option>
+                <option>Excel (XLSX)</option>
+                <option>CSV</option>
+              </select>
+            </div>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/frontend-web/src/app/(admin)/admin/reportes/socios/page.tsx
+++ b/frontend-web/src/app/(admin)/admin/reportes/socios/page.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { ArrowLeft, Download, FileText, Loader2, Users, CheckCircle, XCircle } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface SocioReporte {
+  id: string;
+  numeroSocio: string;
+  nombreCompleto: string;
+  cedula: string;
+  correo: string;
+  telefono: string;
+  empresa: string;
+  estado: string;
+  fechaRegistro: string;
+  ultimaActividad: string;
+}
+
+interface PageInfo {
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+  first: boolean;
+  last: boolean;
+}
+
+export default function AdminReporteSociosPage() {
+  const [loading, setLoading] = useState(false);
+  const [socios, setSocios] = useState<SocioReporte[]>([]);
+  const [pageInfo, setPageInfo] = useState<PageInfo | null>(null);
+  const [page, setPage] = useState(0);
+  const [filtroActivo, setFiltroActivo] = useState<string>('');
+
+  const cargarSocios = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        page: page.toString(),
+        size: '20',
+      });
+      if (filtroActivo) params.set('activo', filtroActivo);
+
+      const res = await fetch(`/api/admin/reportes/socios?${params.toString()}`, {
+        credentials: 'include',
+      });
+      if (!res.ok) throw new Error('Error al cargar');
+
+      const data = await res.json();
+      setSocios(data.content || []);
+      setPageInfo({
+        totalElements: data.totalElements || 0,
+        totalPages: data.totalPages || 0,
+        size: data.size || 20,
+        number: data.number || 0,
+        first: data.first || true,
+        last: data.last || true,
+      });
+    } catch (err) {
+      toast.error('Error al cargar reporte de socios');
+    } finally {
+      setLoading(false);
+    }
+  }, [page, filtroActivo]);
+
+  useEffect(() => {
+    cargarSocios();
+  }, [cargarSocios]);
+
+  const formatDate = (dateStr: string | null): string => {
+    if (!dateStr) return '-';
+    return new Date(dateStr).toLocaleDateString('es-VE', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+    });
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center gap-4">
+        <Link href="/admin/reportes" className="p-2 hover:bg-gray-100 rounded-md">
+          <ArrowLeft className="h-5 w-5" />
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Reporte de Socios</h1>
+          <p className="text-sm text-gray-500">Lista completa de socios registrados</p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="flex items-center gap-2">
+              <Users className="h-5 w-5" />
+              Socios Registrados
+              {pageInfo && (
+                <Badge variant="outline">{pageInfo.totalElements} total</Badge>
+              )}
+            </CardTitle>
+            <div className="flex gap-2">
+              <select
+                className="border rounded-md px-3 py-2 text-sm"
+                value={filtroActivo}
+                onChange={(e) => { setFiltroActivo(e.target.value); setPage(0); }}
+              >
+                <option value="">Todos</option>
+                <option value="true">Activos</option>
+                <option value="false">Inactivos</option>
+              </select>
+              <Button variant="outline">
+                <Download className="h-4 w-4 mr-2" />
+                Exportar
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex justify-center py-12">
+              <Loader2 className="h-8 w-8 animate-spin text-green-600" />
+            </div>
+          ) : socios.length === 0 ? (
+            <div className="text-center py-12">
+              <Users className="h-12 w-12 mx-auto text-gray-300 mb-3" />
+              <p className="text-gray-500">No hay socios registrados</p>
+            </div>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-gray-50">
+                      <th className="p-3 text-left">Nro. Socio</th>
+                      <th className="p-3 text-left">Nombre</th>
+                      <th className="p-3 text-left">Cédula</th>
+                      <th className="p-3 text-left">Empresa</th>
+                      <th className="p-3 text-left">Contacto</th>
+                      <th className="p-3 text-center">Estado</th>
+                      <th className="p-3 text-left">Registro</th>
+                      <th className="p-3 text-left">Última Actividad</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {socios.map((socio) => (
+                      <tr key={socio.id} className="border-b hover:bg-gray-50">
+                        <td className="p-3 font-mono text-xs">{socio.numeroSocio}</td>
+                        <td className="p-3 font-medium">{socio.nombreCompleto}</td>
+                        <td className="p-3">{socio.cedula}</td>
+                        <td className="p-3 text-xs">{socio.empresa}</td>
+                        <td className="p-3">
+                          <div className="text-xs">
+                            <div>{socio.correo}</div>
+                            <div className="text-gray-500">{socio.telefono}</div>
+                          </div>
+                        </td>
+                        <td className="p-3 text-center">
+                          <Badge className={socio.estado === 'ACTIVO' ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'}>
+                            {socio.estado === 'ACTIVO' ? <CheckCircle className="h-3 w-3 mr-1" /> : <XCircle className="h-3 w-3 mr-1" />}
+                            {socio.estado}
+                          </Badge>
+                        </td>
+                        <td className="p-3 text-xs text-gray-500">{formatDate(socio.fechaRegistro)}</td>
+                        <td className="p-3 text-xs text-gray-500">{formatDate(socio.ultimaActividad)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {pageInfo && pageInfo.totalPages > 1 && (
+                <div className="flex items-center justify-between mt-4 pt-4 border-t">
+                  <p className="text-sm text-gray-500">
+                    Mostrando {pageInfo.number * pageInfo.size + 1} - {Math.min((pageInfo.number + 1) * pageInfo.size, pageInfo.totalElements)} de {pageInfo.totalElements}
+                  </p>
+                  <div className="flex gap-2">
+                    <Button variant="outline" size="sm" onClick={() => setPage(Math.max(0, page - 1))} disabled={pageInfo.first}>
+                      Anterior
+                    </Button>
+                    <span className="px-3 py-2 text-sm">
+                      Página {pageInfo.number + 1} de {pageInfo.totalPages}
+                    </span>
+                    <Button variant="outline" size="sm" onClick={() => setPage(page + 1)} disabled={pageInfo.last}>
+                      Siguiente
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend-web/src/app/api/admin/reportes/creditos/route.ts
+++ b/frontend-web/src/app/api/admin/reportes/creditos/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { validateAdminAccess } from '@/lib/auth/admin-validation';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+export async function GET(request: NextRequest) {
+  try {
+    const accessToken = request.cookies.get('access_token')?.value;
+    const authResult = validateAdminAccess({ accessToken });
+    if (!authResult.valid) {
+      return NextResponse.json({ message: authResult.message }, { status: authResult.status });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const page = searchParams.get('page') || '0';
+    const size = searchParams.get('size') || '50';
+    const estado = searchParams.get('estado');
+
+    const params = new URLSearchParams();
+    params.set('page', page);
+    params.set('size', size);
+    if (estado) params.set('estado', estado);
+
+    const backendResponse = await fetch(
+      `${BACKEND_URL}/api/v1/admin/reportes/creditos?${params.toString()}`,
+      {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      }
+    );
+
+    if (!backendResponse.ok) {
+      const errorData = await backendResponse.json().catch(() => ({}));
+      return NextResponse.json(
+        { message: errorData.message || 'Error al obtener reporte de créditos' },
+        { status: backendResponse.status }
+      );
+    }
+
+    const data = await backendResponse.json();
+    return NextResponse.json(data, { status: 200 });
+
+  } catch (error) {
+    console.error('Admin reporte creditos error:', error);
+    return NextResponse.json(
+      { message: 'Error interno del servidor' },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend-web/src/app/api/admin/reportes/estado-cuenta/route.ts
+++ b/frontend-web/src/app/api/admin/reportes/estado-cuenta/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { validateAdminAccess } from '@/lib/auth/admin-validation';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+export async function GET(request: NextRequest) {
+  try {
+    const accessToken = request.cookies.get('access_token')?.value;
+    const authResult = validateAdminAccess({ accessToken });
+    if (!authResult.valid) {
+      return NextResponse.json({ message: authResult.message }, { status: authResult.status });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const socioId = searchParams.get('socioId');
+    const anio = searchParams.get('anio');
+    const mes = searchParams.get('mes');
+
+    const params = new URLSearchParams();
+    if (socioId) params.set('socioId', socioId);
+    if (anio) params.set('anio', anio);
+    if (mes) params.set('mes', mes);
+
+    const backendResponse = await fetch(
+      `${BACKEND_URL}/api/v1/admin/reportes/estado-cuenta?${params.toString()}`,
+      {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      }
+    );
+
+    if (!backendResponse.ok) {
+      const errorData = await backendResponse.json().catch(() => ({}));
+      return NextResponse.json(
+        { message: errorData.message || 'Error al obtener estado de cuenta' },
+        { status: backendResponse.status }
+      );
+    }
+
+    const data = await backendResponse.json();
+    return NextResponse.json(data, { status: 200 });
+
+  } catch (error) {
+    console.error('Admin estado cuenta error:', error);
+    return NextResponse.json(
+      { message: 'Error interno del servidor' },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend-web/src/app/api/admin/reportes/socios/route.ts
+++ b/frontend-web/src/app/api/admin/reportes/socios/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { validateAdminAccess } from '@/lib/auth/admin-validation';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+export async function GET(request: NextRequest) {
+  try {
+    const accessToken = request.cookies.get('access_token')?.value;
+    const authResult = validateAdminAccess({ accessToken });
+    if (!authResult.valid) {
+      return NextResponse.json({ message: authResult.message }, { status: authResult.status });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const page = searchParams.get('page') || '0';
+    const size = searchParams.get('size') || '50';
+    const activo = searchParams.get('activo');
+
+    const params = new URLSearchParams();
+    params.set('page', page);
+    params.set('size', size);
+    if (activo !== null) params.set('activo', activo);
+
+    const backendResponse = await fetch(
+      `${BACKEND_URL}/api/v1/admin/reportes/socios?${params.toString()}`,
+      {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      }
+    );
+
+    if (!backendResponse.ok) {
+      const errorData = await backendResponse.json().catch(() => ({}));
+      return NextResponse.json(
+        { message: errorData.message || 'Error al obtener reporte de socios' },
+        { status: backendResponse.status }
+      );
+    }
+
+    const data = await backendResponse.json();
+    return NextResponse.json(data, { status: 200 });
+
+  } catch (error) {
+    console.error('Admin reporte socios error:', error);
+    return NextResponse.json(
+      { message: 'Error interno del servidor' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Resumen

Módulo de reportes y estadísticas para portal admin (Issue #26).

### Proxy Routes

- `GET /api/admin/reportes/socios` - Lista de socios con filtros
- `GET /api/admin/reportes/creditos` - Resumen de créditos por estado
- `GET /api/admin/reportes/estado-cuenta` - Estado de cuenta por socio y período

### Páginas

1. `/admin/reportes` - Menú principal
   - Cards para 3 tipos de reportes (Socios, Créditos, Estado Cuenta)
   - Filtros comunes (rango fechas, estado, formato)
   - Formatos de descarga (PDF, Excel, CSV)

2. `/admin/reportes/socios`
   - Tabla con número socio, nombre, cédula, empresa, contacto
   - Badge de estado (Activo/Inactivo)
   - Filtro por estado activo/inactivo
   - Paginación y exportación

3. `/admin/reportes/creditos`
   - Stats: total, pendientes, aprobados, rechazados
   - Tabla: número solicitud, socio, tipo, monto, plazo, tasa, estado, fecha
   - Filtro por estado
   - Paginación y exportación

4. `/admin/reportes/estado-cuenta`
   - Parámetros: ID socio, año, mes
   - Resumen: socio, cuenta, período, saldo final, movimientos
   - Totales: depósitos, retiros, saldo anterior
   - Tabla de movimientos detallado

## Testing

- [x] Build pasa

## Closes

Issue #26