### PR TITLE
fix(frontend): force-dynamic + no-cache QA — fix Cloudflare cache

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -13,6 +13,7 @@ jobs:
   deploy-qa:
     name: Deploy a QA (qa.fatrans.com.ve)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     permissions:
       pull-requests: write
@@ -29,15 +30,19 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
           port: 22
-          timeout: 15m
+          timeout: 25m
+          command_timeout: 25m
           script: |
             bash /opt/fatrans-qa/deploy-qa.sh ${{ github.sha }}
 
       - name: Verificar QA levantado
         run: |
           sleep 15
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://qa.fatrans.com.ve || echo "000")
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://qa-auth.fatrans.com.ve || echo "000")
           echo "QA HTTP status: $STATUS"
+          if [ "$STATUS" != "200" ] && [ "$STATUS" != "301" ] && [ "$STATUS" != "302" ]; then
+            echo "⚠️ QA no responde con 200 (status: $STATUS)"
+          fi
 
       - name: Notificar resultado
         if: always()
@@ -48,8 +53,8 @@ jobs:
             const sha = context.sha.substring(0, 7);
             const icon = status === 'success' ? '✅' : '❌';
             const msg = status === 'success'
-              ? icon + ' **Deploy QA exitoso** — ' + sha + '\n\n🌐 https://qa.fatrans.com.ve\n🌐 https://qa-app.fatrans.com.ve\n🌐 https://qa-admin.fatrans.com.ve'
-              : icon + ' **Deploy QA FALLÓ** — ' + sha + ' — revisar logs en GitHub Actions';
+              ? `${icon} **Deploy QA exitoso** — \`${sha}\`\n\n🌐 https://qa-auth.fatrans.com.ve\n🌐 https://qa-app.fatrans.com.ve\n🌐 https://qa-admin.fatrans.com.ve`
+              : `${icon} **Deploy QA FALLÓ** — \`${sha}\` — revisar logs en GitHub Actions`;
             const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/frontend-web/src/app/(auth)/login/page.tsx
+++ b/frontend-web/src/app/(auth)/login/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import type { Metadata } from "next";
 import { LoginFormNeobank } from '@/components/features/auth/login-form-neobank';
 

--- a/frontend-web/src/app/(auth)/registro/page.tsx
+++ b/frontend-web/src/app/(auth)/registro/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import { RegistrationForm } from '@/components/features/auth/registration-form';
 
 export default function RegistroPage() {

--- a/frontend-web/src/app/(public)/page.tsx
+++ b/frontend-web/src/app/(public)/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## Problema raiz

Next.js pre-renderizaba la landing y el login como paginas estaticas con `s-maxage=31536000`. Cloudflare las cacheaba por 1 año y servia el HTML viejo con `auth.fatrans.com.ve` aunque el contenedor QA tuviera `qa-auth.fatrans.com.ve`.

## Solucion

- `export const dynamic = force-dynamic` en `page.tsx`, `login/page.tsx` y `registro/page.tsx`
- Nginx QA: `Cache-Control: no-store` en todos los bloques qa-*

## Resultado

QA landing → links a `qa-auth.fatrans.com.ve` en cada request sin cache