### PR TITLE
test(#107): Tests para gestión de socios

### DIFF
--- a/backend/src/test/java/com/tufondo/socios/presentation/controller/SocioControllerTest.java
+++ b/backend/src/test/java/com/tufondo/socios/presentation/controller/SocioControllerTest.java
@@ -1,0 +1,84 @@
+package com.tufondo.socios.presentation.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("SocioController - Tests de Seguridad")
+class SocioControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private static final UUID SOCIO_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+    @Nested
+    @DisplayName("Seguridad - Endpoints requieren autenticación")
+    class SeguridadTests {
+
+        @Test
+        @DisplayName("GET /api/v1/socios sin auth devuelve 403")
+        void listar_sin_auth_devuelve_403() throws Exception {
+            mockMvc.perform(get("/api/v1/socios"))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("GET /api/v1/socios/{id} sin auth devuelve 403")
+        void obtener_sin_auth_devuelve_403() throws Exception {
+            mockMvc.perform(get("/api/v1/socios/{id}", SOCIO_ID))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("PATCH /api/v1/socios/{id}/activar sin auth devuelve 403")
+        void activar_sin_auth_devuelve_403() throws Exception {
+            mockMvc.perform(patch("/api/v1/socios/{id}/activar", SOCIO_ID))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("PATCH /api/v1/socios/{id}/desactivar sin auth devuelve 403")
+        void desactivar_sin_auth_devuelve_403() throws Exception {
+            mockMvc.perform(patch("/api/v1/socios/{id}/desactivar", SOCIO_ID))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("GET /api/v1/socios/buscar sin auth devuelve 403")
+        void buscar_sin_auth_devuelve_403() throws Exception {
+            mockMvc.perform(get("/api/v1/socios/buscar")
+                            .param("nombre", "Juan"))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("PUT /api/v1/socios/{id} sin auth devuelve 403")
+        void actualizar_sin_auth_devuelve_403() throws Exception {
+            mockMvc.perform(put("/api/v1/socios/{id}", SOCIO_ID)
+                            .contentType("application/json")
+                            .content("{}"))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("DELETE /api/v1/socios/{id} sin auth devuelve 403")
+        void eliminar_sin_auth_devuelve_403() throws Exception {
+            mockMvc.perform(delete("/api/v1/socios/{id}", SOCIO_ID))
+                    .andExpect(status().isForbidden());
+        }
+    }
+}

--- a/frontend-web/src/app/(admin)/admin/socios/admin-socios.test.tsx
+++ b/frontend-web/src/app/(admin)/admin/socios/admin-socios.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import AdminSociosPage from '@/app/(admin)/admin/socios/page';
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+const mockSociosData = {
+  content: [
+    {
+      id: '11111111-1111-1111-1111-111111111111',
+      numeroSocio: 'SOC-2024-001',
+      tipoDocumento: 'CEDULA',
+      numeroDocumento: 'V-30123456',
+      primerNombre: 'Juan',
+      segundoNombre: 'Carlos',
+      primerApellido: 'Pérez',
+      segundoApellido: 'García',
+      correoElectronico: 'juan.perez@test.com',
+      telefonoPrincipal: '04121234567',
+      empresa: 'Empresa ABC',
+      estado: 'ACTIVO',
+      fechaRegistro: '2024-01-15T10:30:00Z',
+    },
+    {
+      id: '22222222-2222-2222-2222-222222222222',
+      numeroSocio: 'SOC-2024-002',
+      tipoDocumento: 'CEDULA',
+      numeroDocumento: 'V-30234567',
+      primerNombre: 'María',
+      segundoNombre: 'Isabel',
+      primerApellido: 'López',
+      segundoApellido: 'Mendoza',
+      correoElectronico: 'maria.lopez@test.com',
+      telefonoPrincipal: '04141234567',
+      empresa: 'Empresa XYZ',
+      estado: 'PENDIENTE',
+      fechaRegistro: '2024-02-20T14:00:00Z',
+    },
+  ],
+  totalElements: 2,
+  totalPages: 1,
+  size: 15,
+  number: 0,
+  first: true,
+  last: true,
+  empty: false,
+};
+
+describe('AdminSociosPage', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('debe renderizar el título de la página', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockSociosData,
+    });
+
+    render(<AdminSociosPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Gestión de Socios')).toBeTruthy();
+    });
+  });
+
+  it('debe mostrar la tabla de socios después de cargar', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockSociosData,
+    });
+
+    render(<AdminSociosPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Juan Carlos Pérez García')).toBeTruthy();
+    });
+  });
+
+  it('debe mostrar mensaje cuando no hay socios', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        content: [],
+        totalElements: 0,
+        totalPages: 0,
+      }),
+    });
+
+    render(<AdminSociosPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No hay socios registrados/i)).toBeTruthy();
+    });
+  });
+
+  it('debe manejar errores al cargar socios', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    render(<AdminSociosPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No hay socios registrados/i)).toBeTruthy();
+    });
+  });
+
+  it('debe tener input de búsqueda', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockSociosData,
+    });
+
+    render(<AdminSociosPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/Buscar por cédula/i)).toBeTruthy();
+    });
+  });
+
+  it('debe tener select de filtros de estado', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockSociosData,
+    });
+
+    render(<AdminSociosPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toBeTruthy();
+    });
+  });
+
+  it('debe tener headers de tabla correctos', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockSociosData,
+    });
+
+    render(<AdminSociosPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Nro. Socio')).toBeTruthy();
+      expect(screen.getByText('Nombre')).toBeTruthy();
+      expect(screen.getByText('Cédula')).toBeTruthy();
+      expect(screen.getByText('Email')).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Resumen
Tests para la funcionalidad de gestión de socios (Issue #107).

## Tests Backend
- **SocioControllerTest**: 7 tests de seguridad
  - Verifica que todos los endpoints requieren autenticación (403 sin auth)

## Tests Frontend
- **admin-socios.test.tsx**: 7 tests
  - Renderizado del título de la página
  - Carga correcta de la tabla de socios
  - Mensaje cuando no hay socios
  - Manejo de errores al cargar
  - Input de búsqueda funcional
  - Select de filtros de estado
  - Headers de tabla correctos

## Resultados
- Frontend: 237 tests passing
- Backend: 181 tests passing