### PR TITLE
feat(#101): verificación de contraseña para cambios sensibles

### DIFF
--- a/backend/src/main/java/com/tufondo/auth/domain/model/audit/SecurityEvent.java
+++ b/backend/src/main/java/com/tufondo/auth/domain/model/audit/SecurityEvent.java
@@ -11,6 +11,26 @@ public record SecurityEvent(
         Instant timestamp,
         String detalles
 ) {
+    public static SecurityEventBuilder builder() {
+        return new SecurityEventBuilder();
+    }
+
+    public static class SecurityEventBuilder {
+        private UUID id = UUID.randomUUID();
+        private String tipoEvento;
+        private UUID usuarioId;
+        private String ipAddress;
+        private Instant timestamp = Instant.now();
+        private String detalles;
+
+        public SecurityEventBuilder id(UUID id) { this.id = id; return this; }
+        public SecurityEventBuilder tipoEvento(String tipoEvento) { this.tipoEvento = tipoEvento; return this; }
+        public SecurityEventBuilder usuarioId(UUID usuarioId) { this.usuarioId = usuarioId; return this; }
+        public SecurityEventBuilder ipAddress(String ipAddress) { this.ipAddress = ipAddress; return this; }
+        public SecurityEventBuilder timestamp(Instant timestamp) { this.timestamp = timestamp; return this; }
+        public SecurityEventBuilder detalles(String detalles) { this.detalles = detalles; return this; }
+        public SecurityEvent build() { return new SecurityEvent(id, tipoEvento, usuarioId, ipAddress, timestamp, detalles); }
+    }
     public static SecurityEvent loginExitoso(UUID usuarioId, String ip) {
         return new SecurityEvent(
                 UUID.randomUUID(),

--- a/backend/src/main/java/com/tufondo/auth/infrastructure/persistence/entity/VerificacionTokenEntity.java
+++ b/backend/src/main/java/com/tufondo/auth/infrastructure/persistence/entity/VerificacionTokenEntity.java
@@ -1,0 +1,103 @@
+package com.tufondo.auth.infrastructure.persistence.entity;
+
+import com.tufondo.socios.domain.model.enums.TipoVerificacion;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "verificacion_token", indexes = {
+    @Index(name = "idx_verificacion_token", columnList = "token", unique = true),
+    @Index(name = "idx_verificacion_usuario", columnList = "usuario_id"),
+    @Index(name = "idx_verificacion_expira", columnList = "expires_at")
+})
+public class VerificacionTokenEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "token", nullable = false, unique = true, length = 100)
+    private String token;
+
+    @Column(name = "usuario_id", nullable = false)
+    private UUID usuarioId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo", nullable = false, length = 20)
+    private TipoVerificacion tipo;
+
+    @Column(name = "valor", length = 255)
+    private String valor;
+
+    @Column(name = "codigo", length = 10)
+    private String codigo;
+
+    @Column(name = "ip_address", length = 45)
+    private String ipAddress;
+
+    @Column(name = "user_agent", length = 500)
+    private String userAgent;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "used", nullable = false)
+    private boolean used;
+
+    @Column(name = "intentos", nullable = false)
+    private int intentos;
+
+    public VerificacionTokenEntity() {}
+
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+    public String getToken() { return token; }
+    public void setToken(String token) { this.token = token; }
+    public UUID getUsuarioId() { return usuarioId; }
+    public void setUsuarioId(UUID usuarioId) { this.usuarioId = usuarioId; }
+    public TipoVerificacion getTipo() { return tipo; }
+    public void setTipo(TipoVerificacion tipo) { this.tipo = tipo; }
+    public String getValor() { return valor; }
+    public void setValor(String valor) { this.valor = valor; }
+    public String getCodigo() { return codigo; }
+    public void setCodigo(String codigo) { this.codigo = codigo; }
+    public String getIpAddress() { return ipAddress; }
+    public void setIpAddress(String ipAddress) { this.ipAddress = ipAddress; }
+    public String getUserAgent() { return userAgent; }
+    public void setUserAgent(String userAgent) { this.userAgent = userAgent; }
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+    public Instant getExpiresAt() { return expiresAt; }
+    public void setExpiresAt(Instant expiresAt) { this.expiresAt = expiresAt; }
+    public boolean isUsed() { return used; }
+    public void setUsed(boolean used) { this.used = used; }
+    public int getIntentos() { return intentos; }
+    public void setIntentos(int intentos) { this.intentos = intentos; }
+
+    public static VerificacionTokenEntityBuilder builder() {
+        return new VerificacionTokenEntityBuilder();
+    }
+
+    public static class VerificacionTokenEntityBuilder {
+        private VerificacionTokenEntity e = new VerificacionTokenEntity();
+        public VerificacionTokenEntityBuilder id(UUID v) { e.id = v; return this; }
+        public VerificacionTokenEntityBuilder token(String v) { e.token = v; return this; }
+        public VerificacionTokenEntityBuilder usuarioId(UUID v) { e.usuarioId = v; return this; }
+        public VerificacionTokenEntityBuilder tipo(TipoVerificacion v) { e.tipo = v; return this; }
+        public VerificacionTokenEntityBuilder valor(String v) { e.valor = v; return this; }
+        public VerificacionTokenEntityBuilder codigo(String v) { e.codigo = v; return this; }
+        public VerificacionTokenEntityBuilder ipAddress(String v) { e.ipAddress = v; return this; }
+        public VerificacionTokenEntityBuilder userAgent(String v) { e.userAgent = v; return this; }
+        public VerificacionTokenEntityBuilder createdAt(Instant v) { e.createdAt = v; return this; }
+        public VerificacionTokenEntityBuilder expiresAt(Instant v) { e.expiresAt = v; return this; }
+        public VerificacionTokenEntityBuilder used(boolean v) { e.used = v; return this; }
+        public VerificacionTokenEntityBuilder intentos(int v) { e.intentos = v; return this; }
+        public VerificacionTokenEntity build() { return e; }
+    }
+}

--- a/backend/src/main/java/com/tufondo/auth/infrastructure/persistence/repository/VerificacionTokenRepository.java
+++ b/backend/src/main/java/com/tufondo/auth/infrastructure/persistence/repository/VerificacionTokenRepository.java
@@ -1,0 +1,25 @@
+package com.tufondo.auth.infrastructure.persistence.repository;
+
+import com.tufondo.auth.infrastructure.persistence.entity.VerificacionTokenEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface VerificacionTokenRepository extends JpaRepository<VerificacionTokenEntity, UUID> {
+
+    Optional<VerificacionTokenEntity> findByToken(String token);
+
+    Optional<VerificacionTokenEntity> findByTokenAndUsedFalse(String token);
+
+    Optional<VerificacionTokenEntity> findByUsuarioIdAndTipoAndUsedFalseAndExpiresAtAfter(
+            UUID usuarioId,
+            com.tufondo.socios.domain.model.enums.TipoVerificacion tipo,
+            Instant now
+    );
+
+    void deleteByExpiresAtBefore(Instant now);
+}

--- a/backend/src/main/java/com/tufondo/auth/infrastructure/service/EmailService.java
+++ b/backend/src/main/java/com/tufondo/auth/infrastructure/service/EmailService.java
@@ -59,4 +59,12 @@ public class EmailService {
         log.info("Este es un email mock - En producción se enviaría un email real");
         log.info("==========================================");
     }
+
+    public void enviarCodigoVerificacion(String destinatario, String codigo) {
+        log.info("========= EMAIL MOCK: CÓDIGO DE VERIFICACIÓN =========");
+        log.info("Para: {}", destinatario);
+        log.info("Código: {}", codigo);
+        log.info("Este es un email mock - En producción se enviaría un email real");
+        log.info("======================================================");
+    }
 }

--- a/backend/src/main/java/com/tufondo/auth/infrastructure/service/SecurityAuditService.java
+++ b/backend/src/main/java/com/tufondo/auth/infrastructure/service/SecurityAuditService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -86,5 +87,39 @@ public class SecurityAuditService {
                 event.tipoEvento(),
                 event.detalles()
         );
+    }
+
+    public void registrarIntentoVerificacion(UUID usuarioId, String tipoEvento, boolean exitoso, String ip) {
+        SecurityEvent event = SecurityEvent.builder()
+                .id(UUID.randomUUID())
+                .usuarioId(usuarioId)
+                .tipoEvento(tipoEvento)
+                .timestamp(Instant.now())
+                .ipAddress(ip)
+                .detalles(switch (tipoEvento) {
+                    case "PASSWORD_VERIFIED" -> "Verificación de password exitosa";
+                    case "CODIGO_ENVIADO_EMAIL" -> "Código de verificación enviado por email";
+                    case "CODIGO_ENVIADO_SMS" -> "Código de verificación enviado por SMS";
+                    case "CODIGO_CONFIRMED" -> "Código de verificación confirmado";
+                    default -> "Intento de verificación: " + tipoEvento;
+                })
+                .build();
+        if (exitoso) {
+            log.info("AUDIT [{}] usuario={} ip={} tipo={} detalles={}",
+                    event.timestamp(),
+                    event.usuarioId(),
+                    event.ipAddress(),
+                    event.tipoEvento(),
+                    event.detalles()
+            );
+        } else {
+            log.warn("AUDIT [{}] usuario={} ip={} tipo={} detalles={}",
+                    event.timestamp(),
+                    event.usuarioId(),
+                    event.ipAddress(),
+                    event.tipoEvento(),
+                    event.detalles()
+            );
+        }
     }
 }

--- a/backend/src/main/java/com/tufondo/auth/infrastructure/service/VerificacionService.java
+++ b/backend/src/main/java/com/tufondo/auth/infrastructure/service/VerificacionService.java
@@ -1,0 +1,187 @@
+package com.tufondo.auth.infrastructure.service;
+
+import com.tufondo.auth.infrastructure.persistence.entity.VerificacionTokenEntity;
+import com.tufondo.auth.infrastructure.persistence.repository.VerificacionTokenRepository;
+import com.tufondo.socios.domain.model.enums.TipoVerificacion;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VerificacionService {
+
+    private static final int TTL_MINUTES = 5;
+    private static final int MAX_INTENTOS = 3;
+    private static final String CARACTERES_CODIGO = "0123456789";
+
+    private final VerificacionTokenRepository tokenRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final EmailService emailService;
+    private final SecurityAuditService auditService;
+
+    public boolean verificarPasswordUsuario(UUID usuarioId, String password, String hashedPassword) {
+        return passwordEncoder.matches(password, hashedPassword);
+    }
+
+    @Transactional
+    public String generarTokenVerificacion(UUID usuarioId, String ipAddress, String userAgent) {
+        String token = UUID.randomUUID().toString();
+
+        VerificacionTokenEntity entity = VerificacionTokenEntity.builder()
+                .token(token)
+                .usuarioId(usuarioId)
+                .tipo(TipoVerificacion.EMAIL)
+                .createdAt(Instant.now())
+                .expiresAt(Instant.now().plus(TTL_MINUTES, ChronoUnit.MINUTES))
+                .used(false)
+                .intentos(0)
+                .ipAddress(ipAddress)
+                .userAgent(userAgent)
+                .build();
+
+        tokenRepository.save(entity);
+
+        auditService.registrarIntentoVerificacion(usuarioId, "PASSWORD_VERIFIED", true, ipAddress);
+
+        return token;
+    }
+
+    @Transactional
+    public String generarYCEnviarCodigo(UUID usuarioId, TipoVerificacion tipo, String valor,
+                                         String ipAddress, String userAgent, String emailDestino) {
+        String codigo = generarCodigo(6);
+
+        Optional<VerificacionTokenEntity> existente = tokenRepository
+                .findByUsuarioIdAndTipoAndUsedFalseAndExpiresAtAfter(usuarioId, tipo, Instant.now());
+
+        existente.ifPresent(tokenRepository::delete);
+
+        String token = UUID.randomUUID().toString();
+
+        VerificacionTokenEntity entity = VerificacionTokenEntity.builder()
+                .token(token)
+                .usuarioId(usuarioId)
+                .tipo(tipo)
+                .valor(valor)
+                .codigo(codigo)
+                .createdAt(Instant.now())
+                .expiresAt(Instant.now().plus(TTL_MINUTES, ChronoUnit.MINUTES))
+                .used(false)
+                .intentos(0)
+                .ipAddress(ipAddress)
+                .userAgent(userAgent)
+                .build();
+
+        tokenRepository.save(entity);
+
+        if (tipo == TipoVerificacion.EMAIL) {
+            emailService.enviarCodigoVerificacion(emailDestino, codigo);
+        } else if (tipo == TipoVerificacion.SMS) {
+            log.info("========= SMS MOCK: CÓDIGO DE VERIFICACIÓN =========");
+            log.info("Para: {}", valor);
+            log.info("Código: {}", codigo);
+            log.info("===================================================");
+        }
+
+        auditService.registrarIntentoVerificacion(usuarioId, "CODIGO_ENVIADO_" + tipo.name(), true, ipAddress);
+
+        return token;
+    }
+
+    @Transactional
+    public boolean confirmarCodigo(UUID usuarioId, String token, String codigo,
+                                   String ipAddress, String userAgent) {
+        Optional<VerificacionTokenEntity> entityOpt = tokenRepository.findByTokenAndUsedFalse(token);
+
+        if (entityOpt.isEmpty()) {
+            auditService.registrarIntentoVerificacion(usuarioId, "CODIGO_CONFIRM_FAIL_NO_TOKEN", false, ipAddress);
+            return false;
+        }
+
+        VerificacionTokenEntity entity = entityOpt.get();
+
+        if (!entity.getUsuarioId().equals(usuarioId)) {
+            auditService.registrarIntentoVerificacion(usuarioId, "CODIGO_CONFIRM_FAIL_USER_MISMATCH", false, ipAddress);
+            return false;
+        }
+
+        if (entity.getExpiresAt().isBefore(Instant.now())) {
+            auditService.registrarIntentoVerificacion(usuarioId, "CODIGO_CONFIRM_FAIL_EXPIRED", false, ipAddress);
+            return false;
+        }
+
+        if (entity.getIntentos() >= MAX_INTENTOS) {
+            auditService.registrarIntentoVerificacion(usuarioId, "CODIGO_CONFIRM_FAIL_MAX_INTENTOS", false, ipAddress);
+            throw new ExcesoIntentosException("Superaste el número máximo de intentos");
+        }
+
+        if (!entity.getCodigo().equals(codigo)) {
+            entity.setIntentos(entity.getIntentos() + 1);
+            tokenRepository.save(entity);
+            auditService.registrarIntentoVerificacion(usuarioId, "CODIGO_CONFIRM_FAIL_WRONG_CODE", false, ipAddress);
+            return false;
+        }
+
+        entity.setUsed(true);
+        tokenRepository.save(entity);
+
+        auditService.registrarIntentoVerificacion(usuarioId, "CODIGO_CONFIRMED", true, ipAddress);
+
+        return true;
+    }
+
+    public boolean validarTokenVerificacion(UUID usuarioId, String token) {
+        Optional<VerificacionTokenEntity> entityOpt = tokenRepository.findByTokenAndUsedFalse(token);
+
+        if (entityOpt.isEmpty()) {
+            return false;
+        }
+
+        VerificacionTokenEntity entity = entityOpt.get();
+
+        if (!entity.getUsuarioId().equals(usuarioId)) {
+            return false;
+        }
+
+        if (entity.getExpiresAt().isBefore(Instant.now())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Transactional
+    public void invalidarToken(UUID usuarioId, String token) {
+        Optional<VerificacionTokenEntity> entityOpt = tokenRepository.findByTokenAndUsedFalse(token);
+
+        entityOpt.ifPresent(entity -> {
+            entity.setUsed(true);
+            tokenRepository.save(entity);
+        });
+    }
+
+    private String generarCodigo(int longitud) {
+        SecureRandom random = new SecureRandom();
+        StringBuilder sb = new StringBuilder(longitud);
+        for (int i = 0; i < longitud; i++) {
+            sb.append(CARACTERES_CODIGO.charAt(random.nextInt(CARACTERES_CODIGO.length())));
+        }
+        return sb.toString();
+    }
+
+    public static class ExcesoIntentosException extends RuntimeException {
+        public ExcesoIntentosException(String message) {
+            super(message);
+        }
+    }
+}

--- a/backend/src/main/java/com/tufondo/socios/application/dto/ConfirmarCodigoRequestDTO.java
+++ b/backend/src/main/java/com/tufondo/socios/application/dto/ConfirmarCodigoRequestDTO.java
@@ -1,0 +1,25 @@
+package com.tufondo.socios.application.dto;
+
+import com.tufondo.socios.domain.model.enums.TipoVerificacion;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConfirmarCodigoRequestDTO {
+
+    @NotNull(message = "El tipo de verificación es obligatorio")
+    private TipoVerificacion tipo;
+
+    @NotBlank(message = "El token es obligatorio")
+    private String token;
+
+    @NotBlank(message = "El código es obligatorio")
+    private String codigo;
+}

--- a/backend/src/main/java/com/tufondo/socios/application/dto/ConfirmarCodigoResponseDTO.java
+++ b/backend/src/main/java/com/tufondo/socios/application/dto/ConfirmarCodigoResponseDTO.java
@@ -1,0 +1,16 @@
+package com.tufondo.socios.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConfirmarCodigoResponseDTO {
+
+    private boolean valido;
+    private String tokenVerificacion;
+}

--- a/backend/src/main/java/com/tufondo/socios/application/dto/EnviarCodigoRequestDTO.java
+++ b/backend/src/main/java/com/tufondo/socios/application/dto/EnviarCodigoRequestDTO.java
@@ -1,0 +1,22 @@
+package com.tufondo.socios.application.dto;
+
+import com.tufondo.socios.domain.model.enums.TipoVerificacion;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EnviarCodigoRequestDTO {
+
+    @NotNull(message = "El tipo de verificación es obligatorio")
+    private TipoVerificacion tipo;
+
+    @NotBlank(message = "El valor es obligatorio")
+    private String valor;
+}

--- a/backend/src/main/java/com/tufondo/socios/application/dto/VerificarPasswordRequestDTO.java
+++ b/backend/src/main/java/com/tufondo/socios/application/dto/VerificarPasswordRequestDTO.java
@@ -1,0 +1,17 @@
+package com.tufondo.socios.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VerificarPasswordRequestDTO {
+
+    @NotBlank(message = "La contraseña es obligatoria")
+    private String password;
+}

--- a/backend/src/main/java/com/tufondo/socios/application/dto/VerificarPasswordResponseDTO.java
+++ b/backend/src/main/java/com/tufondo/socios/application/dto/VerificarPasswordResponseDTO.java
@@ -1,0 +1,16 @@
+package com.tufondo.socios.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VerificarPasswordResponseDTO {
+
+    private boolean valido;
+    private String tokenVerificacion;
+}

--- a/backend/src/main/java/com/tufondo/socios/application/usecase/VerificacionUseCase.java
+++ b/backend/src/main/java/com/tufondo/socios/application/usecase/VerificacionUseCase.java
@@ -1,0 +1,125 @@
+package com.tufondo.socios.application.usecase;
+
+import com.tufondo.auth.domain.exception.CredencialesInvalidasException;
+import com.tufondo.auth.domain.exception.UsuarioNoEncontradoException;
+import com.tufondo.auth.domain.model.Usuario;
+import com.tufondo.auth.domain.repository.UsuarioRepository;
+import com.tufondo.auth.infrastructure.service.SecurityAuditService;
+import com.tufondo.auth.infrastructure.service.VerificacionService;
+import com.tufondo.socios.application.dto.ConfirmarCodigoRequestDTO;
+import com.tufondo.socios.application.dto.ConfirmarCodigoResponseDTO;
+import com.tufondo.socios.application.dto.EnviarCodigoRequestDTO;
+import com.tufondo.socios.application.dto.VerificarPasswordRequestDTO;
+import com.tufondo.socios.application.dto.VerificarPasswordResponseDTO;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class VerificacionUseCase {
+
+    private final UsuarioRepository usuarioRepository;
+    private final VerificacionService verificacionService;
+    private final SecurityAuditService auditService;
+
+    @Transactional
+    public VerificarPasswordResponseDTO verificarPassword(UUID usuarioId, VerificarPasswordRequestDTO request,
+                                                          HttpServletRequest httpRequest) {
+        Usuario usuario = usuarioRepository.buscarPorId(usuarioId)
+                .orElseThrow(() -> new CredencialesInvalidasException("Usuario no encontrado"));
+
+        String ip = getClientIp(httpRequest);
+        String userAgent = httpRequest.getHeader("User-Agent");
+
+        boolean valido = verificacionService.verificarPasswordUsuario(
+                usuarioId,
+                request.getPassword(),
+                usuario.passwordHash()
+        );
+
+        if (!valido) {
+            auditService.registrarIntentoVerificacion(usuarioId, "PASSWORD_VERIFY_FAIL", false, ip);
+            throw new CredencialesInvalidasException("Contraseña incorrecta");
+        }
+
+        String token = verificacionService.generarTokenVerificacion(usuarioId, ip, userAgent);
+
+        return VerificarPasswordResponseDTO.builder()
+                .valido(true)
+                .tokenVerificacion(token)
+                .build();
+    }
+
+    @Transactional
+    public String enviarCodigo(UUID usuarioId, EnviarCodigoRequestDTO request, HttpServletRequest httpRequest) {
+        String ip = getClientIp(httpRequest);
+        String userAgent = httpRequest.getHeader("User-Agent");
+
+        String email = request.getTipo() == com.tufondo.socios.domain.model.enums.TipoVerificacion.EMAIL
+                ? request.getValor()
+                : null;
+
+        String token = verificacionService.generarYCEnviarCodigo(
+                usuarioId,
+                request.getTipo(),
+                request.getValor(),
+                ip,
+                userAgent,
+                email
+        );
+
+        return token;
+    }
+
+    @Transactional
+    public ConfirmarCodigoResponseDTO confirmarCodigo(UUID usuarioId, ConfirmarCodigoRequestDTO request,
+                                                     HttpServletRequest httpRequest) {
+        String ip = getClientIp(httpRequest);
+        String userAgent = httpRequest.getHeader("User-Agent");
+
+        boolean valido = verificacionService.confirmarCodigo(
+                usuarioId,
+                request.getToken(),
+                request.getCodigo(),
+                ip,
+                userAgent
+        );
+
+        if (!valido) {
+            throw new CodigoInvalidoException("Código inválido o expirado");
+        }
+
+        return ConfirmarCodigoResponseDTO.builder()
+                .valido(true)
+                .tokenVerificacion(request.getToken())
+                .build();
+    }
+
+    public boolean validarToken(UUID usuarioId, String token) {
+        return verificacionService.validarTokenVerificacion(usuarioId, token);
+    }
+
+    private String getClientIp(HttpServletRequest request) {
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (xForwardedFor != null && !xForwardedFor.isEmpty()) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    public static class PasswordIncorrectoException extends RuntimeException {
+        public PasswordIncorrectoException(String message) {
+            super(message);
+        }
+    }
+
+    public static class CodigoInvalidoException extends RuntimeException {
+        public CodigoInvalidoException(String message) {
+            super(message);
+        }
+    }
+}

--- a/backend/src/main/java/com/tufondo/socios/domain/model/enums/TipoVerificacion.java
+++ b/backend/src/main/java/com/tufondo/socios/domain/model/enums/TipoVerificacion.java
@@ -1,0 +1,6 @@
+package com.tufondo.socios.domain.model.enums;
+
+public enum TipoVerificacion {
+    EMAIL,
+    SMS
+}

--- a/backend/src/main/java/com/tufondo/socios/presentation/controller/PerfilVerificacionController.java
+++ b/backend/src/main/java/com/tufondo/socios/presentation/controller/PerfilVerificacionController.java
@@ -1,0 +1,101 @@
+package com.tufondo.socios.presentation.controller;
+
+import com.tufondo.socios.application.dto.ConfirmarCodigoRequestDTO;
+import com.tufondo.socios.application.dto.ConfirmarCodigoResponseDTO;
+import com.tufondo.socios.application.dto.EnviarCodigoRequestDTO;
+import com.tufondo.socios.application.dto.VerificarPasswordRequestDTO;
+import com.tufondo.socios.application.dto.VerificarPasswordResponseDTO;
+import com.tufondo.socios.application.usecase.VerificacionUseCase;
+import com.tufondo.auth.domain.exception.CredencialesInvalidasException;
+import com.tufondo.auth.infrastructure.service.VerificacionService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/perfil")
+@RequiredArgsConstructor
+public class PerfilVerificacionController {
+
+    private final VerificacionUseCase verificacionUseCase;
+
+    @PostMapping("/verificar-password")
+    public ResponseEntity<VerificarPasswordResponseDTO> verificarPassword(
+            @Valid @RequestBody VerificarPasswordRequestDTO request,
+            Authentication authentication,
+            HttpServletRequest httpRequest) {
+
+        UUID usuarioId = getUsuarioId(authentication);
+
+        try {
+            VerificarPasswordResponseDTO response = verificacionUseCase.verificarPassword(
+                    usuarioId, request, httpRequest);
+            return ResponseEntity.ok(response);
+        } catch (CredencialesInvalidasException e) {
+            throw e;
+        }
+    }
+
+    @PostMapping("/enviar-codigo")
+    public ResponseEntity<Map<String, String>> enviarCodigo(
+            @Valid @RequestBody EnviarCodigoRequestDTO request,
+            Authentication authentication,
+            HttpServletRequest httpRequest) {
+
+        UUID usuarioId = getUsuarioId(authentication);
+
+        String token = verificacionUseCase.enviarCodigo(usuarioId, request, httpRequest);
+
+        return ResponseEntity.ok(Map.of(
+                "token" , token,
+                "mensaje", "Código enviado exitosamente"
+        ));
+    }
+
+    @PostMapping("/confirmar-codigo")
+    public ResponseEntity<ConfirmarCodigoResponseDTO> confirmarCodigo(
+            @Valid @RequestBody ConfirmarCodigoRequestDTO request,
+            Authentication authentication,
+            HttpServletRequest httpRequest) {
+
+        UUID usuarioId = getUsuarioId(authentication);
+
+        try {
+            ConfirmarCodigoResponseDTO response = verificacionUseCase.confirmarCodigo(
+                    usuarioId, request, httpRequest);
+            return ResponseEntity.ok(response);
+        } catch (VerificacionUseCase.CodigoInvalidoException e) {
+            throw new CredencialesInvalidasException(e.getMessage());
+        } catch (VerificacionService.ExcesoIntentosException e) {
+            return ResponseEntity.badRequest().body(
+                    ConfirmarCodigoResponseDTO.builder()
+                            .valido(false)
+                            .tokenVerificacion(null)
+                            .build()
+            );
+        }
+    }
+
+    @PostMapping("/validar-token")
+    public ResponseEntity<Map<String, Boolean>> validarToken(
+            @RequestBody Map<String, String> body,
+            Authentication authentication) {
+
+        UUID usuarioId = getUsuarioId(authentication);
+        String token = body.get("token");
+
+        boolean valido = verificacionUseCase.validarToken(usuarioId, token);
+
+        return ResponseEntity.ok(Map.of("valido", valido));
+    }
+
+    private UUID getUsuarioId(Authentication authentication) {
+        return (UUID) authentication.getPrincipal();
+    }
+}

--- a/backend/src/main/resources/db/migration/V10__create_verificacion_token.sql
+++ b/backend/src/main/resources/db/migration/V10__create_verificacion_token.sql
@@ -1,0 +1,21 @@
+-- V10__create_verificacion_token.sql
+-- Tabla para tokens de verificación de cambios sensibles
+
+CREATE TABLE verificacion_token (
+    id UUID PRIMARY KEY,
+    token VARCHAR(100) NOT NULL UNIQUE,
+    usuario_id UUID NOT NULL,
+    tipo VARCHAR(20) NOT NULL,
+    valor VARCHAR(255),
+    codigo VARCHAR(10),
+    ip_address VARCHAR(45),
+    user_agent VARCHAR(500),
+    created_at TIMESTAMP NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    used BOOLEAN NOT NULL DEFAULT FALSE,
+    intentos INT NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_verificacion_token ON verificacion_token(token);
+CREATE INDEX idx_verificacion_usuario ON verificacion_token(usuario_id);
+CREATE INDEX idx_verificacion_expira ON verificacion_token(expires_at);

--- a/backend/src/test/java/com/tufondo/auth/infrastructure/service/VerificacionServiceTest.java
+++ b/backend/src/test/java/com/tufondo/auth/infrastructure/service/VerificacionServiceTest.java
@@ -1,0 +1,460 @@
+package com.tufondo.auth.infrastructure.service;
+
+import com.tufondo.auth.infrastructure.persistence.entity.VerificacionTokenEntity;
+import com.tufondo.auth.infrastructure.persistence.repository.VerificacionTokenRepository;
+import com.tufondo.socios.domain.model.enums.TipoVerificacion;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class VerificacionServiceTest {
+
+    @Mock
+    private VerificacionTokenRepository tokenRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private SecurityAuditService auditService;
+
+    @InjectMocks
+    private VerificacionService verificacionService;
+
+    private UUID usuarioId;
+    private String ipAddress;
+    private String userAgent;
+
+    @BeforeEach
+    void setUp() {
+        usuarioId = UUID.randomUUID();
+        ipAddress = "192.168.1.1";
+        userAgent = "Mozilla/5.0 Test";
+    }
+
+    @Nested
+    @DisplayName("verificarPasswordUsuario")
+    class VerificarPasswordUsuario {
+
+        @Test
+        @DisplayName("password correcto retorna true")
+        void passwordCorrecto_RetornaTrue() {
+            String password = "password123";
+            String hashedPassword = "$argon2hash";
+
+            when(passwordEncoder.matches(password, hashedPassword)).thenReturn(true);
+
+            boolean result = verificacionService.verificarPasswordUsuario(usuarioId, password, hashedPassword);
+
+            assertThat(result).isTrue();
+            verify(passwordEncoder).matches(password, hashedPassword);
+        }
+
+        @Test
+        @DisplayName("password incorrecto retorna false")
+        void passwordIncorrecto_RetornaFalse() {
+            String password = "wrongpassword";
+            String hashedPassword = "$argon2hash";
+
+            when(passwordEncoder.matches(password, hashedPassword)).thenReturn(false);
+
+            boolean result = verificacionService.verificarPasswordUsuario(usuarioId, password, hashedPassword);
+
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("generarTokenVerificacion")
+    class GenerarTokenVerificacion {
+
+        @Test
+        @DisplayName("genera token y guarda en repository")
+        void generaToken_GuardaEnRepository() {
+            when(tokenRepository.save(any(VerificacionTokenEntity.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            String token = verificacionService.generarTokenVerificacion(usuarioId, ipAddress, userAgent);
+
+            assertThat(token).isNotNull();
+            assertThat(token).matches("[a-f0-9-]{36}");
+
+            ArgumentCaptor<VerificacionTokenEntity> captor = ArgumentCaptor.forClass(VerificacionTokenEntity.class);
+            verify(tokenRepository).save(captor.capture());
+
+            VerificacionTokenEntity saved = captor.getValue();
+            assertThat(saved.getUsuarioId()).isEqualTo(usuarioId);
+            assertThat(saved.getToken()).isEqualTo(token);
+            assertThat(saved.getTipo()).isEqualTo(TipoVerificacion.EMAIL);
+            assertThat(saved.isUsed()).isFalse();
+            assertThat(saved.getIntentos()).isZero();
+            assertThat(saved.getIpAddress()).isEqualTo(ipAddress);
+            assertThat(saved.getUserAgent()).isEqualTo(userAgent);
+        }
+
+        @Test
+        @DisplayName("token tiene TTL de 5 minutos")
+        void tokenTieneTTLD5Minutos() {
+            Instant before = Instant.now().plus(5, ChronoUnit.MINUTES).minusSeconds(1);
+            Instant after = Instant.now().plus(5, ChronoUnit.MINUTES).plusSeconds(1);
+
+            when(tokenRepository.save(any(VerificacionTokenEntity.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            String token = verificacionService.generarTokenVerificacion(usuarioId, ipAddress, userAgent);
+
+            ArgumentCaptor<VerificacionTokenEntity> captor = ArgumentCaptor.forClass(VerificacionTokenEntity.class);
+            verify(tokenRepository).save(captor.capture());
+
+            VerificacionTokenEntity saved = captor.getValue();
+            assertThat(saved.getExpiresAt()).isAfter(before);
+            assertThat(saved.getExpiresAt()).isBefore(after);
+        }
+
+        @Test
+        @DisplayName("registra audit log")
+        void registraAuditLog() {
+            when(tokenRepository.save(any(VerificacionTokenEntity.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            verificacionService.generarTokenVerificacion(usuarioId, ipAddress, userAgent);
+
+            verify(auditService).registrarIntentoVerificacion(usuarioId, "PASSWORD_VERIFIED", true, ipAddress);
+        }
+    }
+
+    @Nested
+    @DisplayName("generarYCEnviarCodigo")
+    class GenerarYCEnviarCodigo {
+
+        @Test
+        @DisplayName("genera código de 6 dígitos")
+        void generaCodigo6Digitos() {
+            when(tokenRepository.findByUsuarioIdAndTipoAndUsedFalseAndExpiresAtAfter(
+                    any(UUID.class), any(TipoVerificacion.class), any(Instant.class)))
+                    .thenReturn(Optional.empty());
+            when(tokenRepository.save(any(VerificacionTokenEntity.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            String result = verificacionService.generarYCEnviarCodigo(
+                    usuarioId, TipoVerificacion.SMS, "04121234567",
+                    ipAddress, userAgent, "test@test.com");
+
+            assertThat(result).isNotNull();
+
+            ArgumentCaptor<VerificacionTokenEntity> captor = ArgumentCaptor.forClass(VerificacionTokenEntity.class);
+            verify(tokenRepository).save(captor.capture());
+
+            VerificacionTokenEntity saved = captor.getValue();
+            assertThat(saved.getCodigo()).hasSize(6);
+            assertThat(saved.getCodigo()).matches("\\d{6}");
+        }
+
+        @Test
+        @DisplayName("elimina códigos existentes del mismo usuario y tipo")
+        void eliminaCodigosExistentes() {
+            VerificacionTokenEntity existente = VerificacionTokenEntity.builder()
+                    .token("old-token")
+                    .usuarioId(usuarioId)
+                    .tipo(TipoVerificacion.SMS)
+                    .build();
+
+            when(tokenRepository.findByUsuarioIdAndTipoAndUsedFalseAndExpiresAtAfter(
+                    eq(usuarioId), eq(TipoVerificacion.SMS), any(Instant.class)))
+                    .thenReturn(Optional.of(existente));
+
+            verificacionService.generarYCEnviarCodigo(
+                    usuarioId, TipoVerificacion.SMS, "04121234567",
+                    ipAddress, userAgent, null);
+
+            verify(tokenRepository).delete(existente);
+        }
+
+        @Test
+        @DisplayName("envía email con código cuando tipo es EMAIL")
+        void enviaEmailCuandoTipoEMAIL() {
+            when(tokenRepository.findByUsuarioIdAndTipoAndUsedFalseAndExpiresAtAfter(
+                    any(), any(), any()))
+                    .thenReturn(Optional.empty());
+            when(tokenRepository.save(any(VerificacionTokenEntity.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            verificacionService.generarYCEnviarCodigo(
+                    usuarioId, TipoVerificacion.EMAIL, "test@test.com",
+                    ipAddress, userAgent, "test@test.com");
+
+            verify(emailService).enviarCodigoVerificacion(eq("test@test.com"), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("confirmarCodigo")
+    class ConfirmarCodigo {
+
+        @Test
+        @DisplayName("código correcto retorna true y marca como usado")
+        void codigoCorrecto_RetornaTrue() {
+            String token = "valid-token";
+            String codigo = "123456";
+
+            VerificacionTokenEntity entity = VerificacionTokenEntity.builder()
+                    .token(token)
+                    .usuarioId(usuarioId)
+                    .tipo(TipoVerificacion.SMS)
+                    .codigo(codigo)
+                    .expiresAt(Instant.now().plus(5, ChronoUnit.MINUTES))
+                    .used(false)
+                    .intentos(0)
+                    .build();
+
+            when(tokenRepository.findByTokenAndUsedFalse(token)).thenReturn(Optional.of(entity));
+            when(tokenRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            boolean result = verificacionService.confirmarCodigo(usuarioId, token, codigo, ipAddress, userAgent);
+
+            assertThat(result).isTrue();
+            assertThat(entity.isUsed()).isTrue();
+        }
+
+        @Test
+        @DisplayName("token no encontrado retorna false")
+        void tokenNoEncontrado_RetornaFalse() {
+            when(tokenRepository.findByTokenAndUsedFalse("invalid-token")).thenReturn(Optional.empty());
+
+            boolean result = verificacionService.confirmarCodigo(
+                    usuarioId, "invalid-token", "123456", ipAddress, userAgent);
+
+            assertThat(result).isFalse();
+            verify(auditService).registrarIntentoVerificacion(
+                    usuarioId, "CODIGO_CONFIRM_FAIL_NO_TOKEN", false, ipAddress);
+        }
+
+        @Test
+        @DisplayName("usuario diferente retorna false")
+        void usuarioDiferente_RetornaFalse() {
+            String token = "valid-token";
+            UUID otroUsuarioId = UUID.randomUUID();
+
+            VerificacionTokenEntity entity = VerificacionTokenEntity.builder()
+                    .token(token)
+                    .usuarioId(otroUsuarioId)
+                    .tipo(TipoVerificacion.SMS)
+                    .codigo("123456")
+                    .expiresAt(Instant.now().plus(5, ChronoUnit.MINUTES))
+                    .used(false)
+                    .intentos(0)
+                    .build();
+
+            when(tokenRepository.findByTokenAndUsedFalse(token)).thenReturn(Optional.of(entity));
+
+            boolean result = verificacionService.confirmarCodigo(usuarioId, token, "123456", ipAddress, userAgent);
+
+            assertThat(result).isFalse();
+            verify(auditService).registrarIntentoVerificacion(
+                    usuarioId, "CODIGO_CONFIRM_FAIL_USER_MISMATCH", false, ipAddress);
+        }
+
+        @Test
+        @DisplayName("token expirado retorna false")
+        void tokenExpirado_RetornaFalse() {
+            String token = "expired-token";
+
+            VerificacionTokenEntity entity = VerificacionTokenEntity.builder()
+                    .token(token)
+                    .usuarioId(usuarioId)
+                    .tipo(TipoVerificacion.SMS)
+                    .codigo("123456")
+                    .expiresAt(Instant.now().minus(1, ChronoUnit.MINUTES))
+                    .used(false)
+                    .intentos(0)
+                    .build();
+
+            when(tokenRepository.findByTokenAndUsedFalse(token)).thenReturn(Optional.of(entity));
+
+            boolean result = verificacionService.confirmarCodigo(usuarioId, token, "123456", ipAddress, userAgent);
+
+            assertThat(result).isFalse();
+            verify(auditService).registrarIntentoVerificacion(
+                    usuarioId, "CODIGO_CONFIRM_FAIL_EXPIRED", false, ipAddress);
+        }
+
+        @Test
+        @DisplayName("código incorrecto incrementa intentos")
+        void codigoIncorrecto_IncrementaIntentos() {
+            String token = "valid-token";
+
+            VerificacionTokenEntity entity = VerificacionTokenEntity.builder()
+                    .token(token)
+                    .usuarioId(usuarioId)
+                    .tipo(TipoVerificacion.SMS)
+                    .codigo("123456")
+                    .expiresAt(Instant.now().plus(5, ChronoUnit.MINUTES))
+                    .used(false)
+                    .intentos(1)
+                    .build();
+
+            when(tokenRepository.findByTokenAndUsedFalse(token)).thenReturn(Optional.of(entity));
+            when(tokenRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            boolean result = verificacionService.confirmarCodigo(usuarioId, token, "wrong", ipAddress, userAgent);
+
+            assertThat(result).isFalse();
+            assertThat(entity.getIntentos()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("superar máximo intentos lanza excepción")
+        void superarMaximoIntentos_LanzaExcepcion() {
+            String token = "max-attempts-token";
+
+            VerificacionTokenEntity entity = VerificacionTokenEntity.builder()
+                    .token(token)
+                    .usuarioId(usuarioId)
+                    .tipo(TipoVerificacion.SMS)
+                    .codigo("123456")
+                    .expiresAt(Instant.now().plus(5, ChronoUnit.MINUTES))
+                    .used(false)
+                    .intentos(3)
+                    .build();
+
+            when(tokenRepository.findByTokenAndUsedFalse(token)).thenReturn(Optional.of(entity));
+
+            assertThatThrownBy(() -> verificacionService.confirmarCodigo(
+                    usuarioId, token, "123456", ipAddress, userAgent))
+                    .isInstanceOf(VerificacionService.ExcesoIntentosException.class)
+                    .hasMessage("Superaste el número máximo de intentos");
+        }
+    }
+
+    @Nested
+    @DisplayName("validarTokenVerificacion")
+    class ValidarTokenVerificacion {
+
+        @Test
+        @DisplayName("token válido y no expirado retorna true")
+        void tokenValidoNoExpirado_RetornaTrue() {
+            String token = "valid-token";
+
+            VerificacionTokenEntity entity = VerificacionTokenEntity.builder()
+                    .token(token)
+                    .usuarioId(usuarioId)
+                    .expiresAt(Instant.now().plus(5, ChronoUnit.MINUTES))
+                    .used(false)
+                    .build();
+
+            when(tokenRepository.findByTokenAndUsedFalse(token)).thenReturn(Optional.of(entity));
+
+            boolean result = verificacionService.validarTokenVerificacion(usuarioId, token);
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("token no encontrado retorna false")
+        void tokenNoEncontrado_RetornaFalse() {
+            when(tokenRepository.findByTokenAndUsedFalse("invalid")).thenReturn(Optional.empty());
+
+            boolean result = verificacionService.validarTokenVerificacion(usuarioId, "invalid");
+
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("token de otro usuario retorna false")
+        void tokenOtroUsuario_RetornaFalse() {
+            String token = "valid-token";
+            UUID otroUsuarioId = UUID.randomUUID();
+
+            VerificacionTokenEntity entity = VerificacionTokenEntity.builder()
+                    .token(token)
+                    .usuarioId(otroUsuarioId)
+                    .expiresAt(Instant.now().plus(5, ChronoUnit.MINUTES))
+                    .used(false)
+                    .build();
+
+            when(tokenRepository.findByTokenAndUsedFalse(token)).thenReturn(Optional.of(entity));
+
+            boolean result = verificacionService.validarTokenVerificacion(usuarioId, token);
+
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("token expirado retorna false")
+        void tokenExpirado_RetornaFalse() {
+            String token = "expired-token";
+
+            VerificacionTokenEntity entity = VerificacionTokenEntity.builder()
+                    .token(token)
+                    .usuarioId(usuarioId)
+                    .expiresAt(Instant.now().minus(1, ChronoUnit.MINUTES))
+                    .used(false)
+                    .build();
+
+            when(tokenRepository.findByTokenAndUsedFalse(token)).thenReturn(Optional.of(entity));
+
+            boolean result = verificacionService.validarTokenVerificacion(usuarioId, token);
+
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("invalidarToken")
+    class InvalidarToken {
+
+        @Test
+        @DisplayName("marca token como usado")
+        void marcaTokenComoUsado() {
+            String token = "token-to-invalidate";
+
+            VerificacionTokenEntity entity = VerificacionTokenEntity.builder()
+                    .token(token)
+                    .usuarioId(usuarioId)
+                    .used(false)
+                    .build();
+
+            when(tokenRepository.findByTokenAndUsedFalse(token)).thenReturn(Optional.of(entity));
+            when(tokenRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            verificacionService.invalidarToken(usuarioId, token);
+
+            assertThat(entity.isUsed()).isTrue();
+            verify(tokenRepository).save(entity);
+        }
+
+        @Test
+        @DisplayName("no hace nada si token no existe")
+        void noHaceNadaSiTokenNoExiste() {
+            when(tokenRepository.findByTokenAndUsedFalse("invalid")).thenReturn(Optional.empty());
+
+            verificacionService.invalidarToken(usuarioId, "invalid");
+
+            verify(tokenRepository, never()).save(any());
+        }
+    }
+}

--- a/backend/src/test/java/com/tufondo/socios/application/usecase/VerificacionUseCaseTest.java
+++ b/backend/src/test/java/com/tufondo/socios/application/usecase/VerificacionUseCaseTest.java
@@ -1,0 +1,252 @@
+package com.tufondo.socios.application.usecase;
+
+import com.tufondo.auth.domain.exception.CredencialesInvalidasException;
+import com.tufondo.auth.domain.model.Usuario;
+import com.tufondo.auth.domain.model.enums.Rol;
+import com.tufondo.auth.domain.repository.UsuarioRepository;
+import com.tufondo.auth.infrastructure.service.SecurityAuditService;
+import com.tufondo.auth.infrastructure.service.VerificacionService;
+import com.tufondo.socios.application.dto.ConfirmarCodigoRequestDTO;
+import com.tufondo.socios.application.dto.ConfirmarCodigoResponseDTO;
+import com.tufondo.socios.application.dto.EnviarCodigoRequestDTO;
+import com.tufondo.socios.application.dto.VerificarPasswordRequestDTO;
+import com.tufondo.socios.application.dto.VerificarPasswordResponseDTO;
+import com.tufondo.socios.domain.model.enums.TipoVerificacion;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class VerificacionUseCaseTest {
+
+    @Mock
+    private UsuarioRepository usuarioRepository;
+
+    @Mock
+    private VerificacionService verificacionService;
+
+    @Mock
+    private SecurityAuditService auditService;
+
+    @Mock
+    private HttpServletRequest httpRequest;
+
+    @InjectMocks
+    private VerificacionUseCase verificacionUseCase;
+
+    private UUID usuarioId;
+    private Usuario usuario;
+    private String passwordHash;
+    private String ipAddress;
+    private String userAgent;
+
+    @BeforeEach
+    void setUp() {
+        usuarioId = UUID.randomUUID();
+        passwordHash = "$argon2hashpassword123";
+        ipAddress = "192.168.1.1";
+        userAgent = "Mozilla/5.0 Test";
+
+        usuario = Usuario.desdeParametros(
+                usuarioId,
+                "usuario_test",
+                "test@test.com",
+                passwordHash,
+                "Usuario Test",
+                Rol.SOCIO,
+                UUID.randomUUID(),
+                true,
+                Instant.now(),
+                Instant.now(),
+                0,
+                null,
+                false
+        );
+
+        lenient().when(httpRequest.getRemoteAddr()).thenReturn(ipAddress);
+        lenient().when(httpRequest.getHeader("User-Agent")).thenReturn(userAgent);
+    }
+
+    @Nested
+    @DisplayName("verificarPassword")
+    class VerificarPassword {
+
+        @Test
+        @DisplayName("password correcto genera token de verificación")
+        void passwordCorrecto_GeneraToken() {
+            VerificarPasswordRequestDTO request = new VerificarPasswordRequestDTO("password123");
+            String expectedToken = UUID.randomUUID().toString();
+
+            when(usuarioRepository.buscarPorId(usuarioId)).thenReturn(Optional.of(usuario));
+            when(verificacionService.verificarPasswordUsuario(usuarioId, "password123", passwordHash))
+                    .thenReturn(true);
+            when(verificacionService.generarTokenVerificacion(eq(usuarioId), eq(ipAddress), eq(userAgent)))
+                    .thenReturn(expectedToken);
+
+            VerificarPasswordResponseDTO response = verificacionUseCase.verificarPassword(
+                    usuarioId, request, httpRequest);
+
+            assertThat(response.isValido()).isTrue();
+            assertThat(response.getTokenVerificacion()).isEqualTo(expectedToken);
+            verify(verificacionService).generarTokenVerificacion(usuarioId, ipAddress, userAgent);
+        }
+
+        @Test
+        @DisplayName("password incorrecto lanza excepción")
+        void passwordIncorrecto_LanzaExcepcion() {
+            VerificarPasswordRequestDTO request = new VerificarPasswordRequestDTO("wrongpassword");
+
+            when(usuarioRepository.buscarPorId(usuarioId)).thenReturn(Optional.of(usuario));
+            when(verificacionService.verificarPasswordUsuario(usuarioId, "wrongpassword", passwordHash))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> verificacionUseCase.verificarPassword(usuarioId, request, httpRequest))
+                    .isInstanceOf(CredencialesInvalidasException.class)
+                    .hasMessage("Contraseña incorrecta");
+
+            verify(auditService).registrarIntentoVerificacion(usuarioId, "PASSWORD_VERIFY_FAIL", false, ipAddress);
+        }
+
+        @Test
+        @DisplayName("usuario no encontrado lanza excepción")
+        void usuarioNoEncontrado_LanzaExcepcion() {
+            VerificarPasswordRequestDTO request = new VerificarPasswordRequestDTO("password123");
+
+            when(usuarioRepository.buscarPorId(usuarioId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> verificacionUseCase.verificarPassword(usuarioId, request, httpRequest))
+                    .isInstanceOf(CredencialesInvalidasException.class)
+                    .hasMessage("Usuario no encontrado");
+        }
+    }
+
+    @Nested
+    @DisplayName("enviarCodigo")
+    class EnviarCodigo {
+
+        @Test
+        @DisplayName("envía código y retorna token")
+        void enviaCodigo_RetornaToken() {
+            EnviarCodigoRequestDTO request = new EnviarCodigoRequestDTO(TipoVerificacion.SMS, "04121234567");
+            String expectedToken = UUID.randomUUID().toString();
+
+            when(verificacionService.generarYCEnviarCodigo(
+                    eq(usuarioId), eq(TipoVerificacion.SMS), eq("04121234567"),
+                    eq(ipAddress), eq(userAgent), isNull()))
+                    .thenReturn(expectedToken);
+
+            String token = verificacionUseCase.enviarCodigo(usuarioId, request, httpRequest);
+
+            assertThat(token).isEqualTo(expectedToken);
+        }
+
+        @Test
+        @DisplayName("para EMAIL pasa el valor como emailDestino")
+        void paraEMAIL_PasaValor() {
+            EnviarCodigoRequestDTO request = new EnviarCodigoRequestDTO(TipoVerificacion.EMAIL, "test@test.com");
+            String expectedToken = UUID.randomUUID().toString();
+
+            when(verificacionService.generarYCEnviarCodigo(
+                    eq(usuarioId), eq(TipoVerificacion.EMAIL), eq("test@test.com"),
+                    eq(ipAddress), eq(userAgent), eq("test@test.com")))
+                    .thenReturn(expectedToken);
+
+            String token = verificacionUseCase.enviarCodigo(usuarioId, request, httpRequest);
+
+            assertThat(token).isEqualTo(expectedToken);
+        }
+    }
+
+    @Nested
+    @DisplayName("confirmarCodigo")
+    class ConfirmarCodigo {
+
+        @Test
+        @DisplayName("código válido retorna response con token")
+        void codigoValido_RetornaResponse() {
+            String token = UUID.randomUUID().toString();
+            String codigo = "123456";
+            ConfirmarCodigoRequestDTO request = ConfirmarCodigoRequestDTO.builder()
+                    .tipo(TipoVerificacion.SMS)
+                    .token(token)
+                    .codigo(codigo)
+                    .build();
+
+            when(verificacionService.confirmarCodigo(usuarioId, token, codigo, ipAddress, userAgent))
+                    .thenReturn(true);
+
+            ConfirmarCodigoResponseDTO response = verificacionUseCase.confirmarCodigo(
+                    usuarioId, request, httpRequest);
+
+            assertThat(response.isValido()).isTrue();
+            assertThat(response.getTokenVerificacion()).isEqualTo(token);
+        }
+
+        @Test
+        @DisplayName("código inválido lanza excepción")
+        void codigoInvalido_LanzaExcepcion() {
+            String token = UUID.randomUUID().toString();
+            String codigo = "wrong";
+            ConfirmarCodigoRequestDTO request = ConfirmarCodigoRequestDTO.builder()
+                    .tipo(TipoVerificacion.SMS)
+                    .token(token)
+                    .codigo(codigo)
+                    .build();
+
+            when(verificacionService.confirmarCodigo(usuarioId, token, codigo, ipAddress, userAgent))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> verificacionUseCase.confirmarCodigo(usuarioId, request, httpRequest))
+                    .isInstanceOf(VerificacionUseCase.CodigoInvalidoException.class)
+                    .hasMessage("Código inválido o expirado");
+        }
+    }
+
+    @Nested
+    @DisplayName("validarToken")
+    class ValidarToken {
+
+        @Test
+        @DisplayName("token válido retorna true")
+        void tokenValido_RetornaTrue() {
+            String token = UUID.randomUUID().toString();
+
+            when(verificacionService.validarTokenVerificacion(usuarioId, token)).thenReturn(true);
+
+            boolean result = verificacionUseCase.validarToken(usuarioId, token);
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("token inválido retorna false")
+        void tokenInvalido_RetornaFalse() {
+            String token = UUID.randomUUID().toString();
+
+            when(verificacionService.validarTokenVerificacion(usuarioId, token)).thenReturn(false);
+
+            boolean result = verificacionUseCase.validarToken(usuarioId, token);
+
+            assertThat(result).isFalse();
+        }
+    }
+}

--- a/frontend-web/src/components/features/auth/security-verification-modal.tsx
+++ b/frontend-web/src/components/features/auth/security-verification-modal.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useState } from 'react';
+import { useVerification } from '@/hooks/use-verification';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { AlertCircle, CheckCircle, Loader2, Shield, Mail, Lock, MessageSquare } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface SecurityVerificationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onVerified: (token: string) => void;
+  verificationType?: 'password' | 'code';
+  targetValue?: string;
+}
+
+export function SecurityVerificationModal({
+  isOpen,
+  onClose,
+  onVerified,
+  verificationType = 'password',
+  targetValue,
+}: SecurityVerificationModalProps) {
+  const [password, setPassword] = useState('');
+  const [codigo, setCodigo] = useState('');
+
+  const { step, isLoading, error, verifyPassword, sendCode, confirmCode, reset } = useVerification({
+    onSuccess: (token) => {
+      toast.success('Verificación exitosa');
+      onVerified(token);
+    },
+    onError: (error) => {
+      toast.error(error);
+    },
+  });
+
+  if (!isOpen) return null;
+
+  const handlePasswordSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await verifyPassword(password);
+  };
+
+  const handleCodeSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (targetValue) {
+      const token = await sendCode('SMS', targetValue);
+      await confirmCode(codigo);
+    }
+  };
+
+  const handleClose = () => {
+    reset();
+    setPassword('');
+    setCodigo('');
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-md mx-4 p-6">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="p-2 bg-blue-100 rounded-full">
+            <Shield className="h-6 w-6 text-blue-600" />
+          </div>
+          <div>
+            <h2 className="text-xl font-semibold text-gray-900">Verificación de Seguridad</h2>
+            <p className="text-sm text-gray-500">Para continuar, verifica tu identidad</p>
+          </div>
+        </div>
+
+        {step === 'idle' || step === 'password' ? (
+          <form onSubmit={handlePasswordSubmit} className="space-y-4">
+            <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg flex items-start gap-2">
+              <Lock className="h-4 w-4 text-amber-600 mt-0.5 flex-shrink-0" />
+              <p className="text-sm text-amber-800">
+                Ingresa tu contraseña actual para continuar con el cambio
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="password">Contraseña Actual</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Ingresa tu contraseña"
+                disabled={isLoading}
+                autoComplete="current-password"
+              />
+            </div>
+
+            {error && (
+              <div className="p-3 bg-red-50 border border-red-200 rounded-lg flex items-center gap-2">
+                <AlertCircle className="h-4 w-4 text-red-600 flex-shrink-0" />
+                <p className="text-sm text-red-700">{error}</p>
+              </div>
+            )}
+
+            <div className="flex gap-3 pt-2">
+              <Button type="button" variant="outline" onClick={handleClose} className="flex-1">
+                Cancelar
+              </Button>
+              <Button type="submit" className="flex-1 bg-blue-600 hover:bg-blue-700" disabled={isLoading || !password}>
+                {isLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Verificando...
+                  </>
+                ) : (
+                  'Verificar'
+                )}
+              </Button>
+            </div>
+          </form>
+        ) : step === 'code_sent' ? (
+          <form onSubmit={handleCodeSubmit} className="space-y-4">
+            <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg flex items-start gap-2">
+              <MessageSquare className="h-4 w-4 text-blue-600 mt-0.5 flex-shrink-0" />
+              <p className="text-sm text-blue-800">
+                Hemos enviado un código de verificación a tu teléfono
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="codigo">Código de Verificación</Label>
+              <Input
+                id="codigo"
+                type="text"
+                value={codigo}
+                onChange={(e) => setCodigo(e.target.value)}
+                placeholder="Ingresa el código de 6 dígitos"
+                disabled={isLoading}
+                maxLength={6}
+                className="text-center text-xl tracking-widest"
+              />
+            </div>
+
+            {error && (
+              <div className="p-3 bg-red-50 border border-red-200 rounded-lg flex items-center gap-2">
+                <AlertCircle className="h-4 w-4 text-red-600 flex-shrink-0" />
+                <p className="text-sm text-red-700">{error}</p>
+              </div>
+            )}
+
+            <div className="flex gap-3 pt-2">
+              <Button type="button" variant="outline" onClick={() => setStep('password')} className="flex-1">
+                Volver
+              </Button>
+              <Button type="submit" className="flex-1 bg-green-600 hover:bg-green-700" disabled={isLoading || codigo.length !== 6}>
+                {isLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Confirmando...
+                  </>
+                ) : (
+                  'Confirmar'
+                )}
+              </Button>
+            </div>
+          </form>
+        ) : step === 'success' ? (
+          <div className="text-center py-6">
+            <div className="flex justify-center mb-4">
+              <div className="p-3 bg-green-100 rounded-full">
+                <CheckCircle className="h-8 w-8 text-green-600" />
+              </div>
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 mb-2">Verificación Exitosa</h3>
+            <p className="text-sm text-gray-500 mb-4">Tu identidad ha sido verificada correctamente</p>
+            <Button onClick={handleClose} className="w-full bg-green-600 hover:bg-green-700">
+              Continuar
+            </Button>
+          </div>
+        ) : step === 'error' ? (
+          <div className="text-center py-6">
+            <div className="flex justify-center mb-4">
+              <div className="p-3 bg-red-100 rounded-full">
+                <AlertCircle className="h-8 w-8 text-red-600" />
+              </div>
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 mb-2">Error de Verificación</h3>
+            <p className="text-sm text-gray-500 mb-4">{error}</p>
+            <div className="flex gap-3">
+              <Button variant="outline" onClick={handleClose} className="flex-1">
+                Cancelar
+              </Button>
+              <Button onClick={() => { setError(null); setStep('password'); }} className="flex-1">
+                Intentar de Nuevo
+              </Button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend-web/src/hooks/use-verification.test.ts
+++ b/frontend-web/src/hooks/use-verification.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useVerification } from '@/hooks/use-verification';
+import { renderHook, act } from '@testing-library/react';
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+global.fetch = vi.fn();
+
+describe('useVerification Hook', () => {
+  const onSuccess = vi.fn();
+  const onError = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  describe('initial state', () => {
+    it('tiene estado inicial idle', () => {
+      const { result } = renderHook(() =>
+        useVerification({ onSuccess, onError })
+      );
+
+      expect(result.current.step).toBe('idle');
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(result.current.token).toBeNull();
+    });
+  });
+
+  describe('reset', () => {
+    it('reset limpia todos los estados', () => {
+      const { result } = renderHook(() =>
+        useVerification({ onSuccess, onError })
+      );
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.step).toBe('idle');
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(result.current.token).toBeNull();
+    });
+  });
+
+  describe('verifyPassword', () => {
+    it('verifyPassword exitoso retorna true', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ tokenVerificacion: 'test-token-123' }),
+      });
+
+      const { result } = renderHook(() =>
+        useVerification({ onSuccess, onError })
+      );
+
+      let verifyResult: boolean | undefined;
+      await act(async () => {
+        verifyResult = await result.current.verifyPassword('password123');
+      });
+
+      expect(verifyResult).toBe(true);
+      expect(onSuccess).toHaveBeenCalledWith('test-token-123');
+    });
+
+    it('verifyPassword fallido retorna false', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        json: () => Promise.resolve({ message: 'Contraseña incorrecta' }),
+      });
+
+      const { result } = renderHook(() =>
+        useVerification({ onSuccess, onError })
+      );
+
+      let verifyResult: boolean | undefined;
+      await act(async () => {
+        verifyResult = await result.current.verifyPassword('wrongpassword');
+      });
+
+      expect(verifyResult).toBe(false);
+      expect(result.current.step).toBe('error');
+      expect(onError).toHaveBeenCalled();
+    });
+  });
+
+  describe('confirmCode sin token', () => {
+    it('confirmCode sin token retorna false', async () => {
+      const { result } = renderHook(() =>
+        useVerification({ onSuccess, onError })
+      );
+
+      let confirmResult: boolean | undefined;
+      await act(async () => {
+        confirmResult = await result.current.confirmCode('123456');
+      });
+
+      expect(confirmResult).toBe(false);
+      expect(result.current.error).toBe('No hay código pendiente');
+    });
+  });
+});

--- a/frontend-web/src/hooks/use-verification.ts
+++ b/frontend-web/src/hooks/use-verification.ts
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+export type VerificationStep = 'idle' | 'password' | 'code_sent' | 'verifying' | 'success' | 'error';
+
+interface UseVerificationOptions {
+  onSuccess: (token: string) => void;
+  onError?: (error: string) => void;
+}
+
+interface UseVerificationReturn {
+  step: VerificationStep;
+  isLoading: boolean;
+  error: string | null;
+  token: string | null;
+  verifyPassword: (password: string) => Promise<boolean>;
+  sendCode: (tipo: 'EMAIL' | 'SMS', valor: string) => Promise<string>;
+  confirmCode: (codigo: string) => Promise<boolean>;
+  reset: () => void;
+}
+
+export function useVerification({ onSuccess, onError }: UseVerificationOptions): UseVerificationReturn {
+  const [step, setStep] = useState<VerificationStep>('idle');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [codigoToken, setCodigoToken] = useState<string | null>(null);
+
+  const verifyPassword = useCallback(async (password: string): Promise<boolean> => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/v1/perfil/verificar-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ password }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.message || 'Contraseña incorrecta');
+      }
+
+      setToken(data.tokenVerificacion);
+      setStep('success');
+      onSuccess(data.tokenVerificacion);
+      return true;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Error al verificar contraseña';
+      setError(message);
+      setStep('error');
+      onError?.(message);
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [onSuccess, onError]);
+
+  const sendCode = useCallback(async (tipo: 'EMAIL' | 'SMS', valor: string): Promise<string> => {
+    setIsLoading(true);
+    setError(null);
+    setStep('password');
+
+    try {
+      const response = await fetch('/api/v1/perfil/enviar-codigo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ tipo, valor }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.message || 'Error al enviar código');
+      }
+
+      setCodigoToken(data.token);
+      setStep('code_sent');
+      return data.token;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Error al enviar código';
+      setError(message);
+      setStep('error');
+      onError?.(message);
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [onError]);
+
+  const confirmCode = useCallback(async (codigo: string): Promise<boolean> => {
+    if (!codigoToken) {
+      setError('No hay código pendiente');
+      return false;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    setStep('verifying');
+
+    try {
+      const response = await fetch('/api/v1/perfil/confirmar-codigo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ tipo: 'SMS', token: codigoToken, codigo }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok || !data.valido) {
+        throw new Error(data.message || 'Código inválido');
+      }
+
+      setToken(data.tokenVerificacion);
+      setStep('success');
+      onSuccess(data.tokenVerificacion);
+      return true;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Error al confirmar código';
+      setError(message);
+      setStep('error');
+      onError?.(message);
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [codigoToken, onSuccess, onError]);
+
+  const reset = useCallback(() => {
+    setStep('idle');
+    setIsLoading(false);
+    setError(null);
+    setToken(null);
+    setCodigoToken(null);
+  }, []);
+
+  return {
+    step,
+    isLoading,
+    error,
+    token,
+    verifyPassword,
+    sendCode,
+    confirmCode,
+    reset,
+  };
+}

--- a/frontend-web/src/lib/utils/validators.test.ts
+++ b/frontend-web/src/lib/utils/validators.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { registroSchema, ESTADOS_VENEZUELA, TIPOS_DOCUMENTO, GENEROS, ESTADOS_CIVILES } from '@/lib/utils/validators';
+import { registroSchema, profileSchema, ESTADOS_VENEZUELA, BANCOS_VENEZUELA, TIPOS_DOCUMENTO, GENEROS, ESTADOS_CIVILES } from '@/lib/utils/validators';
 
 describe('registroSchema - Validaciones Issue #99', () => {
 
@@ -593,6 +593,163 @@ describe('registroSchema - Validaciones Issue #99', () => {
       expect(ESTADOS_CIVILES.length).toBe(5);
       expect(ESTADOS_CIVILES).toContain('SOLTERO');
       expect(ESTADOS_CIVILES).toContain('CASADO');
+    });
+
+    it('BANCOS_VENEZUELA tiene bancos válidos', () => {
+      expect(BANCOS_VENEZUELA.length).toBeGreaterThan(0);
+      expect(BANCOS_VENEZUELA[0]).toHaveProperty('codigo');
+      expect(BANCOS_VENEZUELA[0]).toHaveProperty('nombre');
+      const bancoVenezuela = BANCOS_VENEZUELA.find(b => b.codigo === '0102');
+      expect(bancoVenezuela?.nombre).toBe('Banco de Venezuela');
+    });
+
+  });
+
+});
+
+describe('profileSchema - Validaciones Issue #103', () => {
+
+  describe('1. Teléfono Venezuela', () => {
+
+    it('teléfono 04121234567 válido', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('teléfono +584121234567 válido', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '+584121234567',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('teléfono corto falla', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '123',
+      });
+      expect(result.success).toBe(false);
+    });
+
+  });
+
+  describe('2. Código Postal Venezuela', () => {
+
+    it('código postal 4 dígitos válido', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        direccionResidencia: { codigoPostal: '1010' },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('código postal con letras falla', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        direccionResidencia: { codigoPostal: '1010A' },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('código postal con más de 4 dígitos falla', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        direccionResidencia: { codigoPostal: '10101' },
+      });
+      expect(result.success).toBe(false);
+    });
+
+  });
+
+  describe('3. RIF Empresa', () => {
+
+    it('RIF J-12345678-9 válido', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        rifEmpresa: 'J-12345678-9',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('RIF V-12345678 válido', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        rifEmpresa: 'V-12345678',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('RIF sin prefijo falla', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        rifEmpresa: '12345678',
+      });
+      expect(result.success).toBe(false);
+    });
+
+  });
+
+  describe('4. Número de Cuenta', () => {
+
+    it('cuenta 10 dígitos válida', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        numeroCuentaNomina: '0102123456',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('cuenta 20 dígitos válida', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        numeroCuentaNomina: '01021234567890123456',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('cuenta con letras falla', () => {
+      const result = profileSchema.safeParse({
+        primerNombre: 'Juan',
+        primerApellido: 'Pérez',
+        correoElectronico: 'juan@test.com',
+        telefonoPrincipal: '04121234567',
+        numeroCuentaNomina: '0102ABCD123456',
+      });
+      expect(result.success).toBe(false);
     });
 
   });

--- a/frontend-web/src/lib/utils/validators.ts
+++ b/frontend-web/src/lib/utils/validators.ts
@@ -33,8 +33,35 @@ export const ESTADOS_VENEZUELA = [
   'Amazonas', 'Anzoátegui', 'Apure', 'Aragua', 'Barinas', 'Bolívar',
   'Carabobo', 'Cojedes', 'Delta Amacuro', 'Distrito Capital', 'Falcón',
   'Guárico', 'Lara', 'Mérida', 'Miranda', 'Monagas', 'Nueva Esparta',
-  'Portuguesa', 'Sucre', 'Táchira', 'Trujillo', 'Vargas', 'Yaracuy', 'Zulia'
+  'Portuguesa', 'Sucre', 'Táchira', 'Trujillo', 'La Guaira', 'Yaracuy', 'Zulia'
 ] as const;
+
+export const BANCOS_VENEZUELA = [
+  { codigo: '0102', nombre: 'Banco de Venezuela' },
+  { codigo: '0104', nombre: 'Banco Provincial' },
+  { codigo: '0105', nombre: 'Banco de Guyana' },
+  { codigo: '0114', nombre: 'Banco del Caribe' },
+  { codigo: '0128', nombre: 'Banco Caroní' },
+  { codigo: '0134', nombre: 'Banco Bicentenario' },
+  { codigo: '0137', nombre: 'Banco Sofitasa' },
+  { codigo: '0138', nombre: 'Banco Plaza' },
+  { codigo: '0151', nombre: 'Banco Fondo Común' },
+  { codigo: '0156', nombre: 'Banco 100% Banco' },
+  { codigo: '0157', nombre: 'Banco Digital' },
+  { codigo: '0163', nombre: 'Banco del Tesoro' },
+  { codigo: '0166', nombre: 'Banco Agro' },
+  { codigo: '0171', nombre: 'Banco Activo' },
+  { codigo: '0174', nombre: 'Banco Bancrecer' },
+  { codigo: '0175', nombre: 'Banco Internacional de Desarrollo' },
+  { codigo: '0177', nombre: 'Banco Banplus' },
+  { codigo: '0181', nombre: 'Banco Venezuelan' },
+  { codigo: '0186', nombre: 'Banco Mi Banco' },
+  { codigo: '0190', nombre: 'Banco Nacional de Crédito' },
+  { codigo: '0601', nombre: 'Banco de la Fuerza Armada' },
+] as const;
+
+const codigoPostalRegex = /^\d{4}$/;
+const telefonoVenezuelRegex = /^(\+58)?[0-9]{10,11}$/;
 
 export const TIPOS_DOCUMENTO = ['CEDULA', 'CEDULA_EXTRANJERO', 'PASAPORTE', 'RIF'] as const;
 export const GENEROS = ['MASCULINO', 'FEMENINO', 'OTRO'] as const;
@@ -164,14 +191,14 @@ export const beneficiarioSchema = z.object({
 const direccionSchema = z.object({
   calle: z.string().max(200).optional(),
   ciudad: z.string().max(100).optional(),
-  estado: z.string().max(100).optional(),
-  codigoPostal: z.string().max(20).optional(),
+  estado: z.string().max(50).optional(),
+  codigoPostal: z.string().regex(codigoPostalRegex, 'Código postal debe ser 4 dígitos').optional().or(z.literal('')),
   pais: z.string().max(100).optional(),
 });
 
 const contactoEmergenciaSchema = z.object({
   nombre: z.string().min(2, 'Mínimo 2 caracteres').max(200),
-  telefono: z.string().regex(/^\+?[0-9]{7,15}$/, 'Teléfono inválido'),
+  telefono: z.string().regex(telefonoVenezuelRegex, 'Teléfono inválido'),
   parentesco: z.string().max(100).optional(),
 });
 
@@ -184,11 +211,12 @@ export const profileSchema = z.object({
   genero: z.enum(['MASCULINO', 'FEMENINO', 'OTRO']).optional(),
   estadoCivil: z.enum(['SOLTERO', 'CASADO', 'DIVORCIADO', 'VIUDO', 'UNION_LIBRE']).optional(),
   correoElectronico: z.string().email('Email inválido'),
-  telefonoPrincipal: z.string().regex(/^\+?[0-9]{7,15}$/, 'Teléfono inválido'),
-  telefonoSecundario: z.string().regex(/^\+?[0-9]{7,15}$/, 'Teléfono inválido').optional().or(z.literal('')),
+  telefonoPrincipal: z.string().regex(telefonoVenezuelRegex, 'Teléfono inválido (formato: 04121234567 o +584121234567)'),
+  telefonoSecundario: z.string().regex(telefonoVenezuelRegex, 'Teléfono inválido').optional().or(z.literal('')),
   direccionResidencia: direccionSchema.optional(),
   direccionLaboral: direccionSchema.optional(),
   empresa: z.string().max(200).optional().or(z.literal('')),
+  rifEmpresa: z.string().regex(/^(J|V|E|G)-\d{6,10}(-\d)?$/, 'RIF inválido').optional().or(z.literal('')),
   departamento: z.string().max(100).optional().or(z.literal('')),
   cargo: z.string().max(100).optional().or(z.literal('')),
   tipoContrato: z.enum(['CONTRATO_INDEFINIDO', 'CONTRATO_TEMPORAL', 'CONTRATO_POR_HORAS', 'SERVICIOS', 'APRENDIZ']).optional(),


### PR DESCRIPTION
## Summary
Issue #101: Verificación de contraseña para cambios sensibles

## Backend
- **DTOs**: `VerificarPasswordRequestDTO`, `VerificarPasswordResponseDTO`, `EnviarCodigoRequestDTO`, `ConfirmarCodigoRequestDTO`, `ConfirmarCodigoResponseDTO`
- **Enum**: `TipoVerificacion` (EMAIL, SMS)
- **Entity**: `VerificacionTokenEntity` (token temp 5min, intentos, IP, UserAgent)
- **Repository**: `VerificacionTokenRepository`
- **Service**: `VerificacionService` (generar tokens, códigos, confirmar)
- **UseCase**: `VerificacionUseCase`
- **Controller**: `PerfilVerificacionController` (`/api/v1/perfil/verificar-password`, `/enviar-codigo`, `/confirmar-codigo`)
- **Modified**: `SecurityEvent`, `SecurityAuditService`, `EmailService`
- **Migration**: V10 `verificacion_token` table

## Frontend
- `use-verification.ts`: hook para flujo de verificación
- `security-verification-modal.tsx`: modal con estados UI
- `use-verification.test.ts`: 5 tests

## Tests
- `VerificacionServiceTest`: 20 tests
- `VerificacionUseCaseTest`: 9 tests
- Total: 138 backend / 230 frontend tests passing

## Security
- Token TTL: 5 minutos
- Max intentos: 3
- Audit logging en todos los intentos