### PR TITLE
feat(#103): validación campos específicos Venezuela

### DIFF
--- a/frontend-web/src/lib/utils/validators.test.ts
+++ b/frontend-web/src/lib/utils/validators.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { registroSchema, ESTADOS_VENEZUELA, TIPOS_DOCUMENTO, GENEROS, ESTADOS_CIVILES } from '@/lib/utils/validators';
+import { registroSchema, profileSchema, ESTADOS_VENEZUELA, BANCOS_VENEZUELA, TIPOS_DOCUMENTO, GENEROS, ESTADOS_CIVILES } from '@/lib/utils/validators';
 
 describe('registroSchema - Validaciones Issue #99', () => {
 
@@ -593,6 +593,163 @@ describe('registroSchema - Validaciones Issue #99', () => {
       expect(ESTADOS_CIVILES.length).toBe(5);
       expect(ESTADOS_CIVILES).toContain('SOLTERO');
       expect(ESTADOS_CIVILES).toContain('CASADO');
+    });
+
+    it('BANCOS_VENEZUELA tiene bancos válidos', () => {
+      expect(BANCOS_VENEZUELA.length).toBeGreaterThan(0);
+      expect(BANCOS_VENEZUELA[0]).toHaveProperty('codigo');
+      expect(BANCOS_VENEZUELA[0]).toHaveProperty('nombre');
+      const bancoVenezuela = BANCOS_VENEZUELA.find(b => b.codigo === '0102');
+      expect(bancoVenezuela?.nombre).toBe('Banco de Venezuela');
+    });
+
+  });
+
+});
+
+describe('profileSchema - Validaciones Issue #103', () => {
+
+  describe('1. Teléfono Venezuela', () => {
+
+    it('teléfono 04121234567 válido', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('teléfono +584121234567 válido', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '+584121234567',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('teléfono corto falla', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '123',
+      });
+      expect(result.success).toBe(false);
+    });
+
+  });
+
+  describe('2. Código Postal Venezuela', () => {
+
+    it('código postal 4 dígitos válido', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        direccionResidencia: { codigoPostal: '1010' },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('código postal con letras falla', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        direccionResidencia: { codigoPostal: '1010A' },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('código postal con más de 4 dígitos falla', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        direccionResidencia: { codigoPostal: '10101' },
+      });
+      expect(result.success).toBe(false);
+    });
+
+  });
+
+  describe('3. RIF Empresa', () => {
+
+    it('RIF J-12345678-9 válido', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        rifEmpresa: 'J-12345678-9',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('RIF V-12345678 válido', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        rifEmpresa: 'V-12345678',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('RIF sin prefijo falla', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        rifEmpresa: '12345678',
+      });
+      expect(result.success).toBe(false);
+    });
+
+  });
+
+  describe('4. Número de Cuenta', () => {
+
+    it('cuenta 10 dígitos válida', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        numeroCuentaNomina: '0102123456',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('cuenta 20 dígitos válida', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        numeroCuentaNomina: '01021234567890123456',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('cuenta con letras falla', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        numeroCuentaNomina: '0102ABCD123456',
+      });
+      expect(result.success).toBe(false);
     });
 
   });

--- a/frontend-web/src/lib/utils/validators.ts
+++ b/frontend-web/src/lib/utils/validators.ts
@@ -33,8 +33,35 @@ export const ESTADOS_VENEZUELA = [
   'Amazonas', 'Anzoátegui', 'Apure', 'Aragua', 'Barinas', 'Bolívar',
   'Carabobo', 'Cojedes', 'Delta Amacuro', 'Distrito Capital', 'Falcón',
   'Guárico', 'Lara', 'Mérida', 'Miranda', 'Monagas', 'Nueva Esparta',
-  'Portuguesa', 'Sucre', 'Táchira', 'Trujillo', 'Vargas', 'Yaracuy', 'Zulia'
+  'Portuguesa', 'Sucre', 'Táchira', 'Trujillo', 'La Guaira', 'Yaracuy', 'Zulia'
 ] as const;
+
+export const BANCOS_VENEZUELA = [
+  { codigo: '0102', nombre: 'Banco de Venezuela' },
+  { codigo: '0104', nombre: 'Banco Provincial' },
+  { codigo: '0105', nombre: 'Banco de Guyana' },
+  { codigo: '0114', nombre: 'Banco del Caribe' },
+  { codigo: '0128', nombre: 'Banco Caroní' },
+  { codigo: '0134', nombre: 'Banco Bicentenario' },
+  { codigo: '0137', nombre: 'Banco Sofitasa' },
+  { codigo: '0138', nombre: 'Banco Plaza' },
+  { codigo: '0151', nombre: 'Banco Fondo Común' },
+  { codigo: '0156', nombre: 'Banco 100% Banco' },
+  { codigo: '0157', nombre: 'Banco Digital' },
+  { codigo: '0163', nombre: 'Banco del Tesoro' },
+  { codigo: '0166', nombre: 'Banco Agro' },
+  { codigo: '0171', nombre: 'Banco Activo' },
+  { codigo: '0174', nombre: 'Banco Bancrecer' },
+  { codigo: '0175', nombre: 'Banco Internacional de Desarrollo' },
+  { codigo: '0177', nombre: 'Banco Banplus' },
+  { codigo: '0181', nombre: 'Banco Venezuelan' },
+  { codigo: '0186', nombre: 'Banco Mi Banco' },
+  { codigo: '0190', nombre: 'Banco Nacional de Crédito' },
+  { codigo: '0601', nombre: 'Banco de la Fuerza Armada' },
+] as const;
+
+const codigoPostalRegex = /^\d{4}$/;
+const telefonoVenezuelRegex = /^(\+58)?[0-9]{10,11}$/;
 
 export const TIPOS_DOCUMENTO = ['CEDULA', 'CEDULA_EXTRANJERO', 'PASAPORTE', 'RIF'] as const;
 export const GENEROS = ['MASCULINO', 'FEMENINO', 'OTRO'] as const;
@@ -164,14 +191,14 @@ export const beneficiarioSchema = z.object({
 const direccionSchema = z.object({
   calle: z.string().max(200).optional(),
   ciudad: z.string().max(100).optional(),
-  estado: z.string().max(100).optional(),
-  codigoPostal: z.string().max(20).optional(),
+  estado: z.string().max(50).optional(),
+  codigoPostal: z.string().regex(codigoPostalRegex, 'Código postal debe ser 4 dígitos').optional().or(z.literal('')),
   pais: z.string().max(100).optional(),
 });
 
 const contactoEmergenciaSchema = z.object({
   nombre: z.string().min(2, 'Mínimo 2 caracteres').max(200),
-  telefono: z.string().regex(/^\+?[0-9]{7,15}$/, 'Teléfono inválido'),
+  telefono: z.string().regex(telefonoVenezuelRegex, 'Teléfono inválido'),
   parentesco: z.string().max(100).optional(),
 });
 
@@ -184,11 +211,12 @@ export const profileSchema = z.object({
   genero: z.enum(['MASCULINO', 'FEMENINO', 'OTRO']).optional(),
   estadoCivil: z.enum(['SOLTERO', 'CASADO', 'DIVORCIADO', 'VIUDO', 'UNION_LIBRE']).optional(),
   correoElectronico: z.string().email('Email inválido'),
-  telefonoPrincipal: z.string().regex(/^\+?[0-9]{7,15}$/, 'Teléfono inválido'),
-  telefonoSecundario: z.string().regex(/^\+?[0-9]{7,15}$/, 'Teléfono inválido').optional().or(z.literal('')),
+  telefonoPrincipal: z.string().regex(telefonoVenezuelRegex, 'Teléfono inválido (formato: 04121234567 o +584121234567)'),
+  telefonoSecundario: z.string().regex(telefonoVenezuelRegex, 'Teléfono inválido').optional().or(z.literal('')),
   direccionResidencia: direccionSchema.optional(),
   direccionLaboral: direccionSchema.optional(),
   empresa: z.string().max(200).optional().or(z.literal('')),
+  rifEmpresa: z.string().regex(/^(J|V|E|G)-\d{6,10}(-\d)?$/, 'RIF inválido').optional().or(z.literal('')),
   departamento: z.string().max(100).optional().or(z.literal('')),
   cargo: z.string().max(100).optional().or(z.literal('')),
   tipoContrato: z.enum(['CONTRATO_INDEFINIDO', 'CONTRATO_TEMPORAL', 'CONTRATO_POR_HORAS', 'SERVICIOS', 'APRENDIZ']).optional(),


### PR DESCRIPTION
## Summary
Issue #103: Validación campos específicos Venezuela

## Frontend
- `BANCOS_VENEZUELA`: 21 bancos venezolanos con código y nombre
- `profileSchema`: 
  - Teléfono: formato Venezuela (`+58XXXXXXXXXX` o `0XXXXXXXXX`)
  - Código postal: 4 dígitos
  - RIF empresa: `J|V|E|G-XXXXXXXX(-X)?`
- `direccionSchema`: código postal validado

## Tests
- `validators.test.ts`: +13 tests para profileSchema
- Total: 225 frontend tests passing