### PR TITLE
feat(#109): Invalidar todas las sesiones de un usuario

### DIFF
--- a/backend/src/main/java/com/tufondo/admin/application/dto/SesionInfoResponse.java
+++ b/backend/src/main/java/com/tufondo/admin/application/dto/SesionInfoResponse.java
@@ -1,0 +1,15 @@
+package com.tufondo.admin.application.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record SesionInfoResponse(
+        UUID id,
+        String ipAddress,
+        String userAgent,
+        Instant ultimoAcceso,
+        Instant fechaCreacion,
+        Instant expiraAt,
+        boolean activa
+) {
+}

--- a/backend/src/main/java/com/tufondo/admin/application/dto/SesionInvalidationResponse.java
+++ b/backend/src/main/java/com/tufondo/admin/application/dto/SesionInvalidationResponse.java
@@ -1,0 +1,10 @@
+package com.tufondo.admin.application.dto;
+
+import java.util.UUID;
+
+public record SesionInvalidationResponse(
+        UUID usuarioId,
+        int sesionesInvalidadas,
+        String mensaje
+) {
+}

--- a/backend/src/main/java/com/tufondo/admin/presentation/controller/AdminSesionController.java
+++ b/backend/src/main/java/com/tufondo/admin/presentation/controller/AdminSesionController.java
@@ -1,0 +1,139 @@
+package com.tufondo.admin.presentation.controller;
+
+import com.tufondo.admin.application.dto.SesionInfoResponse;
+import com.tufondo.admin.application.dto.SesionInvalidationResponse;
+import com.tufondo.auth.domain.model.Sesion;
+import com.tufondo.auth.domain.model.Usuario;
+import com.tufondo.auth.domain.repository.SesionRepository;
+import com.tufondo.auth.domain.repository.UsuarioRepository;
+import com.tufondo.auth.infrastructure.service.EmailService;
+import com.tufondo.auth.infrastructure.service.SecurityAuditService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/admin/sesiones")
+@RequiredArgsConstructor
+@Tag(name = "Admin Sesiones", description = "Endpoints para gestión de sesiones de usuarios")
+@SecurityRequirement(name = "bearerAuth")
+public class AdminSesionController {
+
+    private final SesionRepository sesionRepository;
+    private final UsuarioRepository usuarioRepository;
+    private final SecurityAuditService auditService;
+    private final EmailService emailService;
+
+    @GetMapping("/usuario/{usuarioId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
+    @Operation(summary = "Listar sesiones activas de un usuario")
+    public ResponseEntity<List<SesionInfoResponse>> listarSesionesActivas(
+            @PathVariable UUID usuarioId) {
+
+        List<Sesion> sesiones = sesionRepository.buscarSesionesActivasPorUsuario(usuarioId);
+
+        List<SesionInfoResponse> response = sesiones.stream()
+                .map(this::toSesionInfoResponse)
+                .toList();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/usuario/{usuarioId}/invalidar-todas")
+    @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
+    @Operation(summary = "Invalidar todas las sesiones de un usuario")
+    public ResponseEntity<SesionInvalidationResponse> invalidarTodasLasSesiones(
+            @PathVariable UUID usuarioId,
+            HttpServletRequest request,
+            Authentication authentication) {
+
+        String adminId = authentication.getName();
+        String clientIp = getClientIp(request);
+
+        List<Sesion> sesionesActivas = sesionRepository.buscarSesionesActivasPorUsuario(usuarioId);
+        int cantidad = sesionesActivas.size();
+
+        sesionRepository.invalidarTodasPorUsuario(usuarioId);
+
+        auditService.logSesionesInvalidadas(usuarioId, clientIp, UUID.fromString(adminId), cantidad);
+
+        usuarioRepository.buscarPorId(usuarioId).ifPresent(usuario -> {
+            emailService.enviarNotificacionSesionesInvalidadas(
+                    usuario.correoElectronico(),
+                    usuario.nombreUsuario(),
+                    cantidad,
+                    clientIp
+            );
+        });
+
+        log.info("Sesiones invalidadas para usuario {} por admin {} - cantidad: {}",
+                usuarioId, adminId, cantidad);
+
+        return ResponseEntity.ok(new SesionInvalidationResponse(
+                usuarioId,
+                cantidad,
+                "Todas las sesiones han sido invalidadas exitosamente"
+        ));
+    }
+
+    @PostMapping("/{sesionId}/invalidar")
+    @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
+    @Operation(summary = "Invalidar una sesión específica")
+    public ResponseEntity<Void> invalidarSesion(
+            @PathVariable String sesionId,
+            HttpServletRequest request,
+            Authentication authentication) {
+
+        String adminId = authentication.getName();
+        String clientIp = getClientIp(request);
+
+        sesionRepository.invalidarPorTokenId(sesionId);
+
+        auditService.logSesionIndividualInvalidadas(
+                null,
+                clientIp,
+                UUID.fromString(adminId),
+                sesionId
+        );
+
+        log.info("Sesión {} invalidada por admin {} desde IP {}",
+                sesionId, adminId, clientIp);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    private SesionInfoResponse toSesionInfoResponse(Sesion sesion) {
+        return new SesionInfoResponse(
+                sesion.id(),
+                null,
+                null,
+                sesion.ultimaActividad(),
+                sesion.fechaCreacion(),
+                sesion.refreshTokenExpiracion(),
+                sesion.activa()
+        );
+    }
+
+    private String getClientIp(HttpServletRequest request) {
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (xForwardedFor != null && !xForwardedFor.isEmpty()) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+        String xRealIp = request.getHeader("X-Real-IP");
+        if (xRealIp != null && !xRealIp.isEmpty()) {
+            return xRealIp;
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/backend/src/main/java/com/tufondo/auth/domain/model/audit/SecurityEvent.java
+++ b/backend/src/main/java/com/tufondo/auth/domain/model/audit/SecurityEvent.java
@@ -96,4 +96,26 @@ public record SecurityEvent(
                 "rol=" + rol
         );
     }
+
+    public static SecurityEvent sesionesInvalidadas(UUID usuarioId, String ip, UUID invalidadoPor, int cantidad) {
+        return new SecurityEvent(
+                UUID.randomUUID(),
+                "SESSIONS_INVALIDATED",
+                usuarioId,
+                ip,
+                Instant.now(),
+                "invalidado_por=" + invalidadoPor + ", cantidad=" + cantidad
+        );
+    }
+
+    public static SecurityEvent sesionIndividualInvalidadas(UUID usuarioId, String ip, UUID invalidadoPor, String sesionId) {
+        return new SecurityEvent(
+                UUID.randomUUID(),
+                "SESSION_INVALIDATED",
+                usuarioId,
+                ip,
+                Instant.now(),
+                "invalidado_por=" + invalidadoPor + ", sesion_id=" + sesionId
+        );
+    }
 }

--- a/backend/src/main/java/com/tufondo/auth/infrastructure/service/EmailService.java
+++ b/backend/src/main/java/com/tufondo/auth/infrastructure/service/EmailService.java
@@ -67,4 +67,15 @@ public class EmailService {
         log.info("Este es un email mock - En producción se enviaría un email real");
         log.info("======================================================");
     }
+
+    public void enviarNotificacionSesionesInvalidadas(String destinatario, String nombreUsuario, int cantidadSesiones, String ipAdmin) {
+        log.info("========= EMAIL MOCK: SESIONES INVALIDADAS =========");
+        log.info("Para: {}", destinatario);
+        log.info("Usuario: {}", nombreUsuario);
+        log.info("Cantidad de sesiones invalidadas: {}", cantidadSesiones);
+        log.info("IP del administrador que realizó la acción: {}", ipAdmin);
+        log.info("Mensaje: Todas sus sesiones han sido invalidadas por seguridad");
+        log.info("Este es un email mock - En producción se enviaría un email real");
+        log.info("======================================================");
+    }
 }

--- a/backend/src/main/java/com/tufondo/auth/infrastructure/service/SecurityAuditService.java
+++ b/backend/src/main/java/com/tufondo/auth/infrastructure/service/SecurityAuditService.java
@@ -122,4 +122,26 @@ public class SecurityAuditService {
             );
         }
     }
+
+    public void logSesionesInvalidadas(UUID usuarioId, String ip, UUID invalidadoPor, int cantidad) {
+        SecurityEvent event = SecurityEvent.sesionesInvalidadas(usuarioId, ip, invalidadoPor, cantidad);
+        log.warn("AUDIT [{}] usuario={} ip={} tipo={} detalles={}",
+                event.timestamp(),
+                event.usuarioId(),
+                event.ipAddress(),
+                event.tipoEvento(),
+                event.detalles()
+        );
+    }
+
+    public void logSesionIndividualInvalidadas(UUID usuarioId, String ip, UUID invalidadoPor, String sesionId) {
+        SecurityEvent event = SecurityEvent.sesionIndividualInvalidadas(usuarioId, ip, invalidadoPor, sesionId);
+        log.warn("AUDIT [{}] usuario={} ip={} tipo={} detalles={}",
+                event.timestamp(),
+                event.usuarioId(),
+                event.ipAddress(),
+                event.tipoEvento(),
+                event.detalles()
+        );
+    }
 }

--- a/backend/src/test/java/com/tufondo/admin/presentation/controller/AdminSesionControllerTest.java
+++ b/backend/src/test/java/com/tufondo/admin/presentation/controller/AdminSesionControllerTest.java
@@ -1,0 +1,203 @@
+package com.tufondo.admin.presentation.controller;
+
+import com.tufondo.admin.application.dto.SesionInfoResponse;
+import com.tufondo.admin.application.dto.SesionInvalidationResponse;
+import com.tufondo.auth.domain.model.Sesion;
+import com.tufondo.auth.domain.model.Usuario;
+import com.tufondo.auth.domain.model.enums.Rol;
+import com.tufondo.auth.domain.model.enums.TipoToken;
+import com.tufondo.auth.domain.repository.SesionRepository;
+import com.tufondo.auth.domain.repository.UsuarioRepository;
+import com.tufondo.auth.infrastructure.service.EmailService;
+import com.tufondo.auth.infrastructure.service.SecurityAuditService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("AdminSesionController - Tests de Integración")
+class AdminSesionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SesionRepository sesionRepository;
+
+    @MockBean
+    private UsuarioRepository usuarioRepository;
+
+    @MockBean
+    private SecurityAuditService auditService;
+
+    @MockBean
+    private EmailService emailService;
+
+    private static final UUID USUARIO_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID SESION_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private static final UUID ADMIN_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");
+
+    private Usuario usuarioTest;
+    private Sesion sesionTest;
+
+    @BeforeEach
+    void setUp() {
+        usuarioTest = Usuario.desdeParametros(
+                USUARIO_ID,
+                "usuario_test",
+                "usuario@test.com",
+                "hash",
+                "Usuario Test",
+                Rol.SOCIO,
+                UUID.randomUUID(),
+                true,
+                Instant.now(),
+                Instant.now(),
+                0,
+                null,
+                false
+        );
+
+        sesionTest = Sesion.desdeParametros(
+                SESION_ID,
+                USUARIO_ID,
+                "refresh_token_hash",
+                Instant.now().plusSeconds(900),
+                Instant.now().plusSeconds(604800),
+                true,
+                TipoToken.REFRESH_TOKEN,
+                Instant.now(),
+                Instant.now()
+        );
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/admin/sesiones/usuario/{id} - Lista sesiones activas")
+    @WithMockUser(username = "33333333-3333-3333-3333-333333333333", roles = {"ADMIN"})
+    void listar_sesiones_activas_devuelve_lista() throws Exception {
+        List<Sesion> sesiones = List.of(sesionTest);
+        when(sesionRepository.buscarSesionesActivasPorUsuario(USUARIO_ID)).thenReturn(sesiones);
+
+        mockMvc.perform(get("/api/v1/admin/sesiones/usuario/{usuarioId}", USUARIO_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(SESION_ID.toString()))
+                .andExpect(jsonPath("$[0].activa").value(true));
+
+        verify(sesionRepository).buscarSesionesActivasPorUsuario(USUARIO_ID);
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/admin/sesiones/usuario/{id} - Usuario sin sesiones")
+    @WithMockUser(username = "33333333-3333-3333-3333-333333333333", roles = {"ADMIN"})
+    void listar_sesiones_usuario_sin_sesiones_devuelve_lista_vacia() throws Exception {
+        when(sesionRepository.buscarSesionesActivasPorUsuario(USUARIO_ID)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/admin/sesiones/usuario/{usuarioId}", USUARIO_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/admin/sesiones/usuario/{id}/invalidar-todas - Invalida todas las sesiones")
+    @WithMockUser(username = "33333333-3333-3333-3333-333333333333", roles = {"ADMIN"})
+    void invalidar_todas_las_sesiones_devuelve_respuesta_exitosa() throws Exception {
+        List<Sesion> sesiones = List.of(sesionTest);
+        when(sesionRepository.buscarSesionesActivasPorUsuario(USUARIO_ID)).thenReturn(sesiones);
+        when(usuarioRepository.buscarPorId(USUARIO_ID)).thenReturn(Optional.of(usuarioTest));
+        doNothing().when(sesionRepository).invalidarTodasPorUsuario(USUARIO_ID);
+        doNothing().when(auditService).logSesionesInvalidadas(any(), any(), any(), anyInt());
+        doNothing().when(emailService).enviarNotificacionSesionesInvalidadas(any(), any(), anyInt(), any());
+
+        mockMvc.perform(post("/api/v1/admin/sesiones/usuario/{usuarioId}/invalidar-todas", USUARIO_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.usuarioId").value(USUARIO_ID.toString()))
+                .andExpect(jsonPath("$.sesionesInvalidadas").value(1))
+                .andExpect(jsonPath("$.mensaje").value("Todas las sesiones han sido invalidadas exitosamente"));
+
+        verify(sesionRepository).invalidarTodasPorUsuario(USUARIO_ID);
+        verify(auditService).logSesionesInvalidadas(eq(USUARIO_ID), any(), any(), eq(1));
+        verify(emailService).enviarNotificacionSesionesInvalidadas(
+                eq(usuarioTest.correoElectronico()),
+                eq(usuarioTest.nombreUsuario()),
+                eq(1),
+                any()
+        );
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/admin/sesiones/usuario/{id}/invalidar-todas - Usuario no encontrado")
+    @WithMockUser(username = "33333333-3333-3333-3333-333333333333", roles = {"ADMIN"})
+    void invalidar_todas_usuario_no_encontrado_envia_email_sin_datos() throws Exception {
+        List<Sesion> sesiones = List.of(sesionTest);
+        when(sesionRepository.buscarSesionesActivasPorUsuario(USUARIO_ID)).thenReturn(sesiones);
+        when(usuarioRepository.buscarPorId(USUARIO_ID)).thenReturn(Optional.empty());
+        doNothing().when(sesionRepository).invalidarTodasPorUsuario(USUARIO_ID);
+        doNothing().when(auditService).logSesionesInvalidadas(any(), any(), any(), anyInt());
+
+        mockMvc.perform(post("/api/v1/admin/sesiones/usuario/{usuarioId}/invalidar-todas", USUARIO_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sesionesInvalidadas").value(1));
+
+        verify(emailService, never()).enviarNotificacionSesionesInvalidadas(any(), any(), anyInt(), any());
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/admin/sesiones/{sesionId}/invalidar - Invalida sesión específica")
+    @WithMockUser(username = "33333333-3333-3333-3333-333333333333", roles = {"ADMIN"})
+    void invalidar_sesion_especifica_devuelve_no_content() throws Exception {
+        doNothing().when(sesionRepository).invalidarPorTokenId(SESION_ID.toString());
+        doNothing().when(auditService).logSesionIndividualInvalidadas(any(), any(), any(), any());
+
+        mockMvc.perform(post("/api/v1/admin/sesiones/{sesionId}/invalidar", SESION_ID))
+                .andExpect(status().isNoContent());
+
+        verify(sesionRepository).invalidarPorTokenId(SESION_ID.toString());
+        verify(auditService).logSesionIndividualInvalidadas(eq(null), any(), any(), eq(SESION_ID.toString()));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/admin/sesiones/{sesionId}/invalidar - Sesión no existe")
+    @WithMockUser(username = "33333333-3333-3333-3333-333333333333", roles = {"ADMIN"})
+    void invalidar_sesion_no_existente_devuelve_no_content() throws Exception {
+        doNothing().when(sesionRepository).invalidarPorTokenId(any());
+
+        mockMvc.perform(post("/api/v1/admin/sesiones/{sesionId}/invalidar", UUID.randomUUID()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/admin/sesiones/usuario/{id} - Sin autenticación returns 403")
+    void listar_sesiones_sin_auth_devuelve_403() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/sesiones/usuario/{usuarioId}", USUARIO_ID))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/admin/sesiones/usuario/{id}/invalidar-todas - Usuario sin rol ADMIN")
+    @WithMockUser(username = "33333333-3333-3333-3333-333333333333", roles = {"SOCIO"})
+    void invalidar_todas_usuario_sin_rol_admin_devuelve_error() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/sesiones/usuario/{usuarioId}/invalidar-todas", USUARIO_ID))
+                .andExpect(status().is5xxServerError());
+    }
+}

--- a/frontend-web/src/app/(admin)/admin/sesiones/page.tsx
+++ b/frontend-web/src/app/(admin)/admin/sesiones/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Loader2, Search, ShieldAlert } from 'lucide-react';
+import { SessionManager } from '@/components/features/admin/session-manager';
+
+export default function AdminSesionesPage() {
+  const [usuarioId, setUsuarioId] = useState('');
+  const [usuarioNombre, setUsuarioNombre] = useState('');
+  const [showManager, setShowManager] = useState(false);
+
+  const handleBuscar = () => {
+    if (usuarioId.trim()) {
+      setShowManager(true);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">Gestión de Sesiones</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <ShieldAlert className="h-5 w-5" />
+            Buscar Usuario
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-gray-500">
+            Ingrese el ID del usuario para ver y gestionar sus sesiones activas.
+            Esta función permite invalidar sesiones por seguridad.
+          </p>
+          <div className="flex gap-4">
+            <Input
+              placeholder="ID del usuario (UUID)"
+              value={usuarioId}
+              onChange={(e) => setUsuarioId(e.target.value)}
+              className="max-w-md"
+            />
+            <Input
+              placeholder="Nombre del usuario"
+              value={usuarioNombre}
+              onChange={(e) => setUsuarioNombre(e.target.value)}
+              className="max-w-xs"
+            />
+            <Button onClick={handleBuscar} disabled={!usuarioId.trim()}>
+              <Search className="h-4 w-4 mr-2" />
+              Buscar
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {showManager && usuarioId && (
+        <SessionManager
+          usuarioId={usuarioId}
+          usuarioNombre={usuarioNombre || 'Usuario'}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend-web/src/app/(dashboard)/dashboard/kyc/dashboard-kyc.test.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/kyc/dashboard-kyc.test.tsx
@@ -13,7 +13,7 @@ vi.mock('sonner', () => ({
 }));
 
 vi.mock('@/components/ui/progress', () => ({
-  Progress: ({ value }: { value: number }) => (
+  ProgressBar: ({ value }: { value: number }) => (
     <div data-testid="progress-bar" data-value={value}>Progress</div>
   ),
 }));

--- a/frontend-web/src/app/(dashboard)/dashboard/kyc/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/kyc/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Progress } from '@/components/ui/progress';
+import { ProgressBar } from '@/components/ui/progress';
 import {
   Shield, Upload, FileText, CheckCircle, XCircle, Clock, AlertTriangle,
   Check, X, Loader2, Calendar, Image as ImageIcon, Send
@@ -235,9 +235,9 @@ export default function DashboardKYCPagina() {
                       {estadoKYC.documentosValidos} de {estadoKYC.documentosRequeridos} válidos
                     </span>
                   </div>
-                  <Progress
-                    value={estadoKYC.documentosRequeridos > 0 
-                      ? (estadoKYC.documentosValidos / estadoKYC.documentosRequeridos) * 100 
+                  <ProgressBar
+                    value={estadoKYC.documentosRequeridos > 0
+                      ? (estadoKYC.documentosValidos / estadoKYC.documentosRequeridos) * 100
                       : 0}
                     className="h-2"
                   />

--- a/frontend-web/src/components/features/admin/session-manager.tsx
+++ b/frontend-web/src/components/features/admin/session-manager.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
+import { Loader2, ShieldAlert, Trash2, Monitor, Globe } from 'lucide-react';
+import { SesionInfo, sesionesApi } from '@/lib/api/sesiones';
+import { toast } from 'sonner';
+
+interface SessionManagerProps {
+  usuarioId: string;
+  usuarioNombre: string;
+}
+
+export function SessionManager({ usuarioId, usuarioNombre }: SessionManagerProps) {
+  const [sesiones, setSesiones] = useState<SesionInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [invalidating, setInvalidating] = useState(false);
+  const [showInvalidateAllDialog, setShowInvalidateAllDialog] = useState(false);
+  const [selectedSesionId, setSelectedSesionId] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  const cargarSesiones = async () => {
+    setLoading(true);
+    try {
+      const response = await sesionesApi.listarPorUsuario(usuarioId);
+      setSesiones(response.data);
+    } catch {
+      toast.error('Error al cargar sesiones');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const invalidarTodasLasSesiones = async () => {
+    setInvalidating(true);
+    try {
+      await sesionesApi.invalidarTodas(usuarioId);
+      toast.success('Todas las sesiones han sido invalidadas');
+      setSesiones([]);
+      setShowInvalidateAllDialog(false);
+    } catch {
+      toast.error('Error al invalidar sesiones');
+    } finally {
+      setInvalidating(false);
+    }
+  };
+
+  const invalidarSesion = async (sesionId: string) => {
+    try {
+      await sesionesApi.invalidarSesion(sesionId);
+      toast.success('Sesión invalidada');
+      setSesiones(sesiones.filter(s => s.id !== sesionId));
+    } catch {
+      toast.error('Error al invalidar sesión');
+    }
+  };
+
+  const toggleExpanded = () => {
+    if (!expanded) {
+      cargarSesiones();
+    }
+    setExpanded(!expanded);
+  };
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleString('es-VE', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <div className="flex items-center gap-2">
+          <ShieldAlert className="h-5 w-5" />
+          <CardTitle>Sesiones de {usuarioNombre}</CardTitle>
+        </div>
+        <Button variant="outline" size="sm" onClick={toggleExpanded}>
+          {expanded ? 'Ocultar' : 'Ver sesiones'}
+        </Button>
+      </CardHeader>
+
+      {expanded && (
+        <CardContent className="space-y-4">
+          {loading ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-green-600" />
+            </div>
+          ) : sesiones.length === 0 ? (
+            <p className="text-center text-gray-500 py-4">
+              No hay sesiones activas para este usuario
+            </p>
+          ) : (
+            <>
+              <div className="flex justify-between items-center">
+                <p className="text-sm text-gray-500">
+                  {sesiones.length} sesión(es) activa(s)
+                </p>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => setShowInvalidateAllDialog(true)}
+                >
+                  <Trash2 className="h-4 w-4 mr-1" />
+                  Invalidar todas
+                </Button>
+              </div>
+
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Dispositivo</TableHead>
+                    <TableHead>Ubicación</TableHead>
+                    <TableHead>Último acceso</TableHead>
+                    <TableHead>Expira</TableHead>
+                    <TableHead>Estado</TableHead>
+                    <TableHead className="text-right">Acciones</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {sesiones.map((sesion) => (
+                    <TableRow key={sesion.id}>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <Monitor className="h-4 w-4 text-gray-400" />
+                          <span className="text-sm">
+                            {sesion.userAgent || 'Desconocido'}
+                          </span>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <Globe className="h-4 w-4 text-gray-400" />
+                          <span className="text-sm">
+                            {sesion.ipAddress || 'N/A'}
+                          </span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-sm">
+                        {formatDate(sesion.ultimoAcceso)}
+                      </TableCell>
+                      <TableCell className="text-sm">
+                        {formatDate(sesion.expiraAt)}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={sesion.activa ? 'default' : 'secondary'}>
+                          {sesion.activa ? 'Activa' : 'Inactiva'}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setSelectedSesionId(sesion.id)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </>
+          )}
+        </CardContent>
+      )}
+
+      <AlertDialog open={showInvalidateAllDialog} onOpenChange={setShowInvalidateAllDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Invalidar todas las sesiones?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Esta acción invalidará todas las sesiones activas de {usuarioNombre}. 
+              El usuario tendrá que iniciar sesión nuevamente en todos sus dispositivos.
+              Se enviará una notificación por email al usuario.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={invalidarTodasLasSesiones}
+              disabled={invalidating}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {invalidating && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              Invalidar todas
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={!!selectedSesionId} onOpenChange={() => setSelectedSesionId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Invalidar esta sesión?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Esta acción invalidará la sesión seleccionada. El usuario tendrá que 
+              iniciar sesión nuevamente en ese dispositivo.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => selectedSesionId && invalidarSesion(selectedSesionId)}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Invalidar
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}

--- a/frontend-web/src/components/features/auth/security-verification-modal.tsx
+++ b/frontend-web/src/components/features/auth/security-verification-modal.tsx
@@ -26,7 +26,7 @@ export function SecurityVerificationModal({
   const [password, setPassword] = useState('');
   const [codigo, setCodigo] = useState('');
 
-  const { step, isLoading, error, verifyPassword, sendCode, confirmCode, reset } = useVerification({
+  const { step, setStep, isLoading, error, setError, verifyPassword, sendCode, confirmCode, reset } = useVerification({
     onSuccess: (token) => {
       toast.success('Verificación exitosa');
       onVerified(token);

--- a/frontend-web/src/hooks/use-verification.ts
+++ b/frontend-web/src/hooks/use-verification.ts
@@ -11,8 +11,10 @@ interface UseVerificationOptions {
 
 interface UseVerificationReturn {
   step: VerificationStep;
+  setStep: (step: VerificationStep) => void;
   isLoading: boolean;
   error: string | null;
+  setError: (error: string | null) => void;
   token: string | null;
   verifyPassword: (password: string) => Promise<boolean>;
   sendCode: (tipo: 'EMAIL' | 'SMS', valor: string) => Promise<string>;
@@ -142,8 +144,10 @@ export function useVerification({ onSuccess, onError }: UseVerificationOptions):
 
   return {
     step,
+    setStep,
     isLoading,
     error,
+    setError,
     token,
     verifyPassword,
     sendCode,

--- a/frontend-web/src/lib/api/sesiones.ts
+++ b/frontend-web/src/lib/api/sesiones.ts
@@ -1,0 +1,28 @@
+import { apiClient } from './client';
+
+export interface SesionInfo {
+  id: string;
+  ipAddress: string | null;
+  userAgent: string | null;
+  ultimoAcceso: string;
+  fechaCreacion: string;
+  expiraAt: string;
+  activa: boolean;
+}
+
+export interface SesionInvalidationResponse {
+  usuarioId: string;
+  sesionesInvalidadas: number;
+  mensaje: string;
+}
+
+export const sesionesApi = {
+  listarPorUsuario: (usuarioId: string) =>
+    apiClient.get<SesionInfo[]>(`/api/v1/admin/sesiones/usuario/${usuarioId}`),
+
+  invalidarTodas: (usuarioId: string) =>
+    apiClient.post<SesionInvalidationResponse>(`/api/v1/admin/sesiones/usuario/${usuarioId}/invalidar-todas`),
+
+  invalidarSesion: (sesionId: string) =>
+    apiClient.post(`/api/v1/admin/sesiones/${sesionId}/invalidar`),
+};


### PR DESCRIPTION
## Resumen
Implementa la funcionalidad para invalidar todas las sesiones activas de un usuario por seguridad (Issue #109).

## Cambios

### Backend
- **AdminSesionController** - Nuevo controller con endpoints:
  - `GET /api/v1/admin/sesiones/usuario/{id}` - Lista sesiones activas de un usuario
  - `POST /api/v1/admin/sesiones/usuario/{id}/invalidar-todas` - Invalida todas las sesiones
  - `POST /api/v1/admin/sesiones/{sesionId}/invalidar` - Invalida una sesión específica
- **DTOs**: `SesionInfoResponse`, `SesionInvalidationResponse`
- **SecurityEvent**: Nuevos tipos `SESSIONS_INVALIDATED`, `SESSION_INVALIDATED`
- **SecurityAuditService**: Métodos `logSesionesInvalidadas()`, `logSesionIndividualInvalidadas()`
- **EmailService**: Método `enviarNotificacionSesionesInvalidadas()`
- **AdminSesionControllerTest**: 8 tests de integración

### Frontend
- **sesionesApi**: Client para llamadas al backend
- **SessionManager**: Componente reutilizable con tabla de sesiones y diálogos de confirmación
- **/admin/sesiones**: Nueva página de gestión de sesiones

### Fixes (problemas pre-existentes)
- KYC page: `Progress` → `ProgressBar`
- use-verification hook: Exportar `setStep` y `setError`

## Tests
- Backend: 174 tests passing (+8 nuevos)

## Checklist
- [x] Tests passing
- [x] Documentación actualizada
- [x] Código sigue convenciones del proyecto