### PR TITLE
fix: Remove redirect /login -> /auth/login

### DIFF
--- a/frontend-web/next.config.js
+++ b/frontend-web/next.config.js
@@ -56,11 +56,6 @@ const nextConfig = {
   async redirects() {
     return [
       {
-        source: '/login',
-        destination: '/auth/login',
-        permanent: false,
-      },
-      {
         source: '/dashboard',
         destination: '/app',
         permanent: false,


### PR DESCRIPTION
Fix: Remove unnecessary redirect since login page is at /login not /auth/login