### PR TITLE
fix(kyc,admin): desbloquear aprobación KYC + arreglar dashboard y detalle de solicitudes

### DIFF
--- a/backend/src/main/java/com/tufondo/admin/application/dto/DashboardEstadisticasResponse.java
+++ b/backend/src/main/java/com/tufondo/admin/application/dto/DashboardEstadisticasResponse.java
@@ -32,6 +32,14 @@ public class DashboardEstadisticasResponse {
     private BigDecimal capitalDesembolsado;
     private BigDecimal carteraVencida;
 
+    /**
+     * Solicitudes de registro de socios pendientes de aprobar por un admin.
+     * Antes el card "Solicitudes Pendientes" del dashboard mostraba el conteo
+     * de solicitudes de crédito (`solicitudesPendientes`), no el de registro —
+     * por eso aparecía 0 aunque hubiera nuevas solicitudes esperando.
+     */
+    private long solicitudesRegistroPendientes;
+
     private long cuotasVencidas;
     private long cuotasEnMora;
     private long cuotasPagadas;

--- a/backend/src/main/java/com/tufondo/admin/application/usecase/ObtenerDashboardEstadisticasUseCase.java
+++ b/backend/src/main/java/com/tufondo/admin/application/usecase/ObtenerDashboardEstadisticasUseCase.java
@@ -12,6 +12,7 @@ import com.tufondo.creditos.domain.repository.AmortizacionRepository;
 import com.tufondo.creditos.domain.repository.SolicitudCreditoRepository;
 import com.tufondo.socios.domain.model.enums.EstadoSocio;
 import com.tufondo.socios.domain.repository.SocioRepository;
+import com.tufondo.socios.domain.repository.SolicitudRegistroRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,7 @@ public class ObtenerDashboardEstadisticasUseCase {
     private final MovimientoRepository movimientoRepository;
     private final SolicitudCreditoRepository solicitudCreditoRepository;
     private final AmortizacionRepository amortizacionRepository;
+    private final SolicitudRegistroRepository solicitudRegistroRepository;
 
     public DashboardEstadisticasResponse ejecutar() {
         log.info("Obteniendo estadísticas del dashboard admin");
@@ -61,6 +63,11 @@ public class ObtenerDashboardEstadisticasUseCase {
         long solicitudesPendientes = solicitudCreditoRepository.countByEstado(EstadoSolicitud.PENDIENTE);
         long solicitudesAprobadas = solicitudCreditoRepository.countByEstado(EstadoSolicitud.APROBADA);
         long solicitudesRechazadas = solicitudCreditoRepository.countByEstado(EstadoSolicitud.RECHAZADA);
+
+        // Solicitudes de registro de socios (NO de crédito) — el card del dashboard
+        // que dice "Solicitudes Pendientes" se refiere a éstas.
+        long solicitudesRegistroPendientes = solicitudRegistroRepository.contarPorEstado(
+                com.tufondo.socios.domain.model.enums.EstadoSolicitud.PENDIENTE);
 
         BigDecimal capitalDesembolsado = solicitudCreditoRepository.sumMontoSolicitadoByEstado(EstadoSolicitud.DESEMBOLSADO);
         if (capitalDesembolsado == null) capitalDesembolsado = BigDecimal.ZERO;
@@ -103,6 +110,7 @@ public class ObtenerDashboardEstadisticasUseCase {
             .solicitudesPendientes(solicitudesPendientes)
             .solicitudesAprobadas(solicitudesAprobadas)
             .solicitudesRechazadas(solicitudesRechazadas)
+            .solicitudesRegistroPendientes(solicitudesRegistroPendientes)
             .capitalDesembolsado(capitalDesembolsado.setScale(2, RoundingMode.HALF_UP))
             .carteraVencida(interesesMora.setScale(2, RoundingMode.HALF_UP))
             .cuotasVencidas(cuotasVencidas)

--- a/backend/src/main/java/com/tufondo/socios/application/dto/SolicitudRegistroResponseDTO.java
+++ b/backend/src/main/java/com/tufondo/socios/application/dto/SolicitudRegistroResponseDTO.java
@@ -1,30 +1,76 @@
 // 📁 com/tufondo/socios/application/dto/SolicitudRegistroResponseDTO.java
 package com.tufondo.socios.application.dto;
 
+import com.tufondo.socios.domain.model.enums.EstadoCivil;
 import com.tufondo.socios.domain.model.enums.EstadoSolicitud;
+import com.tufondo.socios.domain.model.enums.Genero;
+import com.tufondo.socios.domain.model.enums.TipoDocumento;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 /**
  * DTO de respuesta para solicitud de registro.
+ *
+ * Antes solo exponía 12 campos básicos (nombre, cédula, contacto, empresa) y el
+ * admin no podía ver los datos completos al revisar una solicitud — quedaba a
+ * ciegas sobre dirección, datos laborales, contacto de emergencia, consentimientos
+ * legales, etc. Ahora incluye todos los datos relevantes para que el panel de admin
+ * muestre el detalle completo y pueda decidir aprobar o rechazar con contexto.
+ *
+ * No incluimos la metadata de auditoría LOPDP (ip, user-agent, consent timestamp).
+ * Eso solo se expone vía un endpoint específico de auditoría — el admin operativo
+ * no necesita verlo en el flujo normal.
  */
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class SolicitudRegistroResponseDTO {
-    
+
     private UUID id;
+
+    // --- Datos personales ---
     private String nombreCompleto;
+    private TipoDocumento tipoDocumento;
     private String cedula;
+    private LocalDate fechaNacimiento;
+    private Genero genero;
+    private EstadoCivil estadoCivil;
+
+    // --- Contacto ---
     private String correoElectronico;
     private String telefono;
+
+    // --- Información laboral ---
     private String empresa;
+    private String rifEmpresa;
+    private String departamento;
+    private String cargo;
+    private BigDecimal salario;
+
+    // --- Dirección de residencia ---
+    private String direccionEstado;
+    private String direccionCiudad;
+    private String direccionMunicipio;
+    private String direccionCalle;
+
+    // --- Contacto de emergencia ---
+    private String emergenciaNombre;
+    private String emergenciaTelefono;
+    private String emergenciaParentesco;
+
+    // --- Consentimientos legales ---
+    private Boolean aceptaTerminos;
+    private Boolean aceptaLopdp;
+
+    // --- Estado y trazabilidad de revisión ---
     private EstadoSolicitud estado;
     private LocalDateTime fechaSolicitud;
     private LocalDateTime fechaRevision;

--- a/backend/src/main/java/com/tufondo/socios/application/usecase/SolicitudRegistroDTOMapper.java
+++ b/backend/src/main/java/com/tufondo/socios/application/usecase/SolicitudRegistroDTOMapper.java
@@ -5,17 +5,53 @@ import com.tufondo.socios.application.dto.SolicitudRegistroResponseDTO;
 import com.tufondo.socios.domain.model.SolicitudRegistro;
 import org.springframework.stereotype.Component;
 
+/**
+ * Mapper de SolicitudRegistro (domain) a DTO de respuesta.
+ *
+ * Mapea TODOS los datos relevantes que un admin necesita ver para decidir si
+ * aprueba o rechaza una solicitud. Antes solo se mapeaban 12 campos básicos
+ * y el admin quedaba a ciegas sobre datos laborales, dirección, contacto de
+ * emergencia y consentimientos legales — bug reportado al revisar la cola
+ * en `/admin/solicitudes`.
+ *
+ * NO mapea metadata LOPDP (ip, user-agent, consent timestamp). Ese acceso
+ * queda restringido a auditoría legal específica, no al flujo operativo.
+ */
 @Component
 public class SolicitudRegistroDTOMapper {
-    
+
     public SolicitudRegistroResponseDTO toResponseDTO(SolicitudRegistro solicitud) {
         return SolicitudRegistroResponseDTO.builder()
                 .id(solicitud.getId())
+                // Datos personales
                 .nombreCompleto(solicitud.getNombreCompleto())
+                .tipoDocumento(solicitud.getTipoDocumento())
                 .cedula(solicitud.getCedula())
+                .fechaNacimiento(solicitud.getFechaNacimiento())
+                .genero(solicitud.getGenero())
+                .estadoCivil(solicitud.getEstadoCivil())
+                // Contacto
                 .correoElectronico(solicitud.getCorreoElectronico())
                 .telefono(solicitud.getTelefono())
+                // Laboral
                 .empresa(solicitud.getEmpresa())
+                .rifEmpresa(solicitud.getRifEmpresa())
+                .departamento(solicitud.getDepartamento())
+                .cargo(solicitud.getCargo())
+                .salario(solicitud.getSalario())
+                // Dirección
+                .direccionEstado(solicitud.getDireccionEstado())
+                .direccionCiudad(solicitud.getDireccionCiudad())
+                .direccionMunicipio(solicitud.getDireccionMunicipio())
+                .direccionCalle(solicitud.getDireccionCalle())
+                // Emergencia
+                .emergenciaNombre(solicitud.getEmergenciaNombre())
+                .emergenciaTelefono(solicitud.getEmergenciaTelefono())
+                .emergenciaParentesco(solicitud.getEmergenciaParentesco())
+                // Consentimientos
+                .aceptaTerminos(solicitud.getAceptaTerminos())
+                .aceptaLopdp(solicitud.getAceptaLopdp())
+                // Trazabilidad
                 .estado(solicitud.getEstado())
                 .fechaSolicitud(solicitud.getFechaSolicitud())
                 .fechaRevision(solicitud.getFechaRevision())

--- a/backend/src/main/java/com/tufondo/socios/domain/repository/SolicitudRegistroRepository.java
+++ b/backend/src/main/java/com/tufondo/socios/domain/repository/SolicitudRegistroRepository.java
@@ -34,6 +34,12 @@ public interface SolicitudRegistroRepository {
      * Lista todas las solicitudes con paginación.
      */
     Page<SolicitudRegistro> listar(Pageable pageable);
+
+    /**
+     * Cuenta solicitudes en un estado específico.
+     * Lo usa el dashboard de admin para mostrar cuántas solicitudes hay pendientes.
+     */
+    long contarPorEstado(EstadoSolicitud estado);
     
     /**
      * Verifica si existe una solicitud con la cédula proporcionada.

--- a/backend/src/main/java/com/tufondo/socios/infrastructure/persistence/adapter/SolicitudRegistroRepositoryImpl.java
+++ b/backend/src/main/java/com/tufondo/socios/infrastructure/persistence/adapter/SolicitudRegistroRepositoryImpl.java
@@ -68,6 +68,12 @@ public class SolicitudRegistroRepositoryImpl implements SolicitudRegistroReposit
         jpaRepository.deleteById(id);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public long contarPorEstado(EstadoSolicitud estado) {
+        return jpaRepository.countByEstado(estado);
+    }
+
     private SolicitudRegistroEntity toEntity(SolicitudRegistro domain) {
         return SolicitudRegistroEntity.builder()
                 .id(domain.getId())

--- a/backend/src/main/java/com/tufondo/socios/infrastructure/persistence/jpa/SolicitudRegistroJpaRepository.java
+++ b/backend/src/main/java/com/tufondo/socios/infrastructure/persistence/jpa/SolicitudRegistroJpaRepository.java
@@ -21,4 +21,6 @@ public interface SolicitudRegistroJpaRepository extends JpaRepository<SolicitudR
     
     @Query("SELECT s FROM SolicitudRegistroEntity s WHERE s.estado = :estado")
     Page<SolicitudRegistroEntity> findByEstado(@Param("estado") EstadoSolicitud estado, Pageable pageable);
+
+    long countByEstado(EstadoSolicitud estado);
 }

--- a/backend/src/main/resources/db/migration/V12__cleanup_verificacion_kyc_orphan_columns.sql
+++ b/backend/src/main/resources/db/migration/V12__cleanup_verificacion_kyc_orphan_columns.sql
@@ -1,0 +1,61 @@
+-- V12__cleanup_verificacion_kyc_orphan_columns.sql
+--
+-- Causa raíz: el entity `VerificacionKYCEntity` originalmente mapeaba el campo
+-- como `@Column(name="nivel_verificacion")` (la migración V2 creó la columna así).
+-- En algún refactor previo se renombró el @Column a `nivel`, pero NO se versionó
+-- la migración correspondiente. Hibernate con `ddl-auto: update` agregó la nueva
+-- columna `nivel NOT NULL` y dejó `nivel_verificacion NOT NULL` huérfana.
+--
+-- Resultado: cada INSERT (e.g. al aprobar una solicitud de registro y disparar
+-- el auto-KYC) fallaba con
+--
+--   ERROR: null value in column "nivel_verificacion" of relation
+--   "verificacion_kyc" violates not-null constraint
+--
+-- porque Hibernate llenaba `nivel` pero la columna huérfana `nivel_verificacion`
+-- quedaba null y violaba la constraint.
+--
+-- Fix: dropear las columnas huérfanas que Hibernate ya reemplazó con nombres
+-- nuevos (idempotente: IF EXISTS por si la tabla aún no tiene la columna en
+-- algún entorno futuro).
+--
+-- Columnas huérfanas conocidas (V2 → entity actual):
+--   nivel_verificacion  → reemplazada por `nivel`
+--   fecha_finalizacion  → reemplazada por `fecha_completado`
+--   score_confianza     → eliminada del modelo (no aparece en la entity actual)
+--
+-- Si en algún entorno legacy hay datos en `nivel_verificacion`, los volcamos a
+-- `nivel` antes de dropear para no perder información.
+
+DO $$
+BEGIN
+    -- 1. Sincronizar datos antes de dropear (si la columna vieja todavía existe)
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'verificacion_kyc' AND column_name = 'nivel_verificacion'
+    ) AND EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'verificacion_kyc' AND column_name = 'nivel'
+    ) THEN
+        UPDATE verificacion_kyc
+        SET nivel = nivel_verificacion
+        WHERE nivel IS NULL AND nivel_verificacion IS NOT NULL;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'verificacion_kyc' AND column_name = 'fecha_finalizacion'
+    ) AND EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'verificacion_kyc' AND column_name = 'fecha_completado'
+    ) THEN
+        UPDATE verificacion_kyc
+        SET fecha_completado = fecha_finalizacion
+        WHERE fecha_completado IS NULL AND fecha_finalizacion IS NOT NULL;
+    END IF;
+END $$;
+
+-- 2. Drop columnas huérfanas (idempotente).
+ALTER TABLE verificacion_kyc DROP COLUMN IF EXISTS nivel_verificacion;
+ALTER TABLE verificacion_kyc DROP COLUMN IF EXISTS fecha_finalizacion;
+ALTER TABLE verificacion_kyc DROP COLUMN IF EXISTS score_confianza;

--- a/backend/src/test/java/com/tufondo/socios/application/usecase/SolicitudRegistroDTOMapperTest.java
+++ b/backend/src/test/java/com/tufondo/socios/application/usecase/SolicitudRegistroDTOMapperTest.java
@@ -1,0 +1,148 @@
+package com.tufondo.socios.application.usecase;
+
+import com.tufondo.socios.application.dto.SolicitudRegistroResponseDTO;
+import com.tufondo.socios.domain.model.SolicitudRegistro;
+import com.tufondo.socios.domain.model.enums.EstadoCivil;
+import com.tufondo.socios.domain.model.enums.EstadoSolicitud;
+import com.tufondo.socios.domain.model.enums.Genero;
+import com.tufondo.socios.domain.model.enums.TipoDocumento;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Cubre el bug del panel de admin: el DTO de respuesta antes solo exponía
+ * 12 campos básicos y dejaba al admin a ciegas sobre los datos completos
+ * (dirección, datos laborales, contacto de emergencia, consentimientos).
+ * Este test verifica que TODOS los campos relevantes se propagan al DTO.
+ */
+@DisplayName("SolicitudRegistroDTOMapper - mapeo completo")
+class SolicitudRegistroDTOMapperTest {
+
+    private final SolicitudRegistroDTOMapper mapper = new SolicitudRegistroDTOMapper();
+
+    @Test
+    @DisplayName("Mapea todos los campos del dominio al DTO de respuesta")
+    void mapeoCompleto() {
+        UUID id = UUID.randomUUID();
+        LocalDate nacimiento = LocalDate.of(1990, 5, 15);
+        LocalDateTime fechaSolicitud = LocalDateTime.of(2026, 5, 15, 10, 0);
+        LocalDateTime fechaRevision = LocalDateTime.of(2026, 5, 16, 9, 30);
+
+        SolicitudRegistro solicitud = SolicitudRegistro.builder()
+                .id(id)
+                .nombreCompleto("María José González López")
+                .tipoDocumento(TipoDocumento.CEDULA)
+                .cedula("V-12345678")
+                .fechaNacimiento(nacimiento)
+                .genero(Genero.FEMENINO)
+                .estadoCivil(EstadoCivil.CASADO)
+                .correoElectronico("maria@ejemplo.com")
+                .telefono("04121234567")
+                .empresa("Acme Corp")
+                .rifEmpresa("J-12345678-9")
+                .departamento("Sistemas")
+                .cargo("Analista")
+                .salario(new BigDecimal("1500.00"))
+                .direccionEstado("Distrito Capital")
+                .direccionCiudad("Caracas")
+                .direccionMunicipio("Libertador")
+                .direccionCalle("Av. Principal #123")
+                .emergenciaNombre("Juan González")
+                .emergenciaTelefono("04141234567")
+                .emergenciaParentesco("Cónyuge")
+                .aceptaTerminos(true)
+                .aceptaLopdp(true)
+                .estado(EstadoSolicitud.APROBADA)
+                .fechaSolicitud(fechaSolicitud)
+                .fechaRevision(fechaRevision)
+                .revisadoPor("admin-uuid")
+                .comentario("Todo correcto")
+                .motivoRechazo(null)
+                .build();
+
+        SolicitudRegistroResponseDTO dto = mapper.toResponseDTO(solicitud);
+
+        // Identificación
+        assertThat(dto.getId()).isEqualTo(id);
+        // Datos personales (los nuevos en el DTO — antes no se exponían)
+        assertThat(dto.getNombreCompleto()).isEqualTo("María José González López");
+        assertThat(dto.getTipoDocumento()).isEqualTo(TipoDocumento.CEDULA);
+        assertThat(dto.getCedula()).isEqualTo("V-12345678");
+        assertThat(dto.getFechaNacimiento()).isEqualTo(nacimiento);
+        assertThat(dto.getGenero()).isEqualTo(Genero.FEMENINO);
+        assertThat(dto.getEstadoCivil()).isEqualTo(EstadoCivil.CASADO);
+        // Contacto
+        assertThat(dto.getCorreoElectronico()).isEqualTo("maria@ejemplo.com");
+        assertThat(dto.getTelefono()).isEqualTo("04121234567");
+        // Laboral
+        assertThat(dto.getEmpresa()).isEqualTo("Acme Corp");
+        assertThat(dto.getRifEmpresa()).isEqualTo("J-12345678-9");
+        assertThat(dto.getDepartamento()).isEqualTo("Sistemas");
+        assertThat(dto.getCargo()).isEqualTo("Analista");
+        assertThat(dto.getSalario()).isEqualByComparingTo("1500.00");
+        // Dirección
+        assertThat(dto.getDireccionEstado()).isEqualTo("Distrito Capital");
+        assertThat(dto.getDireccionCiudad()).isEqualTo("Caracas");
+        assertThat(dto.getDireccionMunicipio()).isEqualTo("Libertador");
+        assertThat(dto.getDireccionCalle()).isEqualTo("Av. Principal #123");
+        // Emergencia
+        assertThat(dto.getEmergenciaNombre()).isEqualTo("Juan González");
+        assertThat(dto.getEmergenciaTelefono()).isEqualTo("04141234567");
+        assertThat(dto.getEmergenciaParentesco()).isEqualTo("Cónyuge");
+        // Consentimientos
+        assertThat(dto.getAceptaTerminos()).isTrue();
+        assertThat(dto.getAceptaLopdp()).isTrue();
+        // Trazabilidad
+        assertThat(dto.getEstado()).isEqualTo(EstadoSolicitud.APROBADA);
+        assertThat(dto.getFechaSolicitud()).isEqualTo(fechaSolicitud);
+        assertThat(dto.getFechaRevision()).isEqualTo(fechaRevision);
+        assertThat(dto.getRevisadoPor()).isEqualTo("admin-uuid");
+        assertThat(dto.getComentario()).isEqualTo("Todo correcto");
+        assertThat(dto.getMotivoRechazo()).isNull();
+    }
+
+    @Test
+    @DisplayName("Campos opcionales del dominio se mapean como null (no excepción)")
+    void mapeoCamposOpcionalesNulos() {
+        SolicitudRegistro solicitud = SolicitudRegistro.builder()
+                .id(UUID.randomUUID())
+                .nombreCompleto("Juan Pérez")
+                .tipoDocumento(TipoDocumento.CEDULA)
+                .cedula("V-87654321")
+                .fechaNacimiento(LocalDate.of(2000, 1, 1))
+                .genero(Genero.MASCULINO)
+                .estadoCivil(EstadoCivil.SOLTERO)
+                .correoElectronico("juan@test.com")
+                .telefono("04121111111")
+                .empresa("Empresa")
+                .estado(EstadoSolicitud.PENDIENTE)
+                .fechaSolicitud(LocalDateTime.now())
+                // Todos los opcionales quedan null intencionalmente.
+                .build();
+
+        SolicitudRegistroResponseDTO dto = mapper.toResponseDTO(solicitud);
+
+        assertThat(dto.getRifEmpresa()).isNull();
+        assertThat(dto.getDepartamento()).isNull();
+        assertThat(dto.getCargo()).isNull();
+        assertThat(dto.getSalario()).isNull();
+        assertThat(dto.getDireccionEstado()).isNull();
+        assertThat(dto.getDireccionCiudad()).isNull();
+        assertThat(dto.getDireccionMunicipio()).isNull();
+        assertThat(dto.getDireccionCalle()).isNull();
+        assertThat(dto.getEmergenciaNombre()).isNull();
+        assertThat(dto.getEmergenciaTelefono()).isNull();
+        assertThat(dto.getEmergenciaParentesco()).isNull();
+        // Estado debe seguir reflejándose aunque no haya pasado por revisión.
+        assertThat(dto.getEstado()).isEqualTo(EstadoSolicitud.PENDIENTE);
+        assertThat(dto.getFechaRevision()).isNull();
+        assertThat(dto.getRevisadoPor()).isNull();
+    }
+}

--- a/backend/src/test/java/com/tufondo/socios/infrastructure/persistence/adapter/SolicitudRegistroRepositoryImplTest.java
+++ b/backend/src/test/java/com/tufondo/socios/infrastructure/persistence/adapter/SolicitudRegistroRepositoryImplTest.java
@@ -217,6 +217,38 @@ class SolicitudRegistroRepositoryImplTest {
     }
 
     /**
+     * Cubre el bug del dashboard de admin: el card "Solicitudes Pendientes" mostraba 0
+     * porque el contador apuntaba a `SolicitudCredito`, no a `SolicitudRegistro`. Este
+     * test verifica que la nueva firma `contarPorEstado()` devuelve el conteo correcto
+     * filtrado por estado.
+     */
+    @Test
+    @DisplayName("contarPorEstado devuelve el número de solicitudes en ese estado")
+    void contarPorEstadoFiltraCorrectamente() {
+        // Arrange: 2 pendientes, 1 aprobada.
+        repository.guardar(nuevaSolicitudMinima("V-40000001", "p1@test.com")
+                .aceptaTerminos(true).aceptaLopdp(true)
+                .estado(EstadoSolicitud.PENDIENTE).build());
+        repository.guardar(nuevaSolicitudMinima("V-40000002", "p2@test.com")
+                .aceptaTerminos(true).aceptaLopdp(true)
+                .estado(EstadoSolicitud.PENDIENTE).build());
+        repository.guardar(nuevaSolicitudMinima("V-40000003", "a1@test.com")
+                .aceptaTerminos(true).aceptaLopdp(true)
+                .estado(EstadoSolicitud.APROBADA).build());
+        jpaRepository.flush();
+
+        assertThat(repository.contarPorEstado(EstadoSolicitud.PENDIENTE))
+                .as("Debe contar las 2 solicitudes pendientes")
+                .isEqualTo(2L);
+        assertThat(repository.contarPorEstado(EstadoSolicitud.APROBADA))
+                .as("Debe contar la única solicitud aprobada")
+                .isEqualTo(1L);
+        assertThat(repository.contarPorEstado(EstadoSolicitud.RECHAZADA))
+                .as("Sin solicitudes rechazadas, debe devolver 0")
+                .isEqualTo(0L);
+    }
+
+    /**
      * Builder utilitario con los campos mínimos NOT NULL en el schema.
      */
     private SolicitudRegistro.SolicitudRegistroBuilder nuevaSolicitudMinima(String cedula, String correo) {

--- a/frontend-web/src/app/(admin)/admin/page.tsx
+++ b/frontend-web/src/app/(admin)/admin/page.tsx
@@ -43,6 +43,8 @@ interface DashboardStats {
   solicitudesPendientes: number;
   solicitudesAprobadas: number;
   solicitudesRechazadas: number;
+  /** Solicitudes de registro de socios pendientes de aprobar (NO de crédito). */
+  solicitudesRegistroPendientes: number;
   capitalDesembolsado: number;
   carteraVencida: number;
   cuotasVencidas: number;
@@ -301,8 +303,8 @@ export default function AdminDashboardPage() {
         />
         <MetricCard
           title="Solicitudes Pendientes"
-          value={stats?.solicitudesPendientes || 0}
-          subtitle="Requieren revisión inmediata"
+          value={stats?.solicitudesRegistroPendientes || 0}
+          subtitle="Solicitudes de registro por aprobar"
           trend={{ value: 8.2, positive: false }}
           icon={Clock}
           iconBg="bg-amber-100"
@@ -475,7 +477,7 @@ export default function AdminDashboardPage() {
                   </div>
                   <div>
                     <p className="text-sm font-medium text-slate-900">Ver Solicitudes</p>
-                    <p className="text-xs text-slate-500">{stats?.solicitudesPendientes || 0} pendientes</p>
+                    <p className="text-xs text-slate-500">{stats?.solicitudesRegistroPendientes || 0} pendientes</p>
                   </div>
                 </div>
                 <ChevronRight className="w-4 h-4 text-slate-300 group-hover:text-slate-500 transition-colors" />

--- a/frontend-web/src/app/(admin)/admin/solicitudes/page.tsx
+++ b/frontend-web/src/app/(admin)/admin/solicitudes/page.tsx
@@ -16,17 +16,41 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Loader2, Check, X, Clock, User, Phone, Mail, Building } from 'lucide-react';
+import { Loader2, Check, X, Clock, User, Phone, Mail, Building, Eye, MapPin, ShieldCheck } from 'lucide-react';
 import { toast } from 'sonner';
 
 interface Solicitud {
   id: string;
+  // --- Datos personales ---
   nombreCompleto: string;
+  tipoDocumento?: 'CEDULA' | 'CEDULA_EXTRANJERO' | 'PASAPORTE' | 'RIF';
   cedula: string;
+  fechaNacimiento?: string;
+  genero?: 'MASCULINO' | 'FEMENINO' | 'OTRO';
+  estadoCivil?: 'SOLTERO' | 'CASADO' | 'DIVORCIADO' | 'VIUDO' | 'UNION_LIBRE';
+  // --- Contacto ---
   correoElectronico: string;
   telefono: string;
+  // --- Laboral ---
   empresa: string;
-  estado: 'PENDIENTE' | 'APROBADO' | 'RECHAZADO';
+  rifEmpresa?: string;
+  departamento?: string;
+  cargo?: string;
+  salario?: number | string;
+  // --- Dirección ---
+  direccionEstado?: string;
+  direccionCiudad?: string;
+  direccionMunicipio?: string;
+  direccionCalle?: string;
+  // --- Emergencia ---
+  emergenciaNombre?: string;
+  emergenciaTelefono?: string;
+  emergenciaParentesco?: string;
+  // --- Consentimientos ---
+  aceptaTerminos?: boolean;
+  aceptaLopdp?: boolean;
+  // --- Trazabilidad ---
+  estado: 'PENDIENTE' | 'APROBADO' | 'APROBADA' | 'RECHAZADO' | 'RECHAZADA';
   fechaSolicitud: string;
   fechaRevision?: string;
   revisadoPor?: string;
@@ -40,6 +64,8 @@ export default function SolicitudesPage() {
   const [isProcessing, setIsProcessing] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [rejectMotivo, setRejectMotivo] = useState('');
+  /** Solicitud cuyo detalle completo se está viendo en el modal "Ver detalle". */
+  const [detailSolicitud, setDetailSolicitud] = useState<Solicitud | null>(null);
   const [currentPage, setCurrentPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [totalElementos, setTotalElementos] = useState(0);
@@ -211,6 +237,16 @@ export default function SolicitudesPage() {
                           <div className="flex items-center justify-end gap-2">
                             <Button
                               size="sm"
+                              variant="outline"
+                              onClick={() => setDetailSolicitud(solicitud)}
+                              disabled={isProcessing}
+                              aria-label="Ver detalle"
+                            >
+                              <Eye className="h-4 w-4 mr-1" />
+                              Ver detalle
+                            </Button>
+                            <Button
+                              size="sm"
                               variant="default"
                               className="bg-green-600 hover:bg-green-700"
                               onClick={() => handleAprobar(solicitud.id)}
@@ -300,6 +336,123 @@ export default function SolicitudesPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Modal "Ver detalle": muestra TODOS los campos de la solicitud para que el
+          admin pueda revisar con contexto antes de aprobar/rechazar. */}
+      <Dialog open={!!detailSolicitud} onOpenChange={(open) => !open && setDetailSolicitud(null)}>
+        <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Detalle de la solicitud</DialogTitle>
+            <DialogDescription>
+              {detailSolicitud?.nombreCompleto} — {detailSolicitud?.cedula}
+            </DialogDescription>
+          </DialogHeader>
+
+          {detailSolicitud && (
+            <div className="space-y-5 py-2 text-sm">
+              <DetalleSeccion icon={<User className="h-4 w-4" />} titulo="Datos personales">
+                <DetalleCampo label="Nombre completo" value={detailSolicitud.nombreCompleto} />
+                <DetalleCampo label="Tipo de documento" value={detailSolicitud.tipoDocumento} />
+                <DetalleCampo label="Cédula / documento" value={detailSolicitud.cedula} />
+                <DetalleCampo label="Fecha de nacimiento" value={detailSolicitud.fechaNacimiento} />
+                <DetalleCampo label="Género" value={detailSolicitud.genero} />
+                <DetalleCampo label="Estado civil" value={detailSolicitud.estadoCivil} />
+              </DetalleSeccion>
+
+              <DetalleSeccion icon={<Mail className="h-4 w-4" />} titulo="Contacto">
+                <DetalleCampo label="Correo electrónico" value={detailSolicitud.correoElectronico} />
+                <DetalleCampo label="Teléfono" value={detailSolicitud.telefono} />
+              </DetalleSeccion>
+
+              <DetalleSeccion icon={<Building className="h-4 w-4" />} titulo="Información laboral">
+                <DetalleCampo label="Empresa" value={detailSolicitud.empresa} />
+                <DetalleCampo label="RIF empresa" value={detailSolicitud.rifEmpresa} />
+                <DetalleCampo label="Departamento" value={detailSolicitud.departamento} />
+                <DetalleCampo label="Cargo" value={detailSolicitud.cargo} />
+                <DetalleCampo
+                  label="Salario (Bs)"
+                  value={
+                    detailSolicitud.salario != null && detailSolicitud.salario !== ''
+                      ? String(detailSolicitud.salario)
+                      : undefined
+                  }
+                />
+              </DetalleSeccion>
+
+              <DetalleSeccion icon={<MapPin className="h-4 w-4" />} titulo="Dirección de residencia">
+                <DetalleCampo label="Estado" value={detailSolicitud.direccionEstado} />
+                <DetalleCampo label="Ciudad" value={detailSolicitud.direccionCiudad} />
+                <DetalleCampo label="Municipio" value={detailSolicitud.direccionMunicipio} />
+                <DetalleCampo label="Calle / dirección" value={detailSolicitud.direccionCalle} />
+              </DetalleSeccion>
+
+              <DetalleSeccion icon={<Phone className="h-4 w-4" />} titulo="Contacto de emergencia">
+                <DetalleCampo label="Nombre" value={detailSolicitud.emergenciaNombre} />
+                <DetalleCampo label="Teléfono" value={detailSolicitud.emergenciaTelefono} />
+                <DetalleCampo label="Parentesco" value={detailSolicitud.emergenciaParentesco} />
+              </DetalleSeccion>
+
+              <DetalleSeccion icon={<ShieldCheck className="h-4 w-4" />} titulo="Consentimientos legales">
+                <DetalleCampo
+                  label="Acepta términos"
+                  value={detailSolicitud.aceptaTerminos === true ? 'Sí' : detailSolicitud.aceptaTerminos === false ? 'No' : undefined}
+                />
+                <DetalleCampo
+                  label="Acepta LOPDP"
+                  value={detailSolicitud.aceptaLopdp === true ? 'Sí' : detailSolicitud.aceptaLopdp === false ? 'No' : undefined}
+                />
+              </DetalleSeccion>
+
+              <DetalleSeccion icon={<Clock className="h-4 w-4" />} titulo="Trazabilidad de revisión">
+                <DetalleCampo label="Estado" value={detailSolicitud.estado} />
+                <DetalleCampo label="Fecha solicitud" value={detailSolicitud.fechaSolicitud} />
+                <DetalleCampo label="Fecha revisión" value={detailSolicitud.fechaRevision} />
+                <DetalleCampo label="Revisado por" value={detailSolicitud.revisadoPor} />
+                <DetalleCampo label="Comentario" value={detailSolicitud.comentario} />
+                <DetalleCampo label="Motivo de rechazo" value={detailSolicitud.motivoRechazo} />
+              </DetalleSeccion>
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDetailSolicitud(null)}>
+              Cerrar
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+/* --- Helpers locales para el modal de detalle --- */
+
+function DetalleSeccion({
+  icon,
+  titulo,
+  children,
+}: {
+  icon: React.ReactNode;
+  titulo: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+        <span className="text-blue-600">{icon}</span>
+        <span className="font-semibold">{titulo}</span>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 pl-6">{children}</div>
+    </div>
+  );
+}
+
+function DetalleCampo({ label, value }: { label: string; value?: string | null }) {
+  const display = value == null || value === '' ? '—' : value;
+  return (
+    <div className="flex flex-col">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="text-sm break-words">{display}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Tres bugs reportados al probar QA tras la PR #154

### 🐛 Bug 1 — Aprobar una solicitud rompe con KYC null

```
ERROR: null value in column "nivel_verificacion" of relation "verificacion_kyc"
violates not-null constraint
```

`AprobarSolicitudUseCase` dispara un auto-KYC al aprobar. El INSERT fallaba porque la tabla tenía **dos columnas para el mismo concepto**:

- `nivel_verificacion VARCHAR(20) NOT NULL` — del schema V2 original.
- `nivel VARCHAR(20) NOT NULL` — agregada por Hibernate `ddl-auto: update` cuando se renombró el `@Column` de la entity sin escribir migración versionada.

Hibernate llenaba `nivel`, dejaba `nivel_verificacion` null → constraint violada. `@Transactional` revertía todo el use case (incluso el `Socio` creado).

**Fix:** `V12__cleanup_verificacion_kyc_orphan_columns.sql`
- Migra datos viejos antes de drop (por si entornos legacy tenían valores en `nivel_verificacion`).
- Drop idempotente (`IF EXISTS`) de `nivel_verificacion`, `fecha_finalizacion` y `score_confianza` (las 3 huérfanas detectadas).

### 🐛 Bug 2a — Dashboard "Solicitudes Pendientes" siempre marca 0

El card de `/admin` decía *"Solicitudes Pendientes — Requieren revisión inmediata"* y enlazaba a `/admin/solicitudes` (registro de socios), pero contaba `SolicitudCreditoRepository` (créditos). Tabla equivocada.

**Fix:**
- `SolicitudRegistroRepository#contarPorEstado(EstadoSolicitud)` → JPA `countByEstado()`.
- UseCase inyecta `SolicitudRegistroRepository` y expone `solicitudesRegistroPendientes`.
- Frontend cablea el card y el quick-link "Ver Solicitudes" al campo nuevo.

### 🐛 Bug 2b — Panel de solicitudes sin desglose

`SolicitudRegistroResponseDTO` solo exponía 12 campos (nombre, cédula, contacto, empresa, trazabilidad). El admin no veía: género, estado civil, RIF empresa, salario, dirección completa, contacto de emergencia, consentimientos. Decisión a ciegas.

**Fix:**
- DTO reescrito con todos los datos relevantes (excluye metadata LOPDP — ip/user-agent — que queda para auditoría legal, no flujo operativo).
- Mapper actualizado para mapear los 28 campos.
- Botón nuevo **"Ver detalle"** en cada row → modal con 7 secciones agrupadas (Personal, Contacto, Laboral, Dirección, Emergencia, Consentimientos, Trazabilidad) usando `Dialog` shadcn.

## Tests

- `SolicitudRegistroRepositoryImplTest`: nuevo caso `contarPorEstado` con 2 PENDIENTE + 1 APROBADA + 0 RECHAZADA verificando filtro correcto.
- `SolicitudRegistroDTOMapperTest` (nuevo): 2 casos — mapeo completo + opcionales nulos.

## Compatibilidad

- Lombok `@Builder` genera el nuevo setter sin tocar código existente.
- DTO mantiene `@NoArgsConstructor` para tests legacy.
- Migración Flyway idempotente.

## Test plan post-merge

- [ ] Re-deploy QA corre verde (migración V12 aplica sin error).
- [ ] `qa-admin/admin` muestra el conteo correcto en "Solicitudes Pendientes".
- [ ] `/admin/solicitudes` muestra el botón "Ver detalle" y el modal con todos los campos al hacer click.
- [ ] Aprobar una solicitud crea el socio + KYC sin error de constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)