### PR TITLE
fix(frontend): URLs dinámicas por entorno — QA apunta a QA, prod a prod

### DIFF
--- a/frontend-web/Dockerfile
+++ b/frontend-web/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:18-alpine AS builder
 WORKDIR /app
 
+# Estas variables se hornean en build time
+# Los valores por defecto son de producción
+# Para QA se pasan como --build-arg en el deploy
 ARG NEXT_PUBLIC_API_URL=https://api.fatrans.com.ve/api
 ARG NEXT_PUBLIC_APP_URL=https://app.fatrans.com.ve
 ARG NEXT_PUBLIC_ADMIN_URL=https://admin.fatrans.com.ve
@@ -27,6 +30,12 @@ COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public
 
+# Script de entrypoint que reemplaza las URLs horneadas en build
+# con las variables de entorno reales del contenedor en runtime
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 EXPOSE 3000
 
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/frontend-web/docker-entrypoint.sh
+++ b/frontend-web/docker-entrypoint.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# =============================================================
+# docker-entrypoint.sh
+# Reemplaza las URLs horneadas en el build de Next.js con las
+# variables de entorno reales del contenedor en runtime.
+# Esto permite usar la misma imagen para QA y Producción.
+# =============================================================
+
+set -e
+
+echo "[entrypoint] Configurando URLs del entorno..."
+
+# URLs horneadas en build (valores por defecto del Dockerfile)
+BUILD_API_URL="https://api.fatrans.com.ve/api"
+BUILD_APP_URL="https://app.fatrans.com.ve"
+BUILD_ADMIN_URL="https://admin.fatrans.com.ve"
+BUILD_AUTH_URL="https://auth.fatrans.com.ve"
+
+# URLs reales del entorno (variables de entorno del contenedor)
+RUNTIME_API_URL="${NEXT_PUBLIC_API_URL:-$BUILD_API_URL}"
+RUNTIME_APP_URL="${NEXT_PUBLIC_APP_URL:-$BUILD_APP_URL}"
+RUNTIME_ADMIN_URL="${NEXT_PUBLIC_ADMIN_URL:-$BUILD_ADMIN_URL}"
+RUNTIME_AUTH_URL="${NEXT_PUBLIC_AUTH_URL:-$BUILD_AUTH_URL}"
+
+echo "[entrypoint] API:   $RUNTIME_API_URL"
+echo "[entrypoint] APP:   $RUNTIME_APP_URL"
+echo "[entrypoint] ADMIN: $RUNTIME_ADMIN_URL"
+echo "[entrypoint] AUTH:  $RUNTIME_AUTH_URL"
+
+# Solo reemplazar si las URLs son distintas al build
+if [ "$RUNTIME_AUTH_URL" != "$BUILD_AUTH_URL" ] || \
+   [ "$RUNTIME_API_URL" != "$BUILD_API_URL" ] || \
+   [ "$RUNTIME_APP_URL" != "$BUILD_APP_URL" ] || \
+   [ "$RUNTIME_ADMIN_URL" != "$BUILD_ADMIN_URL" ]; then
+
+  echo "[entrypoint] URLs difieren del build — aplicando reemplazo en archivos compilados..."
+
+  # Reemplazar en todos los chunks de Next.js
+  find /app/.next/static/chunks -name "*.js" -type f | while read file; do
+    sed -i \
+      "s|$BUILD_API_URL|$RUNTIME_API_URL|g; \
+       s|$BUILD_APP_URL|$RUNTIME_APP_URL|g; \
+       s|$BUILD_ADMIN_URL|$RUNTIME_ADMIN_URL|g; \
+       s|$BUILD_AUTH_URL|$RUNTIME_AUTH_URL|g" \
+      "$file"
+  done
+
+  # Reemplazar también en el server bundle
+  find /app/.next/server -name "*.js" -type f | while read file; do
+    sed -i \
+      "s|$BUILD_API_URL|$RUNTIME_API_URL|g; \
+       s|$BUILD_APP_URL|$RUNTIME_APP_URL|g; \
+       s|$BUILD_ADMIN_URL|$RUNTIME_ADMIN_URL|g; \
+       s|$BUILD_AUTH_URL|$RUNTIME_AUTH_URL|g" \
+      "$file"
+  done
+
+  echo "[entrypoint] Reemplazo completado ✓"
+else
+  echo "[entrypoint] URLs iguales al build — sin cambios necesarios"
+fi
+
+# Ejecutar el comando original (node server.js)
+exec "$@"

--- a/frontend-web/src/app/api/admin/solicitudes/[id]/aprobar/route.ts
+++ b/frontend-web/src/app/api/admin/solicitudes/[id]/aprobar/route.ts
@@ -11,7 +11,7 @@ export async function POST(
   const allowedOrigins = [
     'http://localhost:3000',
     'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL, process.env.NEXT_PUBLIC_ADMIN_URL, 'https://auth.fatrans.com.ve', 'https://www.fatrans.com.ve', 'https://fatrans.com.ve',
+    process.env.NEXT_PUBLIC_APP_URL, process.env.NEXT_PUBLIC_ADMIN_URL, process.env.NEXT_PUBLIC_AUTH_URL, process.env.NEXT_PUBLIC_APP_URL, 
   ].filter(Boolean);
 
   if (origin && !allowedOrigins.includes(origin)) {

--- a/frontend-web/src/app/api/admin/solicitudes/[id]/rechazar/route.ts
+++ b/frontend-web/src/app/api/admin/solicitudes/[id]/rechazar/route.ts
@@ -11,7 +11,7 @@ export async function POST(
   const allowedOrigins = [
     'http://localhost:3000',
     'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL, process.env.NEXT_PUBLIC_ADMIN_URL, 'https://auth.fatrans.com.ve', 'https://www.fatrans.com.ve', 'https://fatrans.com.ve',
+    process.env.NEXT_PUBLIC_APP_URL, process.env.NEXT_PUBLIC_ADMIN_URL, process.env.NEXT_PUBLIC_AUTH_URL, process.env.NEXT_PUBLIC_APP_URL, 
   ].filter(Boolean);
 
   if (origin && !allowedOrigins.includes(origin)) {

--- a/frontend-web/src/app/api/admin/solicitudes/route.ts
+++ b/frontend-web/src/app/api/admin/solicitudes/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: NextRequest) {
   const allowedOrigins = [
     'http://localhost:3000',
     'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL, process.env.NEXT_PUBLIC_ADMIN_URL, 'https://auth.fatrans.com.ve', 'https://www.fatrans.com.ve', 'https://fatrans.com.ve',
+    process.env.NEXT_PUBLIC_APP_URL, process.env.NEXT_PUBLIC_ADMIN_URL, process.env.NEXT_PUBLIC_AUTH_URL, process.env.NEXT_PUBLIC_APP_URL, 
   ].filter(Boolean);
 
   if (origin && !allowedOrigins.includes(origin)) {

--- a/frontend-web/src/app/api/auth/cambiar-password/route.ts
+++ b/frontend-web/src/app/api/auth/cambiar-password/route.ts
@@ -20,7 +20,7 @@ export async function POST(request: NextRequest) {
   const allowedOrigins = [
     'http://localhost:3000',
     'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL, process.env.NEXT_PUBLIC_ADMIN_URL, 'https://auth.fatrans.com.ve', 'https://www.fatrans.com.ve', 'https://fatrans.com.ve',
+    process.env.NEXT_PUBLIC_APP_URL, process.env.NEXT_PUBLIC_ADMIN_URL, process.env.NEXT_PUBLIC_AUTH_URL, process.env.NEXT_PUBLIC_APP_URL, 
   ].filter(Boolean);
 
   if (origin && !allowedOrigins.includes(origin)) {

--- a/frontend-web/src/app/api/auth/login/route.ts
+++ b/frontend-web/src/app/api/auth/login/route.ts
@@ -10,9 +10,9 @@ export async function POST(request: NextRequest) {
     'http://localhost:13000',
     process.env.NEXT_PUBLIC_APP_URL,
     process.env.NEXT_PUBLIC_ADMIN_URL,
-    'https://auth.fatrans.com.ve',
-    'https://www.fatrans.com.ve',
-    'https://fatrans.com.ve',
+    process.env.NEXT_PUBLIC_AUTH_URL,
+    process.env.NEXT_PUBLIC_APP_URL,
+    
   ].filter(Boolean);
 
   if (origin && !allowedOrigins.includes(origin)) {

--- a/frontend-web/src/app/api/auth/registro/route.ts
+++ b/frontend-web/src/app/api/auth/registro/route.ts
@@ -9,7 +9,7 @@ export async function POST(request: NextRequest) {
   const allowedOrigins = [
     'http://localhost:3000',
     'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL, process.env.NEXT_PUBLIC_ADMIN_URL, 'https://auth.fatrans.com.ve', 'https://www.fatrans.com.ve', 'https://fatrans.com.ve',
+    process.env.NEXT_PUBLIC_APP_URL, process.env.NEXT_PUBLIC_ADMIN_URL, process.env.NEXT_PUBLIC_AUTH_URL, process.env.NEXT_PUBLIC_APP_URL, 
   ].filter(Boolean);
 
   const allowedReferers = [

--- a/frontend-web/src/components/features/auth/login-form-neobank.tsx
+++ b/frontend-web/src/components/features/auth/login-form-neobank.tsx
@@ -94,8 +94,8 @@ export function LoginFormNeobank() {
         setLoading(false);
 
         const rol = userData.rol;
-        const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://app.fatrans.com.ve';
-        const adminUrl = process.env.NEXT_PUBLIC_ADMIN_URL || 'https://admin.fatrans.com.ve';
+        const appUrl = process.env.NEXT_PUBLIC_APP_URL || '';
+        const adminUrl = process.env.NEXT_PUBLIC_ADMIN_URL || '';
 
         if (rol === 'SOCIO') {
           window.location.href = `${appUrl}/dashboard`;

--- a/frontend-web/src/components/features/auth/login-form-split.tsx
+++ b/frontend-web/src/components/features/auth/login-form-split.tsx
@@ -76,8 +76,8 @@ export function LoginFormSplit() {
         setLoading(false);
 
         const rol = userData.rol;
-        const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://app.fatrans.com.ve';
-        const adminUrl = process.env.NEXT_PUBLIC_ADMIN_URL || 'https://admin.fatrans.com.ve';
+        const appUrl = process.env.NEXT_PUBLIC_APP_URL || '';
+        const adminUrl = process.env.NEXT_PUBLIC_ADMIN_URL || '';
 
         if (rol === 'SOCIO') {
           window.location.href = `${appUrl}/dashboard`;

--- a/frontend-web/src/components/features/auth/login-form.tsx
+++ b/frontend-web/src/components/features/auth/login-form.tsx
@@ -98,8 +98,8 @@ export function LoginForm() {
         setLoading(false);
 
         const rol = userData.rol;
-        const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://app.fatrans.com.ve';
-        const adminUrl = process.env.NEXT_PUBLIC_ADMIN_URL || 'https://admin.fatrans.com.ve';
+        const appUrl = process.env.NEXT_PUBLIC_APP_URL || '';
+        const adminUrl = process.env.NEXT_PUBLIC_ADMIN_URL || '';
 
         if (rol === 'SOCIO') {
           window.location.href = `${appUrl}/dashboard`;


### PR DESCRIPTION
## Problema

La landing de QA redirigía al login de producción (`auth.fatrans.com.ve`) porque los login forms tenían las URLs hardcodeadas en el código fuente.

## Cambios

**Login forms** (`login-form.tsx`, `login-form-neobank.tsx`, `login-form-split.tsx`):
- Eliminado fallback `|| .https://app.fatrans.com.ve.` → ahora usa `|| ..`
- Next.js ahora hornea el valor real de `NEXT_PUBLIC_APP_URL` del build

**API routes** (`login`, `registro`, `cambiar-password`, `solicitudes`):
- `allowedOrigins` usa `process.env` en lugar de strings hardcodeados

**Dockerfile + docker-entrypoint.sh**:
- Script que reemplaza URLs en runtime como capa adicional de seguridad

## Resultado
- QA → redirige a `qa-app.fatrans.com.ve`
- Prod → redirige a `app.fatrans.com.ve`