### PR TITLE
fix(bff/registro): permitir referer/origin del subdominio auth en prod y QA

### DIFF
--- a/frontend-web/src/app/api/auth/registro/route.test.ts
+++ b/frontend-web/src/app/api/auth/registro/route.test.ts
@@ -71,10 +71,16 @@ describe('POST /api/auth/registro (BFF)', () => {
     fetchSpy = vi.spyOn(global, 'fetch');
     // Silenciar console.error en tests (los assertions sobre console no son el foco aquí).
     vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Simular las URLs públicas que define el deploy (prod + QA). Permite ejercitar
+    // la validación cross-subdomain de origin/referer sin acoplarse al .env real.
+    vi.stubEnv('NEXT_PUBLIC_AUTH_URL', 'https://qa-auth.fatrans.com.ve');
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://qa-app.fatrans.com.ve');
+    vi.stubEnv('NEXT_PUBLIC_ADMIN_URL', 'https://qa-admin.fatrans.com.ve');
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('reenvía TODOS los campos del schema al backend con un payload válido', async () => {
@@ -268,6 +274,57 @@ describe('POST /api/auth/registro (BFF)', () => {
     expect(res.status).toBe(403);
     const json = await res.json();
     expect(json.message).toBe('Referer no permitido');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('permite origin/referer del subdominio auth de QA (qa-auth.fatrans.com.ve)', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ id: 'qa-1' }), { status: 201 }) as any
+    );
+    const req = buildRequest({
+      body: buildValidPayload(),
+      origin: 'https://qa-auth.fatrans.com.ve',
+      referer: 'https://qa-auth.fatrans.com.ve/registro',
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(201);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('permite origin/referer del subdominio auth de producción (auth.fatrans.com.ve)', async () => {
+    vi.stubEnv('NEXT_PUBLIC_AUTH_URL', 'https://auth.fatrans.com.ve');
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://app.fatrans.com.ve');
+    vi.stubEnv('NEXT_PUBLIC_ADMIN_URL', 'https://admin.fatrans.com.ve');
+
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ id: 'prod-1' }), { status: 201 }) as any
+    );
+    const req = buildRequest({
+      body: buildValidPayload(),
+      origin: 'https://auth.fatrans.com.ve',
+      referer: 'https://auth.fatrans.com.ve/registro',
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(201);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rechaza un referer cuyo host coincide en prefijo pero NO en dominio (anti-spoof)', async () => {
+    // "https://qa-auth.fatrans.com.ve.evil.com/..." NO debe colar — String#startsWith con
+    // origin completo evita el match parcial porque el host real es "qa-auth.fatrans.com.ve.evil.com".
+    const req = buildRequest({
+      body: buildValidPayload(),
+      origin: null,
+      referer: 'https://qa-auth.fatrans.com.ve.evil.com/registro',
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(403);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 

--- a/frontend-web/src/app/api/auth/registro/route.ts
+++ b/frontend-web/src/app/api/auth/registro/route.ts
@@ -59,16 +59,24 @@ export async function POST(request: NextRequest) {
     process.env.NEXT_PUBLIC_AUTH_URL,
   ].filter(Boolean);
 
-  const allowedReferers = [
-    'http://localhost:3000',
-    'http://localhost:13000',
-  ];
+  // El referer llega como "https://qa-auth.fatrans.com.ve/registro". Parseamos su origin
+  // y lo comparamos con la misma whitelist de allowedOrigins (evita drift entre listas).
+  // OJO con startsWith: "https://auth.fatrans.com.ve.evil.com" también empezaría con
+  // "https://auth.fatrans.com.ve" — por eso usamos URL.origin que extrae esquema+host+puerto.
+  function refererOriginAllowed(headerValue: string): boolean {
+    try {
+      const refOrigin = new URL(headerValue).origin;
+      return allowedOrigins.includes(refOrigin);
+    } catch {
+      return false;
+    }
+  }
 
   if (origin && !allowedOrigins.includes(origin)) {
     return NextResponse.json({ message: 'Origen no permitido' }, { status: 403 });
   }
 
-  if (referer && !allowedReferers.some((r) => referer.startsWith(r))) {
+  if (referer && !refererOriginAllowed(referer)) {
     return NextResponse.json({ message: 'Referer no permitido' }, { status: 403 });
   }
 


### PR DESCRIPTION
## Bug

El BFF `/api/auth/registro` rechazaba con HTTP 403 **"Referer no permitido"** cualquier petición desde `auth.fatrans.com.ve` o `qa-auth.fatrans.com.ve` porque la lista `allowedReferers` solo incluía `localhost` — los dominios publicados nunca fueron whitelistados.

**Síntoma reportado en QA:** al completar el form (5to paso) y dar "Enviar solicitud", el toast mostraba *"Referer no permitido"* y la solicitud nunca llegaba al backend. Confirmado en logs del backend QA: ningún `POST /api/v1/socios/solicitud`.

## Causa raíz

`route.ts` tenía dos listas independientes:

- `allowedOrigins`: derivaba de `NEXT_PUBLIC_*_URL` → incluía los dominios publicados.
- `allowedReferers`: **hard-coded a localhost** — drift histórico, nunca se actualizó al montar el deploy multi-subdominio.

El chequeo era con `String#startsWith(prefix)`, vulnerable a spoof tipo `https://auth.fatrans.com.ve.evil.com` que "empieza con" el dominio permitido pero apunta a otro host.

## Cambios

`src/app/api/auth/registro/route.ts`:

- `allowedReferers` ahora deriva de `allowedOrigins` (fuente única) → imposible drift.
- Validación pasa por `new URL(referer).origin` y comparación exacta contra `allowedOrigins`. `URL.origin` extrae `esquema+host+puerto` canónicos y no permite spoof de prefijo.
- `try/catch` alrededor del parseo: referer malformado → 403, no 500.

## Tests

`route.test.ts` (16 tests, antes 13):

- `vi.stubEnv` / `vi.unstubAllEnvs` en `beforeEach`/`afterEach` para simular `NEXT_PUBLIC_*_URL` sin acoplar al `.env` real.
- 3 casos nuevos:
  - permite origin+referer de `qa-auth.fatrans.com.ve`
  - permite origin+referer de `auth.fatrans.com.ve` (prod)
  - rechaza spoof `qa-auth.fatrans.com.ve.evil.com` (anti-prefix-match)

`npx vitest run src/app/api/auth/registro` → **16/16 ✓**.

## Verificación post-merge

- En QA: completar el form de registro hasta el paso 5 y enviar → debe llegar al backend (`POST /api/v1/socios/solicitud` en logs).
- La solicitud queda en estado `PENDIENTE` y visible en `qa-admin.fatrans.com.ve/admin/solicitudes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)