### PR TITLE
feat(kyc): verificación biométrica con Didit (passive liveness + face match + OCR)

### DIFF
--- a/backend/src/main/java/com/tufondo/kyc/api/controller/BiometricController.java
+++ b/backend/src/main/java/com/tufondo/kyc/api/controller/BiometricController.java
@@ -1,0 +1,125 @@
+package com.tufondo.kyc.api.controller;
+
+import com.tufondo.auth.infrastructure.security.AuthenticatedUser;
+import com.tufondo.kyc.application.dto.request.AceptarConsentimientoBiometricoRequest;
+import com.tufondo.kyc.application.dto.response.IniciarBiometriaResponse;
+import com.tufondo.kyc.application.usecase.IniciarVerificacionBiometricaUseCase;
+import com.tufondo.kyc.application.usecase.ProcesarWebhookBiometricoUseCase;
+import com.tufondo.kyc.application.usecase.RegistrarConsentimientoBiometricoUseCase;
+import com.tufondo.kyc.application.usecase.RevocarConsentimientoBiometricoUseCase;
+import com.tufondo.kyc.domain.model.port.BiometricVerificatorPort;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Endpoints del flujo biométrico:
+ *  - POST /api/v1/kyc/biometric/consentimiento   → socio acepta política LOPDP biométrica
+ *  - POST /api/v1/kyc/biometric/iniciar          → socio inicia sesión con el proveedor
+ *  - POST /api/v1/kyc/biometric/webhook          → callback público del proveedor (sin auth, valida HMAC)
+ *  - POST /api/v1/kyc/biometric/revocar          → socio revoca consentimiento (Art. 7 LOPDP)
+ *
+ * El webhook es público (sin JWT) pero está protegido por HMAC + ventana de timestamp
+ * verificada dentro del adapter del puerto. NO logueamos el body completo (PII potencial).
+ */
+@RestController
+@RequestMapping("/api/v1/kyc/biometric")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "KYC Biométrico", description = "Verificación facial + liveness vía proveedor externo")
+@SecurityRequirement(name = "bearerAuth")
+public class BiometricController {
+
+    private final RegistrarConsentimientoBiometricoUseCase registrarConsentimientoUseCase;
+    private final IniciarVerificacionBiometricaUseCase iniciarBiometriaUseCase;
+    private final ProcesarWebhookBiometricoUseCase procesarWebhookUseCase;
+    private final RevocarConsentimientoBiometricoUseCase revocarConsentimientoUseCase;
+    private final BiometricVerificatorPort biometricPort;
+
+    @PostMapping("/consentimiento")
+    @PreAuthorize("hasRole('SOCIO')")
+    @Operation(summary = "Aceptar consentimiento biométrico (LOPDP)")
+    public ResponseEntity<Void> aceptarConsentimiento(
+            @Valid @RequestBody AceptarConsentimientoBiometricoRequest request,
+            Authentication auth,
+            HttpServletRequest http) {
+        UUID socioId = extraerSocioId(auth);
+        registrarConsentimientoUseCase.ejecutar(socioId, request.getVersionPolitica(),
+                clientIp(http), http.getHeader("User-Agent"));
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/iniciar")
+    @PreAuthorize("hasRole('SOCIO')")
+    @Operation(summary = "Iniciar sesión biométrica con el proveedor")
+    public ResponseEntity<IniciarBiometriaResponse> iniciar(
+            Authentication auth,
+            HttpServletRequest http) {
+        UUID socioId = extraerSocioId(auth);
+
+        IniciarVerificacionBiometricaUseCase.Resultado r = iniciarBiometriaUseCase.ejecutar(
+                socioId, clientIp(http), http.getHeader("User-Agent"));
+
+        return ResponseEntity.ok(IniciarBiometriaResponse.builder()
+                .intentoId(r.intentoId())
+                .sessionId(r.sessionId())
+                .widgetUrl(r.widgetUrl())
+                .widgetToken(r.widgetToken())
+                .proveedor(biometricPort.getProveedor())
+                .build());
+    }
+
+    /**
+     * Webhook público de Didit. La autenticación es por HMAC, no por JWT (de ahí
+     * la anotación de seguridad explícita y la ausencia de @PreAuthorize).
+     */
+    @PostMapping(value = "/webhook", consumes = "application/json")
+    @Operation(summary = "Webhook del proveedor biométrico (HMAC firmado)")
+    public ResponseEntity<Void> webhook(HttpServletRequest http) throws IOException {
+        byte[] rawBody = http.getInputStream().readAllBytes();
+        String signature = http.getHeader("x-signature");
+        String timestamp = http.getHeader("x-timestamp");
+
+        procesarWebhookUseCase.ejecutar(rawBody, signature, timestamp);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/revocar")
+    @PreAuthorize("hasRole('SOCIO')")
+    @Operation(summary = "Revocar consentimiento biométrico (LOPDP Art. 7)")
+    public ResponseEntity<Void> revocar(Authentication auth) {
+        UUID socioId = extraerSocioId(auth);
+        revocarConsentimientoUseCase.ejecutar(socioId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ---- helpers ----
+
+    private UUID extraerSocioId(Authentication authentication) {
+        if (authentication.getPrincipal() instanceof AuthenticatedUser authUser) {
+            return authUser.getSocioId();
+        }
+        return UUID.fromString(authentication.getName());
+    }
+
+    private String clientIp(HttpServletRequest request) {
+        String xff = request.getHeader("X-Forwarded-For");
+        if (xff != null && !xff.isBlank()) {
+            return xff.split(",")[0].trim();
+        }
+        String xRealIp = request.getHeader("X-Real-IP");
+        return xRealIp != null && !xRealIp.isBlank() ? xRealIp : request.getRemoteAddr();
+    }
+}

--- a/backend/src/main/java/com/tufondo/kyc/application/dto/request/AceptarConsentimientoBiometricoRequest.java
+++ b/backend/src/main/java/com/tufondo/kyc/application/dto/request/AceptarConsentimientoBiometricoRequest.java
@@ -1,0 +1,17 @@
+package com.tufondo.kyc.application.dto.request;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class AceptarConsentimientoBiometricoRequest {
+
+    @AssertTrue(message = "Debe aceptar la política biométrica explícitamente")
+    private boolean aceptado;
+
+    @NotBlank(message = "La versión de la política es obligatoria")
+    @Size(max = 20, message = "La versión no puede exceder 20 caracteres")
+    private String versionPolitica;
+}

--- a/backend/src/main/java/com/tufondo/kyc/application/dto/response/IniciarBiometriaResponse.java
+++ b/backend/src/main/java/com/tufondo/kyc/application/dto/response/IniciarBiometriaResponse.java
@@ -1,0 +1,22 @@
+package com.tufondo.kyc.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class IniciarBiometriaResponse {
+    private UUID intentoId;
+    private String sessionId;
+    /** URL del widget de Didit que el frontend debe abrir (iframe / nueva pestaña). */
+    private String widgetUrl;
+    /** Token corto-lived para autenticar el widget (puede ser null según el flow). */
+    private String widgetToken;
+    private String proveedor;
+}

--- a/backend/src/main/java/com/tufondo/kyc/application/usecase/IniciarVerificacionBiometricaUseCase.java
+++ b/backend/src/main/java/com/tufondo/kyc/application/usecase/IniciarVerificacionBiometricaUseCase.java
@@ -1,0 +1,97 @@
+package com.tufondo.kyc.application.usecase;
+
+import com.tufondo.kyc.domain.exception.KYCException;
+import com.tufondo.kyc.domain.model.VerificacionBiometrica;
+import com.tufondo.kyc.domain.model.VerificacionKYC;
+import com.tufondo.kyc.domain.model.enums.EstadoBiometria;
+import com.tufondo.kyc.domain.model.enums.EstadoIntentoBiometrico;
+import com.tufondo.kyc.domain.model.port.BiometricVerificatorPort;
+import com.tufondo.kyc.domain.repository.ConsentimientoBiometricoRepository;
+import com.tufondo.kyc.domain.repository.VerificacionBiometricaRepository;
+import com.tufondo.kyc.domain.repository.VerificacionKYCRepository;
+import com.tufondo.socios.domain.model.Socio;
+import com.tufondo.socios.domain.repository.SocioRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Inicia una sesión biométrica con el proveedor configurado y persiste un intento
+ * en estado PENDIENTE. Devuelve los datos para que el frontend monte el widget.
+ *
+ * Precondiciones:
+ *  - El socio debe tener un consentimiento biométrico vigente (LOPDP).
+ *  - Debe existir una VerificacionKYC activa para el socio (la auto-creada al aprobar
+ *    la solicitud de registro).
+ *
+ * Si ya hay un intento en EN_PROGRESO se reutiliza (idempotencia básica).
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class IniciarVerificacionBiometricaUseCase {
+
+    private final BiometricVerificatorPort biometricPort;
+    private final VerificacionKYCRepository verificacionKYCRepository;
+    private final VerificacionBiometricaRepository biometricaRepository;
+    private final ConsentimientoBiometricoRepository consentimientoRepository;
+    private final SocioRepository socioRepository;
+
+    @Transactional
+    public Resultado ejecutar(UUID socioId, String ipCliente, String userAgent) {
+
+        // 1. Verificar consentimiento LOPDP vigente.
+        consentimientoRepository.findVigenteBySocioId(socioId)
+                .orElseThrow(() -> new KYCException(
+                        "El socio no tiene consentimiento biométrico vigente. " +
+                        "Debe aceptar la política LOPDP biométrica antes de continuar."));
+
+        // 2. Cargar el socio (necesitamos email + nombre para Didit).
+        Socio socio = socioRepository.buscarPorId(socioId)
+                .orElseThrow(() -> new KYCException("Socio no encontrado"));
+
+        // 3. Buscar la VerificacionKYC activa del socio.
+        VerificacionKYC kyc = verificacionKYCRepository.findActiveBySocioId(socioId)
+                .orElseThrow(() -> new KYCException(
+                        "El socio no tiene una verificación KYC activa"));
+
+        // 4. Crear sesión con el proveedor.
+        String nombreCompleto = (socio.getPrimerNombre() + " " + socio.getPrimerApellido()).trim();
+        BiometricVerificatorPort.BiometricSessionResponse session = biometricPort.iniciarSesion(
+                new BiometricVerificatorPort.BiometricSessionRequest(
+                        socioId, socio.getCorreoElectronico(), nombreCompleto, null, null
+                )
+        );
+
+        // 5. Persistir intento PENDIENTE.
+        VerificacionBiometrica intento = VerificacionBiometrica.builder()
+                .verificacionKycId(kyc.getId())
+                .socioId(socioId)
+                .proveedor(biometricPort.getProveedor())
+                .proveedorSessionId(session.sessionId())
+                .proveedorWorkflowId(session.workflowId())
+                .estado(EstadoIntentoBiometrico.PENDIENTE)
+                .fechaInicio(LocalDateTime.now())
+                // Los artefactos se borran a los 90 días por política LOPDP.
+                .fechaExpiracionArtefactos(LocalDateTime.now().plusDays(90))
+                .ipCliente(ipCliente)
+                .userAgent(userAgent)
+                .build();
+        VerificacionBiometrica guardado = biometricaRepository.save(intento);
+
+        // 6. Marcar la KYC como EN_PROGRESO en el cache.
+        kyc.setEstadoBiometria(EstadoBiometria.EN_PROGRESO);
+        verificacionKYCRepository.save(kyc);
+
+        log.info("Sesión biométrica iniciada. socioId={} sessionId={} proveedor={}",
+                socioId, session.sessionId(), biometricPort.getProveedor());
+
+        return new Resultado(guardado.getId(), session.sessionId(), session.widgetUrl(), session.widgetToken());
+    }
+
+    public record Resultado(UUID intentoId, String sessionId, String widgetUrl, String widgetToken) {}
+}

--- a/backend/src/main/java/com/tufondo/kyc/application/usecase/ProcesarWebhookBiometricoUseCase.java
+++ b/backend/src/main/java/com/tufondo/kyc/application/usecase/ProcesarWebhookBiometricoUseCase.java
@@ -1,0 +1,91 @@
+package com.tufondo.kyc.application.usecase;
+
+import com.tufondo.kyc.domain.exception.KYCException;
+import com.tufondo.kyc.domain.model.VerificacionBiometrica;
+import com.tufondo.kyc.domain.model.VerificacionKYC;
+import com.tufondo.kyc.domain.model.enums.EstadoBiometria;
+import com.tufondo.kyc.domain.model.port.BiometricVerificatorPort;
+import com.tufondo.kyc.domain.repository.VerificacionBiometricaRepository;
+import com.tufondo.kyc.domain.repository.VerificacionKYCRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Procesa un webhook del proveedor biométrico (Didit, etc.):
+ *  - El adapter ya verificó la firma HMAC + ventana de timestamp.
+ *  - Aquí solo aplicamos el resultado normalizado: actualizamos el intento y el cache
+ *    de estado en la VerificacionKYC.
+ *
+ * Idempotente: si el webhook se reenvía (Didit reintenta hasta confirmar 2xx), el
+ * segundo procesamiento detecta el estado final y no hace cambios destructivos.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProcesarWebhookBiometricoUseCase {
+
+    private final BiometricVerificatorPort biometricPort;
+    private final VerificacionBiometricaRepository biometricaRepository;
+    private final VerificacionKYCRepository kycRepository;
+
+    @Transactional
+    public void ejecutar(byte[] rawBody, String signatureHeader, String timestampHeader) {
+        BiometricVerificatorPort.BiometricWebhookResult result =
+                biometricPort.procesarWebhook(rawBody, signatureHeader, timestampHeader);
+
+        VerificacionBiometrica intento = biometricaRepository
+                .findByProveedorSessionId(biometricPort.getProveedor(), result.sessionId())
+                .orElseThrow(() -> new KYCException(
+                        "No existe intento biométrico para sessionId=" + result.sessionId()));
+
+        // Idempotencia: si ya está en estado final, no reaplicar.
+        if (intento.getEstado() == com.tufondo.kyc.domain.model.enums.EstadoIntentoBiometrico.APROBADA
+                || intento.getEstado() == com.tufondo.kyc.domain.model.enums.EstadoIntentoBiometrico.RECHAZADA) {
+            log.info("Webhook duplicado para sessionId={} (estado={}); ignorado.",
+                    result.sessionId(), intento.getEstado());
+            return;
+        }
+
+        VerificacionBiometrica actualizado;
+        EstadoBiometria nuevoEstadoCache;
+        switch (result.outcome()) {
+            case APROBADO -> {
+                actualizado = intento.aprobar(
+                        result.livenessScore(), result.faceMatchScore(), result.documentOcrScore());
+                nuevoEstadoCache = EstadoBiometria.APROBADA;
+            }
+            case RECHAZADO -> {
+                actualizado = intento.rechazar(result.motivoFallo(), result.tipoAtaqueDetectado());
+                nuevoEstadoCache = EstadoBiometria.RECHAZADA;
+            }
+            case EXPIRADO -> {
+                actualizado = intento.expirar();
+                nuevoEstadoCache = EstadoBiometria.EXPIRADA;
+            }
+            case CANCELADO -> {
+                actualizado = intento.cancelar();
+                // Permitir reintento: el cache vuelve a NO_INICIADA.
+                nuevoEstadoCache = EstadoBiometria.NO_INICIADA;
+            }
+            default -> {
+                // EN_PROGRESO: solo actualizamos timestamp, no estado final.
+                log.debug("Webhook intermedio para sessionId={} (en progreso)", result.sessionId());
+                return;
+            }
+        }
+
+        biometricaRepository.save(actualizado);
+
+        // Actualizar cache en VerificacionKYC.
+        VerificacionKYC kyc = kycRepository.findById(intento.getVerificacionKycId()).orElse(null);
+        if (kyc != null) {
+            kyc.setEstadoBiometria(nuevoEstadoCache);
+            kycRepository.save(kyc);
+        }
+
+        log.info("Webhook biométrico aplicado. sessionId={} outcome={} liveness={} match={}",
+                result.sessionId(), result.outcome(), result.livenessScore(), result.faceMatchScore());
+    }
+}

--- a/backend/src/main/java/com/tufondo/kyc/application/usecase/RegistrarConsentimientoBiometricoUseCase.java
+++ b/backend/src/main/java/com/tufondo/kyc/application/usecase/RegistrarConsentimientoBiometricoUseCase.java
@@ -1,0 +1,51 @@
+package com.tufondo.kyc.application.usecase;
+
+import com.tufondo.kyc.domain.model.ConsentimientoBiometrico;
+import com.tufondo.kyc.domain.repository.ConsentimientoBiometricoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Registra el consentimiento explícito y separado para tratamiento biométrico,
+ * según exigencia LOPDP venezolana (datos biométricos = categoría sensible).
+ *
+ * El consentimiento general del KYC documental NO sirve — debe ser un consentimiento
+ * informado, libre, expreso y específico para la biometría, mencionando el proveedor
+ * y país de procesamiento.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RegistrarConsentimientoBiometricoUseCase {
+
+    /** Versión actual de la política biométrica. Bumpear cuando cambie el proveedor o el texto. */
+    public static final String VERSION_POLITICA_ACTUAL = "1.0";
+    public static final String PROVEEDOR_DEFAULT = "DIDIT_ES";
+    public static final String PAIS_DEFAULT = "ES";
+
+    private final ConsentimientoBiometricoRepository repository;
+
+    @Transactional
+    public ConsentimientoBiometrico ejecutar(UUID socioId, String versionPolitica,
+                                             String ipCliente, String userAgent) {
+        ConsentimientoBiometrico c = ConsentimientoBiometrico.builder()
+                .socioId(socioId)
+                .versionPolitica(versionPolitica != null ? versionPolitica : VERSION_POLITICA_ACTUAL)
+                .proveedorDestino(PROVEEDOR_DEFAULT)
+                .paisProcesamiento(PAIS_DEFAULT)
+                .aceptado(true)
+                .fechaConsentimiento(LocalDateTime.now())
+                .ipCliente(ipCliente)
+                .userAgent(userAgent)
+                .build();
+        ConsentimientoBiometrico guardado = repository.save(c);
+        log.info("Consentimiento biométrico registrado. socioId={} version={}",
+                socioId, guardado.getVersionPolitica());
+        return guardado;
+    }
+}

--- a/backend/src/main/java/com/tufondo/kyc/application/usecase/RevisarDocumentosUseCase.java
+++ b/backend/src/main/java/com/tufondo/kyc/application/usecase/RevisarDocumentosUseCase.java
@@ -98,6 +98,14 @@ public class RevisarDocumentosUseCase {
                 "La verificacion no esta en estado de revision");
         }
 
+        // Regla de negocio: no se puede aprobar documentalmente si la biometría
+        // no pasó. El analista debe pedir al socio repetir la captura biométrica.
+        if (verificacion.getEstadoBiometria() != com.tufondo.kyc.domain.model.enums.EstadoBiometria.APROBADA) {
+            throw new com.tufondo.kyc.domain.exception.VerificacionNoEditableException(
+                "No se puede aprobar la verificacion: el flujo biometrico no esta aprobado " +
+                "(estado actual: " + verificacion.getEstadoBiometria() + ")");
+        }
+
         EstadoVerificacion estadoAnterior = verificacion.getEstado();
 
         verificacion.setEstado(EstadoVerificacion.APROBADO);

--- a/backend/src/main/java/com/tufondo/kyc/application/usecase/RevocarConsentimientoBiometricoUseCase.java
+++ b/backend/src/main/java/com/tufondo/kyc/application/usecase/RevocarConsentimientoBiometricoUseCase.java
@@ -1,0 +1,69 @@
+package com.tufondo.kyc.application.usecase;
+
+import com.tufondo.kyc.domain.exception.KYCException;
+import com.tufondo.kyc.domain.model.ConsentimientoBiometrico;
+import com.tufondo.kyc.domain.model.VerificacionBiometrica;
+import com.tufondo.kyc.domain.model.port.BiometricVerificatorPort;
+import com.tufondo.kyc.domain.repository.ConsentimientoBiometricoRepository;
+import com.tufondo.kyc.domain.repository.VerificacionBiometricaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Revoca el consentimiento biométrico del socio y solicita borrado al proveedor
+ * (LOPDP Art. 7 — derecho a revocación + derecho al olvido).
+ *
+ * Flujo:
+ *  1. Marca el consentimiento vigente con fecha_revocacion.
+ *  2. Para cada intento biométrico del socio, solicita a Didit el borrado de la sesión.
+ *  3. Borra los registros locales de intentos biométricos (datos biométricos no se
+ *     deben retener tras revocación).
+ *
+ * Errores parciales (Didit no responde) se loggean pero NO bloquean la revocación
+ * local — la prioridad es honrar el derecho del titular; el borrado en el proveedor
+ * se reintenta async después.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RevocarConsentimientoBiometricoUseCase {
+
+    private final ConsentimientoBiometricoRepository consentimientoRepository;
+    private final VerificacionBiometricaRepository biometricaRepository;
+    private final BiometricVerificatorPort biometricPort;
+
+    @Transactional
+    public void ejecutar(UUID socioId) {
+        ConsentimientoBiometrico vigente = consentimientoRepository.findVigenteBySocioId(socioId)
+                .orElseThrow(() -> new KYCException(
+                        "No hay consentimiento biométrico vigente para revocar"));
+
+        // 1. Solicitar borrado en el proveedor por cada intento conocido.
+        // Para el volumen actual (1-10 intentos/socio) va inline. Si crece, mover a job async.
+        List<VerificacionBiometrica> intentos = biometricaRepository.findBySocioId(socioId);
+
+        for (VerificacionBiometrica intento : intentos) {
+            try {
+                biometricPort.solicitarBorradoSesion(intento.getProveedorSessionId());
+            } catch (Exception e) {
+                // No bloquea — el regulador prioriza la revocación local. Se reintenta async.
+                log.error("Borrado en proveedor falló para sessionId={}: {}",
+                        intento.getProveedorSessionId(), e.getMessage());
+            }
+        }
+
+        // 2. Borrar registros locales.
+        biometricaRepository.deleteAllBySocioId(socioId);
+
+        // 3. Marcar consentimiento como revocado.
+        ConsentimientoBiometrico revocado = vigente.revocar();
+        consentimientoRepository.save(revocado);
+
+        log.info("Consentimiento biométrico revocado para socioId={}", socioId);
+    }
+}

--- a/backend/src/main/java/com/tufondo/kyc/domain/model/ConsentimientoBiometrico.java
+++ b/backend/src/main/java/com/tufondo/kyc/domain/model/ConsentimientoBiometrico.java
@@ -1,0 +1,57 @@
+package com.tufondo.kyc.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Consentimiento separado para tratamiento biométrico — exigido por LOPDP Venezuela
+ * porque los datos biométricos son categoría sensible y deben tener:
+ *  - Consentimiento explícito SEPARADO del consentimiento KYC documental.
+ *  - Información sobre transferencia internacional (proveedor + país de procesamiento).
+ *  - Trazabilidad (IP, user-agent, timestamp).
+ *  - Versionado de política para que cambios en el texto requieran re-consentimiento.
+ *  - Revocable (Art. 7 LOPDP).
+ */
+@Getter
+@Builder
+public class ConsentimientoBiometrico {
+
+    private UUID id;
+    private UUID socioId;
+
+    private String versionPolitica;
+    private String proveedorDestino;
+    private String paisProcesamiento;
+
+    private Boolean aceptado;
+    private LocalDateTime fechaConsentimiento;
+    private LocalDateTime fechaRevocacion;
+
+    private String ipCliente;
+    private String userAgent;
+
+    private LocalDateTime createdAt;
+
+    public boolean estaVigente() {
+        return Boolean.TRUE.equals(aceptado) && fechaRevocacion == null;
+    }
+
+    public ConsentimientoBiometrico revocar() {
+        return ConsentimientoBiometrico.builder()
+                .id(this.id)
+                .socioId(this.socioId)
+                .versionPolitica(this.versionPolitica)
+                .proveedorDestino(this.proveedorDestino)
+                .paisProcesamiento(this.paisProcesamiento)
+                .aceptado(this.aceptado)
+                .fechaConsentimiento(this.fechaConsentimiento)
+                .fechaRevocacion(LocalDateTime.now())
+                .ipCliente(this.ipCliente)
+                .userAgent(this.userAgent)
+                .createdAt(this.createdAt)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/tufondo/kyc/domain/model/VerificacionBiometrica.java
+++ b/backend/src/main/java/com/tufondo/kyc/domain/model/VerificacionBiometrica.java
@@ -1,0 +1,143 @@
+package com.tufondo.kyc.domain.model;
+
+import com.tufondo.kyc.domain.model.enums.EstadoIntentoBiometrico;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Intento biométrico (registro individual de la tabla {@code biometric_verification}).
+ *
+ * Inmutable salvo por las transiciones de estado controladas — {@link #aprobar()},
+ * {@link #rechazar(String, String)}, {@link #expirar()}, {@link #cancelar()}.
+ *
+ * Diseño LOPDP-first:
+ * <ul>
+ *   <li>NO almacena ningún template biométrico ni embeddings.</li>
+ *   <li>Solo guarda los scores numéricos (no reversibles a imagen).</li>
+ *   <li>El selfie capturado se guarda en MinIO con TTL corto
+ *       ({@code fechaExpiracionArtefactos}) y se borra automáticamente.</li>
+ *   <li>Cuando el socio revoca su consentimiento biométrico, el use case de
+ *       revocación borra los registros vinculados.</li>
+ * </ul>
+ */
+@Getter
+@Builder
+public class VerificacionBiometrica {
+
+    private UUID id;
+    private UUID verificacionKycId;
+    private UUID socioId;
+
+    private String proveedor;             // "DIDIT", "AWS_REKOGNITION", etc.
+    private String proveedorSessionId;
+    private String proveedorWorkflowId;
+
+    private EstadoIntentoBiometrico estado;
+
+    private BigDecimal livenessScore;     // 0.00–1.00
+    private BigDecimal faceMatchScore;    // 0.00–1.00
+    private BigDecimal documentOcrScore;  // 0.00–1.00
+
+    private String motivoFallo;
+    private String tipoAtaqueDetectado;
+
+    private String selfieStoragePath;
+    private String documentoStoragePath;
+
+    private LocalDateTime fechaInicio;
+    private LocalDateTime fechaCompletado;
+    private LocalDateTime fechaExpiracionArtefactos;
+
+    private String ipCliente;
+    private String userAgent;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Long version;
+
+    /**
+     * Marca el intento como APROBADA. Solo válido desde PENDIENTE o EN_PROGRESO.
+     */
+    public VerificacionBiometrica aprobar(BigDecimal livenessScore,
+                                          BigDecimal faceMatchScore,
+                                          BigDecimal documentOcrScore) {
+        if (estado != EstadoIntentoBiometrico.PENDIENTE && estado != EstadoIntentoBiometrico.EN_PROGRESO) {
+            throw new IllegalStateException("No se puede aprobar un intento en estado " + estado);
+        }
+        return toBuilder()
+                .estado(EstadoIntentoBiometrico.APROBADA)
+                .livenessScore(livenessScore)
+                .faceMatchScore(faceMatchScore)
+                .documentOcrScore(documentOcrScore)
+                .fechaCompletado(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    /**
+     * Marca el intento como RECHAZADA con motivo. Si el proveedor detectó un ataque,
+     * se persiste como evidencia para auditoría.
+     */
+    public VerificacionBiometrica rechazar(String motivo, String tipoAtaqueDetectado) {
+        if (estado != EstadoIntentoBiometrico.PENDIENTE && estado != EstadoIntentoBiometrico.EN_PROGRESO) {
+            throw new IllegalStateException("No se puede rechazar un intento en estado " + estado);
+        }
+        return toBuilder()
+                .estado(EstadoIntentoBiometrico.RECHAZADA)
+                .motivoFallo(motivo)
+                .tipoAtaqueDetectado(tipoAtaqueDetectado)
+                .fechaCompletado(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public VerificacionBiometrica expirar() {
+        return toBuilder()
+                .estado(EstadoIntentoBiometrico.EXPIRADA)
+                .fechaCompletado(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public VerificacionBiometrica cancelar() {
+        return toBuilder()
+                .estado(EstadoIntentoBiometrico.CANCELADA)
+                .fechaCompletado(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    /**
+     * Returns a builder pre-populated with the current state. Mutaciones controladas
+     * por los métodos de transición ({@link #aprobar}, {@link #rechazar}, etc.).
+     */
+    public VerificacionBiometricaBuilder toBuilder() {
+        return VerificacionBiometrica.builder()
+                .id(this.id)
+                .verificacionKycId(this.verificacionKycId)
+                .socioId(this.socioId)
+                .proveedor(this.proveedor)
+                .proveedorSessionId(this.proveedorSessionId)
+                .proveedorWorkflowId(this.proveedorWorkflowId)
+                .estado(this.estado)
+                .livenessScore(this.livenessScore)
+                .faceMatchScore(this.faceMatchScore)
+                .documentOcrScore(this.documentOcrScore)
+                .motivoFallo(this.motivoFallo)
+                .tipoAtaqueDetectado(this.tipoAtaqueDetectado)
+                .selfieStoragePath(this.selfieStoragePath)
+                .documentoStoragePath(this.documentoStoragePath)
+                .fechaInicio(this.fechaInicio)
+                .fechaCompletado(this.fechaCompletado)
+                .fechaExpiracionArtefactos(this.fechaExpiracionArtefactos)
+                .ipCliente(this.ipCliente)
+                .userAgent(this.userAgent)
+                .createdAt(this.createdAt)
+                .updatedAt(this.updatedAt)
+                .version(this.version);
+    }
+}

--- a/backend/src/main/java/com/tufondo/kyc/domain/model/VerificacionKYC.java
+++ b/backend/src/main/java/com/tufondo/kyc/domain/model/VerificacionKYC.java
@@ -1,6 +1,7 @@
 // com.tufondo.kyc.domain.model.VerificacionKYC
 package com.tufondo.kyc.domain.model;
 
+import com.tufondo.kyc.domain.model.enums.EstadoBiometria;
 import com.tufondo.kyc.domain.model.enums.EstadoVerificacion;
 import com.tufondo.kyc.domain.model.enums.NivelVerificacion;
 import lombok.Builder;
@@ -34,6 +35,12 @@ public class VerificacionKYC {
     private String motivoRechazo;
     @Builder.Default
     private List<DocumentoIdentidad> documentos = new ArrayList<>();
+    /**
+     * Cache del resultado del flujo biométrico (Didit/AWS) — null en KYCs creadas antes
+     * de la migración V13. Lo mantiene sincronizado el use case que procesa el webhook.
+     */
+    @Builder.Default
+    private EstadoBiometria estadoBiometria = EstadoBiometria.NO_INICIADA;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 

--- a/backend/src/main/java/com/tufondo/kyc/domain/model/enums/EstadoBiometria.java
+++ b/backend/src/main/java/com/tufondo/kyc/domain/model/enums/EstadoBiometria.java
@@ -1,0 +1,33 @@
+package com.tufondo.kyc.domain.model.enums;
+
+/**
+ * Estado del flujo biométrico cacheado en {@code verificacion_kyc.estado_biometria}.
+ *
+ * Se mantiene sincronizado por el use case que registra el resultado del webhook
+ * del proveedor (Didit, etc.). Es un cache para evitar JOIN con {@code biometric_verification}
+ * en cada listado de la cola del admin.
+ *
+ * Distinción importante con {@link com.tufondo.kyc.domain.model.enums.EstadoVerificacion}:
+ *  - EstadoVerificacion es el estado del KYC global (documental + biométrico).
+ *  - EstadoBiometria es solo el sub-resultado biométrico.
+ *
+ * Una verificación documental puede estar APROBADA mientras la biometría está
+ * RECHAZADA — el analista decide si la rechaza globalmente o pide repetir biometría.
+ */
+public enum EstadoBiometria {
+
+    /** Aún no se inició ningún intento biométrico. Es el estado por defecto. */
+    NO_INICIADA,
+
+    /** Sesión biométrica abierta con el proveedor; esperando que el usuario complete. */
+    EN_PROGRESO,
+
+    /** Liveness + face match cumplieron los umbrales mínimos. */
+    APROBADA,
+
+    /** Liveness o face match fallaron, o el proveedor detectó intento de spoof. */
+    RECHAZADA,
+
+    /** Sesión expiró sin que el usuario la completara (timeout del proveedor). */
+    EXPIRADA
+}

--- a/backend/src/main/java/com/tufondo/kyc/domain/model/enums/EstadoIntentoBiometrico.java
+++ b/backend/src/main/java/com/tufondo/kyc/domain/model/enums/EstadoIntentoBiometrico.java
@@ -1,0 +1,27 @@
+package com.tufondo.kyc.domain.model.enums;
+
+/**
+ * Estado individual de un intento biométrico (registro en {@code biometric_verification}).
+ * Cada intento es atómico: una sesión con un proveedor, con su resultado.
+ *
+ * Un socio puede tener varios intentos (reintenta tras fallar liveness, por ejemplo) —
+ * por eso el modelo separa este enum de {@link EstadoBiometria}, que es el cache
+ * agregado en {@code verificacion_kyc}.
+ */
+public enum EstadoIntentoBiometrico {
+
+    /** Sesión creada en el proveedor pero usuario aún no abrió el widget. */
+    PENDIENTE,
+
+    /** Usuario abrió el widget; el proveedor está procesando. */
+    EN_PROGRESO,
+
+    APROBADA,
+    RECHAZADA,
+
+    /** El proveedor cerró la sesión por timeout sin que el usuario terminara. */
+    EXPIRADA,
+
+    /** El usuario o un admin canceló el intento explícitamente. */
+    CANCELADA
+}

--- a/backend/src/main/java/com/tufondo/kyc/domain/model/port/BiometricVerificatorPort.java
+++ b/backend/src/main/java/com/tufondo/kyc/domain/model/port/BiometricVerificatorPort.java
@@ -1,0 +1,79 @@
+package com.tufondo.kyc.domain.model.port;
+
+import java.math.BigDecimal;
+
+/**
+ * Puerto de verificación biométrica — abstrae al proveedor externo (Didit, AWS Rekognition,
+ * etc.) para que el dominio pueda intercambiarlo sin tocar use cases ni entities.
+ *
+ * Cubre las tres capacidades que aplica el KYC biométrico de Fatrans:
+ *  - Liveness detection (anti-spoofing): que la persona frente a la cámara sea real.
+ *  - Face match: que la cara coincida con la foto de la cédula.
+ *  - Identity document OCR: extracción de datos de la cédula (opcional, depende del flow).
+ *
+ * El proveedor maneja todo en una sola sesión asíncrona — creamos la sesión, el
+ * usuario completa el flow en el widget del proveedor, recibimos el resultado por webhook.
+ */
+public interface BiometricVerificatorPort {
+
+    /**
+     * Crea una sesión nueva con el proveedor y devuelve los datos para que el
+     * frontend monte el widget de captura.
+     *
+     * @param request socioId + email + flow type
+     * @return session id + URL del widget + workflow id
+     */
+    BiometricSessionResponse iniciarSesion(BiometricSessionRequest request);
+
+    /**
+     * Verifica la firma del webhook (HMAC) y parsea el payload a un resultado normalizado.
+     *
+     * @param rawBody          body crudo recibido en el endpoint webhook
+     * @param signatureHeader  header de firma (Didit usa "x-signature")
+     * @param timestampHeader  timestamp del envío (anti-replay attack)
+     * @return resultado normalizado o throw si la firma no valida
+     */
+    BiometricWebhookResult procesarWebhook(byte[] rawBody, String signatureHeader, String timestampHeader);
+
+    /**
+     * Solicita al proveedor que borre todos los datos asociados al session id.
+     * Se invoca cuando el socio revoca su consentimiento biométrico (LOPDP Art. 7).
+     */
+    void solicitarBorradoSesion(String proveedorSessionId);
+
+    String getProveedor();
+
+
+    // ---- DTOs del puerto (records, no exponen detalles del proveedor) ----
+
+    record BiometricSessionRequest(
+            java.util.UUID socioId,
+            String email,
+            String nombreCompleto,
+            String workflowId,
+            String callbackUrl
+    ) {}
+
+    record BiometricSessionResponse(
+            String sessionId,
+            String workflowId,
+            String widgetUrl,
+            String widgetToken
+    ) {}
+
+    /**
+     * Resultado parseado de un webhook del proveedor. El use case lo aplica
+     * sobre el {@code VerificacionBiometrica} para hacer la transición de estado.
+     */
+    record BiometricWebhookResult(
+            String sessionId,
+            BiometricOutcome outcome,
+            BigDecimal livenessScore,
+            BigDecimal faceMatchScore,
+            BigDecimal documentOcrScore,
+            String motivoFallo,
+            String tipoAtaqueDetectado
+    ) {}
+
+    enum BiometricOutcome { APROBADO, RECHAZADO, EN_PROGRESO, EXPIRADO, CANCELADO }
+}

--- a/backend/src/main/java/com/tufondo/kyc/domain/repository/ConsentimientoBiometricoRepository.java
+++ b/backend/src/main/java/com/tufondo/kyc/domain/repository/ConsentimientoBiometricoRepository.java
@@ -1,0 +1,16 @@
+package com.tufondo.kyc.domain.repository;
+
+import com.tufondo.kyc.domain.model.ConsentimientoBiometrico;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ConsentimientoBiometricoRepository {
+
+    ConsentimientoBiometrico save(ConsentimientoBiometrico consentimiento);
+
+    /** Devuelve el consentimiento vigente (aceptado + no revocado) más reciente del socio. */
+    Optional<ConsentimientoBiometrico> findVigenteBySocioId(UUID socioId);
+
+    Optional<ConsentimientoBiometrico> findById(UUID id);
+}

--- a/backend/src/main/java/com/tufondo/kyc/domain/repository/VerificacionBiometricaRepository.java
+++ b/backend/src/main/java/com/tufondo/kyc/domain/repository/VerificacionBiometricaRepository.java
@@ -1,0 +1,27 @@
+package com.tufondo.kyc.domain.repository;
+
+import com.tufondo.kyc.domain.model.VerificacionBiometrica;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface VerificacionBiometricaRepository {
+
+    VerificacionBiometrica save(VerificacionBiometrica verificacion);
+
+    Optional<VerificacionBiometrica> findById(UUID id);
+
+    /** Búsqueda por session id devuelto por el proveedor (Didit). Útil al recibir el webhook. */
+    Optional<VerificacionBiometrica> findByProveedorSessionId(String proveedor, String sessionId);
+
+    List<VerificacionBiometrica> findByVerificacionKycId(UUID verificacionKycId);
+
+    List<VerificacionBiometrica> findBySocioId(UUID socioId);
+
+    /**
+     * Borra todos los intentos biométricos asociados a un socio. Lo usa el flujo de
+     * revocación de consentimiento (LOPDP Art. 7 — derecho al olvido).
+     */
+    void deleteAllBySocioId(UUID socioId);
+}

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/biometric/DiditKycAdapter.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/biometric/DiditKycAdapter.java
@@ -1,0 +1,275 @@
+package com.tufondo.kyc.infrastructure.biometric;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tufondo.kyc.domain.exception.KYCException;
+import com.tufondo.kyc.domain.model.port.BiometricVerificatorPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Adapter del puerto {@link BiometricVerificatorPort} para el proveedor Didit
+ * (didit.me) — passive liveness iBeta L1 + face match + ID document OCR + AML,
+ * gratis hasta 500 verificaciones/mes.
+ *
+ * Documentación API: https://docs.didit.me
+ *
+ * Capacidades:
+ *  - {@link #iniciarSesion}: crea una sesión en Didit y devuelve la URL del widget
+ *    que el frontend embeberá. El widget se encarga de la captura de cámara,
+ *    instrucciones al usuario, captura de cédula y selfie con liveness.
+ *  - {@link #procesarWebhook}: verifica la firma HMAC-SHA256 + ventana de timestamp
+ *    (anti-replay) y normaliza el payload a {@link BiometricWebhookResult}.
+ *  - {@link #solicitarBorradoSesion}: para revocación LOPDP — pide a Didit que
+ *    elimine los datos asociados al session id.
+ *
+ * Si {@code fatrans.kyc.didit.enabled=false} (caso desarrollo sin credenciales),
+ * lanza {@link KYCException} explícita en lugar de hacer llamadas con credenciales nulas.
+ */
+@Service
+@Slf4j
+@Configuration
+@EnableConfigurationProperties(DiditProperties.class)
+public class DiditKycAdapter implements BiometricVerificatorPort {
+
+    public static final String PROVIDER_NAME = "DIDIT";
+
+    private final DiditProperties props;
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public DiditKycAdapter(DiditProperties props, ObjectMapper objectMapper) {
+        this.props = props;
+        this.restTemplate = new RestTemplate();
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String getProveedor() {
+        return PROVIDER_NAME;
+    }
+
+    @Override
+    public BiometricSessionResponse iniciarSesion(BiometricSessionRequest request) {
+        ensureEnabled();
+
+        String workflowId = request.workflowId() != null && !request.workflowId().isBlank()
+                ? request.workflowId()
+                : props.getWorkflowId();
+        if (workflowId == null || workflowId.isBlank()) {
+            throw new KYCException("Didit workflow_id no configurado");
+        }
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("workflow_id", workflowId);
+        body.put("vendor_data", request.socioId().toString());
+        // Didit no requiere el email; solo lo agregamos como metadata para el dashboard.
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("email", request.email());
+        metadata.put("nombre_completo", request.nombreCompleto());
+        body.put("metadata", metadata);
+
+        String callback = request.callbackUrl() != null && !request.callbackUrl().isBlank()
+                ? request.callbackUrl()
+                : props.getCallbackUrl();
+        if (callback != null && !callback.isBlank()) {
+            body.put("callback", callback);
+        }
+
+        HttpHeaders headers = baseHeaders();
+        try {
+            ResponseEntity<JsonNode> response = restTemplate.exchange(
+                    props.getBaseUrl() + "/session/",
+                    HttpMethod.POST,
+                    new HttpEntity<>(body, headers),
+                    JsonNode.class
+            );
+            JsonNode payload = response.getBody();
+            if (payload == null) {
+                throw new KYCException("Didit devolvió payload vacío al crear sesión");
+            }
+            String sessionId = textOrNull(payload, "session_id");
+            String widgetUrl = textOrNull(payload, "url");
+            String widgetToken = textOrNull(payload, "session_token");
+            if (sessionId == null || widgetUrl == null) {
+                throw new KYCException("Respuesta de Didit incompleta: falta session_id o url");
+            }
+            log.info("Didit session created. socioId={} sessionId={}", request.socioId(), sessionId);
+            return new BiometricSessionResponse(sessionId, workflowId, widgetUrl, widgetToken);
+        } catch (RestClientException e) {
+            // No logueamos el body ni headers (puede contener apiKey reflejada en algunos errores).
+            log.error("Didit session error: {}", e.getMessage());
+            throw new KYCException("Error iniciando sesión biométrica con el proveedor");
+        }
+    }
+
+    @Override
+    public BiometricWebhookResult procesarWebhook(byte[] rawBody, String signatureHeader, String timestampHeader) {
+        ensureEnabled();
+
+        if (signatureHeader == null || signatureHeader.isBlank()) {
+            throw new KYCException("Webhook sin firma: rechazado");
+        }
+        if (props.getWebhookSecret() == null || props.getWebhookSecret().isBlank()) {
+            throw new KYCException("DIDIT_WEBHOOK_SECRET no configurado");
+        }
+
+        // Anti-replay: el timestamp debe estar dentro de la ventana de tolerancia.
+        validateTimestamp(timestampHeader);
+
+        // Verificación HMAC-SHA256 del body crudo con la clave compartida.
+        String expectedSignature = hmacSha256Hex(props.getWebhookSecret(), rawBody);
+        if (!constantTimeEquals(expectedSignature, normalizeSignature(signatureHeader))) {
+            log.warn("Webhook Didit firma inválida (timestamp={})", timestampHeader);
+            throw new KYCException("Firma de webhook inválida");
+        }
+
+        try {
+            JsonNode payload = objectMapper.readTree(rawBody);
+            String sessionId = textOrNull(payload, "session_id");
+            String status = textOrNull(payload, "status");
+            JsonNode decision = payload.path("decision");
+
+            BiometricOutcome outcome = mapStatus(status);
+            BigDecimal livenessScore = readScore(decision, "liveness", "score");
+            BigDecimal faceMatchScore = readScore(decision, "face_match", "score");
+            BigDecimal documentOcrScore = readScore(decision, "id_verification", "confidence_score");
+
+            String motivoFallo = null;
+            String tipoAtaque = null;
+            if (outcome == BiometricOutcome.RECHAZADO) {
+                motivoFallo = textOrNull(decision, "warnings");
+                tipoAtaque = textOrNull(decision.path("liveness"), "attack_type");
+            }
+
+            return new BiometricWebhookResult(
+                    sessionId, outcome, livenessScore, faceMatchScore, documentOcrScore,
+                    motivoFallo, tipoAtaque
+            );
+        } catch (Exception e) {
+            log.error("Error parseando webhook Didit: {}", e.getMessage());
+            throw new KYCException("Webhook payload inválido");
+        }
+    }
+
+    @Override
+    public void solicitarBorradoSesion(String proveedorSessionId) {
+        ensureEnabled();
+        try {
+            HttpHeaders headers = baseHeaders();
+            restTemplate.exchange(
+                    props.getBaseUrl() + "/session/" + proveedorSessionId + "/",
+                    HttpMethod.DELETE,
+                    new HttpEntity<>(headers),
+                    Void.class
+            );
+            log.info("Didit session borrada (revocación LOPDP). sessionId={}", proveedorSessionId);
+        } catch (RestClientException e) {
+            log.error("Error al solicitar borrado de sesión Didit {}: {}", proveedorSessionId, e.getMessage());
+            throw new KYCException("No se pudo solicitar el borrado en el proveedor");
+        }
+    }
+
+    // ---------- helpers internos ----------
+
+    private void ensureEnabled() {
+        if (!props.isEnabled()) {
+            throw new KYCException("KYC biométrico (Didit) no está habilitado en este entorno");
+        }
+    }
+
+    private HttpHeaders baseHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("x-api-key", props.getApiKey());
+        return headers;
+    }
+
+    private void validateTimestamp(String timestampHeader) {
+        if (timestampHeader == null || timestampHeader.isBlank()) {
+            // Algunos proveedores no lo envían — toleramos pero registramos.
+            log.debug("Webhook Didit sin timestamp; saltando validación anti-replay");
+            return;
+        }
+        try {
+            long ts = Long.parseLong(timestampHeader);
+            long now = Instant.now().getEpochSecond();
+            long delta = Math.abs(now - ts);
+            if (delta > props.getWebhookTimestampToleranceSeconds()) {
+                throw new KYCException("Webhook fuera de ventana temporal (replay sospechoso)");
+            }
+        } catch (NumberFormatException e) {
+            throw new KYCException("Timestamp de webhook inválido");
+        }
+    }
+
+    private String hmacSha256Hex(String secret, byte[] body) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            byte[] digest = mac.doFinal(body);
+            return HexFormat.of().formatHex(digest);
+        } catch (Exception e) {
+            throw new KYCException("Error computando HMAC-SHA256 del webhook");
+        }
+    }
+
+    private boolean constantTimeEquals(String a, String b) {
+        if (a == null || b == null || a.length() != b.length()) return false;
+        int result = 0;
+        for (int i = 0; i < a.length(); i++) result |= a.charAt(i) ^ b.charAt(i);
+        return result == 0;
+    }
+
+    private String normalizeSignature(String header) {
+        // Didit suele enviar la firma como hex puro; algunos proveedores anteponen "sha256=".
+        return header.toLowerCase().startsWith("sha256=") ? header.substring(7) : header;
+    }
+
+    private BiometricOutcome mapStatus(String status) {
+        if (status == null) return BiometricOutcome.EN_PROGRESO;
+        return switch (status.toUpperCase()) {
+            case "APPROVED", "VERIFIED" -> BiometricOutcome.APROBADO;
+            case "DECLINED", "REJECTED" -> BiometricOutcome.RECHAZADO;
+            case "EXPIRED" -> BiometricOutcome.EXPIRADO;
+            case "ABANDONED", "CANCELLED" -> BiometricOutcome.CANCELADO;
+            default -> BiometricOutcome.EN_PROGRESO;
+        };
+    }
+
+    private String textOrNull(JsonNode node, String field) {
+        if (node == null) return null;
+        JsonNode v = node.path(field);
+        return v.isMissingNode() || v.isNull() ? null : v.asText();
+    }
+
+    private BigDecimal readScore(JsonNode parent, String section, String field) {
+        if (parent == null) return null;
+        JsonNode v = parent.path(section).path(field);
+        if (v.isMissingNode() || v.isNull() || !v.isNumber()) return null;
+        // Algunos endpoints devuelven 0-100, otros 0-1. Normalizamos a 0-1.
+        double raw = v.asDouble();
+        if (raw > 1.0) raw = raw / 100.0;
+        return BigDecimal.valueOf(raw);
+    }
+}

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/biometric/DiditProperties.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/biometric/DiditProperties.java
@@ -1,0 +1,34 @@
+package com.tufondo.kyc.infrastructure.biometric;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Properties de configuración del proveedor Didit (KYC biométrico).
+ *
+ * Se cargan desde env vars con prefijo {@code DIDIT_*} (mapeadas en application.yml):
+ *
+ *   DIDIT_API_KEY          → apiKey
+ *   DIDIT_WEBHOOK_SECRET   → webhookSecret
+ *   DIDIT_WORKFLOW_ID      → workflowId
+ *   DIDIT_BASE_URL         → baseUrl (default: https://verification.didit.me/v2)
+ *   DIDIT_CALLBACK_URL     → callbackUrl
+ *   DIDIT_ENABLED          → enabled (default: false → adapter inactivo si falta config)
+ *
+ * Si {@code enabled} es false, el adapter inicia pero NO realiza llamadas reales —
+ * permite que la app arranque en desarrollo sin credenciales.
+ */
+@Data
+@ConfigurationProperties(prefix = "fatrans.kyc.didit")
+public class DiditProperties {
+
+    private boolean enabled = false;
+    private String apiKey;
+    private String webhookSecret;
+    private String workflowId;
+    private String baseUrl = "https://verification.didit.me/v2";
+    private String callbackUrl;
+
+    /** Ventana de tolerancia para webhook timestamp (anti-replay). 5 minutos por defecto. */
+    private long webhookTimestampToleranceSeconds = 300;
+}

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/adapter/ConsentimientoBiometricoRepositoryImpl.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/adapter/ConsentimientoBiometricoRepositoryImpl.java
@@ -1,0 +1,68 @@
+package com.tufondo.kyc.infrastructure.persistence.adapter;
+
+import com.tufondo.kyc.domain.model.ConsentimientoBiometrico;
+import com.tufondo.kyc.domain.repository.ConsentimientoBiometricoRepository;
+import com.tufondo.kyc.infrastructure.persistence.entity.ConsentimientoBiometricoEntity;
+import com.tufondo.kyc.infrastructure.persistence.jpa.ConsentimientoBiometricoJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class ConsentimientoBiometricoRepositoryImpl implements ConsentimientoBiometricoRepository {
+
+    private final ConsentimientoBiometricoJpaRepository jpaRepository;
+
+    @Override
+    @Transactional
+    public ConsentimientoBiometrico save(ConsentimientoBiometrico c) {
+        return toDomain(jpaRepository.save(toEntity(c)));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<ConsentimientoBiometrico> findVigenteBySocioId(UUID socioId) {
+        return jpaRepository.findVigenteBySocioId(socioId).map(this::toDomain);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<ConsentimientoBiometrico> findById(UUID id) {
+        return jpaRepository.findById(id).map(this::toDomain);
+    }
+
+    private ConsentimientoBiometricoEntity toEntity(ConsentimientoBiometrico d) {
+        return ConsentimientoBiometricoEntity.builder()
+                .id(d.getId())
+                .socioId(d.getSocioId())
+                .versionPolitica(d.getVersionPolitica())
+                .proveedorDestino(d.getProveedorDestino())
+                .paisProcesamiento(d.getPaisProcesamiento())
+                .aceptado(d.getAceptado())
+                .fechaConsentimiento(d.getFechaConsentimiento())
+                .fechaRevocacion(d.getFechaRevocacion())
+                .ipCliente(d.getIpCliente())
+                .userAgent(d.getUserAgent())
+                .build();
+    }
+
+    private ConsentimientoBiometrico toDomain(ConsentimientoBiometricoEntity e) {
+        return ConsentimientoBiometrico.builder()
+                .id(e.getId())
+                .socioId(e.getSocioId())
+                .versionPolitica(e.getVersionPolitica())
+                .proveedorDestino(e.getProveedorDestino())
+                .paisProcesamiento(e.getPaisProcesamiento())
+                .aceptado(e.getAceptado())
+                .fechaConsentimiento(e.getFechaConsentimiento())
+                .fechaRevocacion(e.getFechaRevocacion())
+                .ipCliente(e.getIpCliente())
+                .userAgent(e.getUserAgent())
+                .createdAt(e.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/adapter/VerificacionBiometricaRepositoryImpl.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/adapter/VerificacionBiometricaRepositoryImpl.java
@@ -1,0 +1,109 @@
+package com.tufondo.kyc.infrastructure.persistence.adapter;
+
+import com.tufondo.kyc.domain.model.VerificacionBiometrica;
+import com.tufondo.kyc.domain.repository.VerificacionBiometricaRepository;
+import com.tufondo.kyc.infrastructure.persistence.entity.VerificacionBiometricaEntity;
+import com.tufondo.kyc.infrastructure.persistence.jpa.VerificacionBiometricaJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class VerificacionBiometricaRepositoryImpl implements VerificacionBiometricaRepository {
+
+    private final VerificacionBiometricaJpaRepository jpaRepository;
+
+    @Override
+    @Transactional
+    public VerificacionBiometrica save(VerificacionBiometrica verificacion) {
+        VerificacionBiometricaEntity saved = jpaRepository.save(toEntity(verificacion));
+        return toDomain(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<VerificacionBiometrica> findById(UUID id) {
+        return jpaRepository.findById(id).map(this::toDomain);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<VerificacionBiometrica> findByProveedorSessionId(String proveedor, String sessionId) {
+        return jpaRepository.findByProveedorAndProveedorSessionId(proveedor, sessionId).map(this::toDomain);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<VerificacionBiometrica> findByVerificacionKycId(UUID verificacionKycId) {
+        return jpaRepository.findByVerificacionKycId(verificacionKycId).stream().map(this::toDomain).toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<VerificacionBiometrica> findBySocioId(UUID socioId) {
+        return jpaRepository.findBySocioId(socioId).stream().map(this::toDomain).toList();
+    }
+
+    @Override
+    @Transactional
+    public void deleteAllBySocioId(UUID socioId) {
+        jpaRepository.deleteAllBySocioId(socioId);
+    }
+
+    private VerificacionBiometricaEntity toEntity(VerificacionBiometrica d) {
+        return VerificacionBiometricaEntity.builder()
+                .id(d.getId())
+                .verificacionKycId(d.getVerificacionKycId())
+                .socioId(d.getSocioId())
+                .proveedor(d.getProveedor())
+                .proveedorSessionId(d.getProveedorSessionId())
+                .proveedorWorkflowId(d.getProveedorWorkflowId())
+                .estado(d.getEstado())
+                .livenessScore(d.getLivenessScore())
+                .faceMatchScore(d.getFaceMatchScore())
+                .documentOcrScore(d.getDocumentOcrScore())
+                .motivoFallo(d.getMotivoFallo())
+                .tipoAtaqueDetectado(d.getTipoAtaqueDetectado())
+                .selfieStoragePath(d.getSelfieStoragePath())
+                .documentoStoragePath(d.getDocumentoStoragePath())
+                .fechaInicio(d.getFechaInicio())
+                .fechaCompletado(d.getFechaCompletado())
+                .fechaExpiracionArtefactos(d.getFechaExpiracionArtefactos())
+                .ipCliente(d.getIpCliente())
+                .userAgent(d.getUserAgent())
+                .version(d.getVersion())
+                .build();
+    }
+
+    private VerificacionBiometrica toDomain(VerificacionBiometricaEntity e) {
+        return VerificacionBiometrica.builder()
+                .id(e.getId())
+                .verificacionKycId(e.getVerificacionKycId())
+                .socioId(e.getSocioId())
+                .proveedor(e.getProveedor())
+                .proveedorSessionId(e.getProveedorSessionId())
+                .proveedorWorkflowId(e.getProveedorWorkflowId())
+                .estado(e.getEstado())
+                .livenessScore(e.getLivenessScore())
+                .faceMatchScore(e.getFaceMatchScore())
+                .documentOcrScore(e.getDocumentOcrScore())
+                .motivoFallo(e.getMotivoFallo())
+                .tipoAtaqueDetectado(e.getTipoAtaqueDetectado())
+                .selfieStoragePath(e.getSelfieStoragePath())
+                .documentoStoragePath(e.getDocumentoStoragePath())
+                .fechaInicio(e.getFechaInicio())
+                .fechaCompletado(e.getFechaCompletado())
+                .fechaExpiracionArtefactos(e.getFechaExpiracionArtefactos())
+                .ipCliente(e.getIpCliente())
+                .userAgent(e.getUserAgent())
+                .createdAt(e.getCreatedAt())
+                .updatedAt(e.getUpdatedAt())
+                .version(e.getVersion())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/adapter/VerificacionKYCRepositoryImpl.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/adapter/VerificacionKYCRepositoryImpl.java
@@ -128,6 +128,7 @@ public class VerificacionKYCRepositoryImpl implements VerificacionKYCRepository 
             .fechaRevision(entity.getFechaRevision())
             .comentariosRevision(entity.getComentariosRevision())
             .motivoRechazo(entity.getMotivoRechazo())
+            .estadoBiometria(entity.getEstadoBiometria())
             .createdAt(entity.getCreatedAt())
             .updatedAt(entity.getUpdatedAt())
             .build();
@@ -147,6 +148,7 @@ public class VerificacionKYCRepositoryImpl implements VerificacionKYCRepository 
             .fechaRevision(domain.getFechaRevision())
             .comentariosRevision(domain.getComentariosRevision())
             .motivoRechazo(domain.getMotivoRechazo())
+            .estadoBiometria(domain.getEstadoBiometria())
             .createdAt(domain.getCreatedAt())
             .updatedAt(domain.getUpdatedAt())
             .build();

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/entity/ConsentimientoBiometricoEntity.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/entity/ConsentimientoBiometricoEntity.java
@@ -1,0 +1,57 @@
+package com.tufondo.kyc.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "biometric_consent")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConsentimientoBiometricoEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "socio_id", nullable = false)
+    private UUID socioId;
+
+    @Column(name = "version_politica", nullable = false, length = 20)
+    private String versionPolitica;
+
+    @Column(name = "proveedor_destino", nullable = false, length = 50)
+    private String proveedorDestino;
+
+    @Column(name = "pais_procesamiento", nullable = false, length = 50)
+    private String paisProcesamiento;
+
+    @Column(name = "aceptado", nullable = false)
+    private Boolean aceptado;
+
+    @Column(name = "fecha_consentimiento", nullable = false)
+    private LocalDateTime fechaConsentimiento;
+
+    @Column(name = "fecha_revocacion")
+    private LocalDateTime fechaRevocacion;
+
+    @Column(name = "ip_cliente", length = 45)
+    private String ipCliente;
+
+    @Column(name = "user_agent", length = 500)
+    private String userAgent;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/entity/VerificacionBiometricaEntity.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/entity/VerificacionBiometricaEntity.java
@@ -1,0 +1,100 @@
+package com.tufondo.kyc.infrastructure.persistence.entity;
+
+import com.tufondo.kyc.domain.model.enums.EstadoIntentoBiometrico;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Los índices y constraints viven en la migración Flyway V13 — no se declaran aquí
+ * para evitar duplicación cuando ddl-auto migre de update a validate.
+ */
+@Entity
+@Table(name = "biometric_verification")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VerificacionBiometricaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "verificacion_kyc_id", nullable = false)
+    private UUID verificacionKycId;
+
+    @Column(name = "socio_id", nullable = false)
+    private UUID socioId;
+
+    @Column(name = "proveedor", nullable = false, length = 50)
+    private String proveedor;
+
+    @Column(name = "proveedor_session_id", nullable = false, length = 255)
+    private String proveedorSessionId;
+
+    @Column(name = "proveedor_workflow_id", length = 100)
+    private String proveedorWorkflowId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "estado", nullable = false, length = 30)
+    private EstadoIntentoBiometrico estado;
+
+    @Column(name = "liveness_score", precision = 5, scale = 4)
+    private BigDecimal livenessScore;
+
+    @Column(name = "face_match_score", precision = 5, scale = 4)
+    private BigDecimal faceMatchScore;
+
+    @Column(name = "document_ocr_score", precision = 5, scale = 4)
+    private BigDecimal documentOcrScore;
+
+    @Column(name = "motivo_fallo", length = 500)
+    private String motivoFallo;
+
+    @Column(name = "tipo_ataque_detectado", length = 100)
+    private String tipoAtaqueDetectado;
+
+    @Column(name = "selfie_storage_path", length = 500)
+    private String selfieStoragePath;
+
+    @Column(name = "documento_storage_path", length = 500)
+    private String documentoStoragePath;
+
+    @Column(name = "fecha_inicio", nullable = false)
+    private LocalDateTime fechaInicio;
+
+    @Column(name = "fecha_completado")
+    private LocalDateTime fechaCompletado;
+
+    @Column(name = "fecha_expiracion_artefactos")
+    private LocalDateTime fechaExpiracionArtefactos;
+
+    @Column(name = "ip_cliente", length = 45)
+    private String ipCliente;
+
+    @Column(name = "user_agent", length = 500)
+    private String userAgent;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
+}

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/entity/VerificacionKYCEntity.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/entity/VerificacionKYCEntity.java
@@ -1,6 +1,7 @@
 // com.tufondo.kyc.infrastructure.persistence.entity.VerificacionKYCEntity
 package com.tufondo.kyc.infrastructure.persistence.entity;
 
+import com.tufondo.kyc.domain.model.enums.EstadoBiometria;
 import com.tufondo.kyc.domain.model.enums.EstadoVerificacion;
 import com.tufondo.kyc.domain.model.enums.NivelVerificacion;
 import jakarta.persistence.*;
@@ -64,6 +65,15 @@ public class VerificacionKYCEntity {
 
     @Column(name = "motivo_rechazo", columnDefinition = "TEXT")
     private String motivoRechazo;
+
+    /**
+     * Cache del resultado biométrico (Didit/AWS) — mantiene el listado del admin
+     * rápido sin JOIN con biometric_verification. Se actualiza por el use case
+     * que procesa el webhook del proveedor.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "estado_biometria", nullable = false, length = 30)
+    private EstadoBiometria estadoBiometria;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/jpa/ConsentimientoBiometricoJpaRepository.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/jpa/ConsentimientoBiometricoJpaRepository.java
@@ -1,0 +1,19 @@
+package com.tufondo.kyc.infrastructure.persistence.jpa;
+
+import com.tufondo.kyc.infrastructure.persistence.entity.ConsentimientoBiometricoEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface ConsentimientoBiometricoJpaRepository extends JpaRepository<ConsentimientoBiometricoEntity, UUID> {
+
+    @Query("SELECT c FROM ConsentimientoBiometricoEntity c " +
+           "WHERE c.socioId = :socioId AND c.aceptado = true AND c.fechaRevocacion IS NULL " +
+           "ORDER BY c.fechaConsentimiento DESC")
+    Optional<ConsentimientoBiometricoEntity> findVigenteBySocioId(@Param("socioId") UUID socioId);
+}

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/jpa/VerificacionBiometricaJpaRepository.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/jpa/VerificacionBiometricaJpaRepository.java
@@ -1,0 +1,21 @@
+package com.tufondo.kyc.infrastructure.persistence.jpa;
+
+import com.tufondo.kyc.infrastructure.persistence.entity.VerificacionBiometricaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface VerificacionBiometricaJpaRepository extends JpaRepository<VerificacionBiometricaEntity, UUID> {
+
+    Optional<VerificacionBiometricaEntity> findByProveedorAndProveedorSessionId(String proveedor, String sessionId);
+
+    List<VerificacionBiometricaEntity> findByVerificacionKycId(UUID verificacionKycId);
+
+    List<VerificacionBiometricaEntity> findBySocioId(UUID socioId);
+
+    void deleteAllBySocioId(UUID socioId);
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -64,6 +64,23 @@ storage:
     kyc: bucket-kyc
 
 # ============================================
+# KYC BIOMÉTRICO - PROVEEDOR DIDIT
+# ============================================
+# Habilitar solo cuando se configuren las env vars; deshabilitado por defecto
+# permite que la app arranque sin credenciales (los endpoints biométricos
+# devuelven KYCException explícita).
+fatrans:
+  kyc:
+    didit:
+      enabled: ${DIDIT_ENABLED:false}
+      api-key: ${DIDIT_API_KEY:}
+      webhook-secret: ${DIDIT_WEBHOOK_SECRET:}
+      workflow-id: ${DIDIT_WORKFLOW_ID:}
+      base-url: ${DIDIT_BASE_URL:https://verification.didit.me/v2}
+      callback-url: ${DIDIT_CALLBACK_URL:}
+      webhook-timestamp-tolerance-seconds: 300
+
+# ============================================
 # MÓDULO DOCUMENTOS PDF - CONFIGURACIÓN
 # ============================================
 documentospdf:

--- a/backend/src/main/resources/db/migration/V13__create_biometric_verification.sql
+++ b/backend/src/main/resources/db/migration/V13__create_biometric_verification.sql
@@ -1,0 +1,142 @@
+-- V13__create_biometric_verification.sql
+--
+-- Capa de persistencia para el módulo de verificación biométrica del KYC.
+--
+-- Decisiones de diseño:
+--
+-- 1. Tabla SEPARADA `biometric_verification`, no columnas en `verificacion_kyc`.
+--    Una solicitud KYC puede generar varios intentos biométricos (usuario reintenta
+--    tras un fallo de liveness). Mantenemos el histórico para auditoría LOPDP.
+--
+-- 2. NO almacenamos el template biométrico ni la imagen completa — solo:
+--      • scores (numéricos, no reversibles a imagen)
+--      • session_id del proveedor (referencia para auditoría / revocación)
+--    Esto cumple el principio de minimización LOPDP (datos biométricos sensibles).
+--
+-- 3. La columna `estado_biometria` en `verificacion_kyc` es un cache de "¿pasó la
+--    biometría?" para no tener que JOIN cada vez que listamos la cola del admin.
+--    Se mantiene sincronizada por el use case que registra el resultado del webhook.
+--
+-- 4. `biometric_consent` es una tabla aparte porque el consentimiento de datos
+--    biométricos en LOPDP venezolana exige separación del consentimiento general,
+--    versionado, revocable y con trazabilidad (ip, user-agent, timestamp).
+
+-- 1. Tabla principal de intentos biométricos.
+CREATE TABLE IF NOT EXISTS biometric_verification (
+    id                      UUID            PRIMARY KEY DEFAULT uuid_generate_v4(),
+    verificacion_kyc_id     UUID            NOT NULL REFERENCES verificacion_kyc(id) ON DELETE CASCADE,
+    socio_id                UUID            NOT NULL REFERENCES socios(id) ON DELETE CASCADE,
+
+    -- Identificación del proveedor (Didit, AWS Rekognition, etc.) — permite swap futuro.
+    proveedor               VARCHAR(50)     NOT NULL,
+    proveedor_session_id    VARCHAR(255)    NOT NULL,   -- referencia opaca del proveedor
+    proveedor_workflow_id   VARCHAR(100),               -- workflow específico (Didit usa workflow_id)
+
+    -- Estado del intento individual.
+    estado                  VARCHAR(30)     NOT NULL,
+    -- Scores 0.00–1.00 (NUMERIC(5,4) permite 4 decimales). Null = no medido aún.
+    liveness_score          NUMERIC(5,4),
+    face_match_score        NUMERIC(5,4),
+    document_ocr_score      NUMERIC(5,4),
+
+    -- Resultado textual del proveedor para diagnóstico (no PII).
+    motivo_fallo            VARCHAR(500),
+    tipo_ataque_detectado   VARCHAR(100),               -- e.g. "SPOOF_PRINT", "REPLAY"
+
+    -- URLs presignadas / referencias a artefactos en MinIO (TTL corto, 90 días).
+    selfie_storage_path     VARCHAR(500),
+    documento_storage_path  VARCHAR(500),
+
+    -- Auditoría temporal.
+    fecha_inicio            TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    fecha_completado        TIMESTAMP,
+    fecha_expiracion_artefactos TIMESTAMP,              -- cuando se borra el selfie de MinIO
+
+    -- IP y user-agent del usuario que inició el intento (LOPDP trazabilidad).
+    ip_cliente              VARCHAR(45),
+    user_agent              VARCHAR(500),
+
+    created_at              TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at              TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    version                 BIGINT,
+
+    CONSTRAINT chk_biometric_estado CHECK (estado IN (
+        'PENDIENTE',
+        'EN_PROGRESO',
+        'APROBADA',
+        'RECHAZADA',
+        'EXPIRADA',
+        'CANCELADA'
+    )),
+    CONSTRAINT chk_biometric_scores CHECK (
+        (liveness_score      IS NULL OR (liveness_score      BETWEEN 0 AND 1)) AND
+        (face_match_score    IS NULL OR (face_match_score    BETWEEN 0 AND 1)) AND
+        (document_ocr_score  IS NULL OR (document_ocr_score  BETWEEN 0 AND 1))
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_biometric_verificacion_kyc
+    ON biometric_verification (verificacion_kyc_id);
+
+CREATE INDEX IF NOT EXISTS idx_biometric_socio
+    ON biometric_verification (socio_id);
+
+CREATE INDEX IF NOT EXISTS idx_biometric_estado_fecha
+    ON biometric_verification (estado, fecha_inicio DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_biometric_proveedor_session
+    ON biometric_verification (proveedor, proveedor_session_id);
+
+
+-- 2. Cache de estado en verificacion_kyc para listados rápidos.
+ALTER TABLE verificacion_kyc
+    ADD COLUMN IF NOT EXISTS estado_biometria VARCHAR(30);
+
+-- Default para registros previos: NO_INICIADA (no rompe nada, semánticamente correcto).
+UPDATE verificacion_kyc
+    SET estado_biometria = 'NO_INICIADA'
+    WHERE estado_biometria IS NULL;
+
+ALTER TABLE verificacion_kyc
+    ALTER COLUMN estado_biometria SET NOT NULL,
+    ALTER COLUMN estado_biometria SET DEFAULT 'NO_INICIADA';
+
+ALTER TABLE verificacion_kyc
+    DROP CONSTRAINT IF EXISTS chk_verificacion_kyc_estado_biometria;
+ALTER TABLE verificacion_kyc
+    ADD CONSTRAINT chk_verificacion_kyc_estado_biometria CHECK (estado_biometria IN (
+        'NO_INICIADA',
+        'EN_PROGRESO',
+        'APROBADA',
+        'RECHAZADA',
+        'EXPIRADA'
+    ));
+
+
+-- 3. Consentimiento LOPDP biométrico (separado del consentimiento KYC general).
+CREATE TABLE IF NOT EXISTS biometric_consent (
+    id                          UUID            PRIMARY KEY DEFAULT uuid_generate_v4(),
+    socio_id                    UUID            NOT NULL REFERENCES socios(id) ON DELETE CASCADE,
+
+    -- Versión del texto de consentimiento aceptado. Cambiamos versión cuando cambie el
+    -- texto (cambio de proveedor, cambio de país de procesamiento, etc.).
+    version_politica            VARCHAR(20)     NOT NULL,
+    proveedor_destino           VARCHAR(50)     NOT NULL,    -- e.g. "DIDIT_ES"
+    pais_procesamiento          VARCHAR(50)     NOT NULL,    -- e.g. "ES" (España)
+
+    aceptado                    BOOLEAN         NOT NULL,
+    fecha_consentimiento        TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    fecha_revocacion            TIMESTAMP,                   -- LOPDP Art. 7: derecho a revocar
+
+    ip_cliente                  VARCHAR(45),
+    user_agent                  VARCHAR(500),
+
+    created_at                  TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT chk_biometric_consent_revocacion CHECK (
+        (fecha_revocacion IS NULL) OR (fecha_revocacion >= fecha_consentimiento)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_biometric_consent_socio_activo
+    ON biometric_consent (socio_id) WHERE fecha_revocacion IS NULL;

--- a/backend/src/test/java/com/tufondo/kyc/infrastructure/biometric/DiditKycAdapterTest.java
+++ b/backend/src/test/java/com/tufondo/kyc/infrastructure/biometric/DiditKycAdapterTest.java
@@ -1,0 +1,129 @@
+package com.tufondo.kyc.infrastructure.biometric;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tufondo.kyc.domain.exception.KYCException;
+import com.tufondo.kyc.domain.model.port.BiometricVerificatorPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.HexFormat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests críticos del adapter Didit centrados en la verificación del webhook (HMAC + ventana
+ * de timestamp). Si el adapter aceptara un webhook con firma inválida, un atacante podría
+ * marcar manualmente una verificación como APROBADA y burlar todo el flujo KYC.
+ *
+ * No tocamos la red real — los métodos {@code iniciarSesion} y {@code solicitarBorradoSesion}
+ * requieren e2e con Didit sandbox y se prueban en otro escenario.
+ */
+@DisplayName("DiditKycAdapter — verificación de webhook (HMAC + anti-replay)")
+class DiditKycAdapterTest {
+
+    private static final String SECRET = "test-secret-for-hmac-256";
+    private static final String SESSION_ID = "didit-sess-abc-123";
+
+    private DiditKycAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        DiditProperties props = new DiditProperties();
+        props.setEnabled(true);
+        props.setApiKey("test-api-key");
+        props.setWebhookSecret(SECRET);
+        props.setWorkflowId("test-workflow");
+        props.setWebhookTimestampToleranceSeconds(300);
+        adapter = new DiditKycAdapter(props, new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("Acepta un webhook con firma HMAC correcta y timestamp dentro de ventana")
+    void aceptaWebhookValido() {
+        byte[] body = ("""
+                {
+                  "session_id": "%s",
+                  "status": "APPROVED",
+                  "decision": {
+                    "liveness": { "score": 0.95, "attack_type": null },
+                    "face_match": { "score": 0.91 },
+                    "id_verification": { "confidence_score": 0.88 }
+                  }
+                }
+                """.formatted(SESSION_ID)).getBytes(StandardCharsets.UTF_8);
+        String signature = hmacHex(SECRET, body);
+        String timestamp = String.valueOf(Instant.now().getEpochSecond());
+
+        BiometricVerificatorPort.BiometricWebhookResult result =
+                adapter.procesarWebhook(body, signature, timestamp);
+
+        assertThat(result.sessionId()).isEqualTo(SESSION_ID);
+        assertThat(result.outcome()).isEqualTo(BiometricVerificatorPort.BiometricOutcome.APROBADO);
+        assertThat(result.livenessScore()).isEqualByComparingTo("0.95");
+        assertThat(result.faceMatchScore()).isEqualByComparingTo("0.91");
+    }
+
+    @Test
+    @DisplayName("Rechaza un webhook con firma HMAC inválida (intento de spoofing)")
+    void rechazaFirmaInvalida() {
+        byte[] body = ("{\"session_id\":\"" + SESSION_ID + "\",\"status\":\"APPROVED\"}").getBytes();
+        String wrongSignature = hmacHex("otro-secret", body);
+        String timestamp = String.valueOf(Instant.now().getEpochSecond());
+
+        assertThatThrownBy(() -> adapter.procesarWebhook(body, wrongSignature, timestamp))
+                .isInstanceOf(KYCException.class)
+                .hasMessageContaining("Firma de webhook inválida");
+    }
+
+    @Test
+    @DisplayName("Rechaza un webhook con timestamp fuera de ventana (replay attack)")
+    void rechazaTimestampViejo() {
+        byte[] body = ("{\"session_id\":\"" + SESSION_ID + "\",\"status\":\"APPROVED\"}").getBytes();
+        String signature = hmacHex(SECRET, body);
+        // 1 hora atrás → fuera de la ventana de 300s.
+        String timestamp = String.valueOf(Instant.now().getEpochSecond() - 3600);
+
+        assertThatThrownBy(() -> adapter.procesarWebhook(body, signature, timestamp))
+                .isInstanceOf(KYCException.class)
+                .hasMessageContaining("ventana temporal");
+    }
+
+    @Test
+    @DisplayName("Rechaza un webhook sin firma")
+    void rechazaSinFirma() {
+        byte[] body = "{}".getBytes();
+        assertThatThrownBy(() -> adapter.procesarWebhook(body, null, "0"))
+                .isInstanceOf(KYCException.class)
+                .hasMessageContaining("sin firma");
+    }
+
+    @Test
+    @DisplayName("Acepta firma con prefijo 'sha256=' (formato alterno común)")
+    void aceptaFirmaConPrefijoSha256() {
+        byte[] body = ("{\"session_id\":\"" + SESSION_ID + "\",\"status\":\"DECLINED\"}").getBytes();
+        String signature = "sha256=" + hmacHex(SECRET, body);
+        String timestamp = String.valueOf(Instant.now().getEpochSecond());
+
+        BiometricVerificatorPort.BiometricWebhookResult result =
+                adapter.procesarWebhook(body, signature, timestamp);
+
+        assertThat(result.outcome()).isEqualTo(BiometricVerificatorPort.BiometricOutcome.RECHAZADO);
+    }
+
+    /** Helper local: computa HMAC-SHA256 en hex (igual lógica que el adapter). */
+    private String hmacHex(String secret, byte[] body) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            return HexFormat.of().formatHex(mac.doFinal(body));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/docs/adr/0004-kyc-biometrico-didit.md
+++ b/docs/adr/0004-kyc-biometrico-didit.md
@@ -1,0 +1,130 @@
+# ADR 0004 — KYC biométrico con Didit (proveedor externo)
+
+**Fecha**: 2026-05-15
+**Estado**: Aceptada (POC en QA, monitorear antes de prod)
+**Contexto previo**: ADR 0001 (secrets), ADR 0002 (JWT), ADR 0003 (Build ID).
+
+## Contexto
+
+El módulo KYC actual de Fatrans valida documentos (cédula, selfie con cédula,
+comprobantes) pero no incluye:
+
+- **Liveness detection** (anti-spoofing). Un atacante puede subir una foto impresa
+  de la cédula y un selfie estático ajeno y completar el KYC.
+- **Face match** entre el selfie y la foto de la cédula.
+- **OCR del documento** (los datos los digita el socio manualmente, sin verificación).
+
+Sin liveness, el KYC es trivialmente burlable. Para fintech regulada, **iBeta L2**
+(ISO/IEC 30107-3) es lo defensible legalmente. Construir liveness propio expone a
+fraude de presentación masivo y LOPDP exige medidas técnicas adecuadas.
+
+## Restricciones del contexto
+
+- **Venezuela**: pagos USD complicados; muchos SaaS KYC (Onfido, Jumio, Veriff,
+  Sumsub) rechazan el onboarding del cliente en compliance interno.
+- **VPS sin GPU**: descarta self-host de modelos faciales serios.
+- **Volumen inicial bajo** (~100–1000 verificaciones/mes en arranque), creciendo
+  a ~10k/mes en año 2.
+- **LOPDP** clasifica datos biométricos como sensibles → consentimiento explícito,
+  separado, versionado y revocable.
+
+## Decisión
+
+Adoptamos **Didit** (didit.me, sede España) como proveedor primario de KYC biométrico:
+
+- **Passive liveness iBeta L1 + face match + ID document OCR + AML/PEP**, todo en
+  un solo proveedor.
+- **500 verificaciones gratis/mes** (cubre el arranque sin costo).
+- Pago **prepago en USD** desde tarjeta venezolana internacional o stablecoin.
+- Sin restricción explícita de país para Venezuela.
+- API REST + webhooks + widget JS embebible.
+
+El acceso al proveedor se hace mediante un **puerto unificado**
+`BiometricVerificatorPort` (hexagonal). Si más adelante Didit deja de servirnos,
+cambiamos el adapter sin tocar use cases ni dominio.
+
+## Alternativa de respaldo (Plan B)
+
+**AWS Rekognition Face Liveness + Textract** ($0.05–0.15 por verificación). Solo
+si Didit rechaza el onboarding del fondo o si necesitamos iBeta L3 (máscaras 3D y
+deepfakes — relevante a mediano plazo). El puerto está diseñado para que el
+adapter sea reemplazable.
+
+## Lo que NO elegimos y por qué
+
+| Opción | Por qué no |
+|---|---|
+| **InsightFace / CompreFace / MediaPipe** (self-host) | Sin liveness ISO/iBeta certificable → riesgo de fraude + incumplimiento LOPDP. |
+| **Onfido / Jumio / Veriff / Sumsub** | Compliance interno probable rechazo Venezuela; mínimos mensuales caros. |
+| **Truora** (LatAm) | Venezuela no listado oficialmente; pricing no público. |
+
+## Consecuencias
+
+### Positivas
+
+- Liveness iBeta L1 + face match desde día 0.
+- $0 costos los primeros 12–18 meses al volumen actual.
+- Adapter reemplazable (puerto hexagonal).
+- Cumplimiento LOPDP: consentimiento separado, política versionada, revocación
+  con borrado verificable en el proveedor.
+
+### Negativas / Riesgos
+
+- **Riesgo geográfico**: si Didit cambia política y restringe Venezuela, hay que
+  migrar. Mitigación: puerto abstracto + adapter AWS listo como fallback.
+- **iBeta L1 ≠ L3**: pasivos avanzados (deepfakes) pueden colar. Mitigación: el
+  analista humano sigue siendo el aprobador final (no aprobación automática).
+- **Transferencia internacional de datos biométricos a España**: la LOPDP
+  venezolana exige consentimiento expreso que mencione país y proveedor — el
+  texto del consentimiento lo hace.
+- **Dependencia de webhook**: si Didit no entrega el webhook, el flujo se queda
+  colgado. Mitigación: timeout configurable + endpoint manual de consulta a Didit
+  (no implementado en el MVP, planificado para fase 2).
+
+## Implementación (PR feature/kyc-biometric-didit)
+
+- Migración Flyway `V13__create_biometric_verification.sql`: tablas
+  `biometric_verification` y `biometric_consent` + columna `estado_biometria` en
+  `verificacion_kyc`.
+- Puerto `BiometricVerificatorPort` con 3 métodos + 4 records DTO.
+- Adapter `DiditKycAdapter` con HMAC-SHA256 + ventana de timestamp anti-replay.
+- Use cases: `RegistrarConsentimientoBiometrico`, `IniciarVerificacionBiometrica`,
+  `ProcesarWebhookBiometrico`, `RevocarConsentimientoBiometrico`.
+- Controller `BiometricController` con 4 endpoints (consentimiento, iniciar,
+  webhook público, revocar).
+- Integración en `RevisarDocumentosUseCase.aprobar()`: bloquea aprobación si
+  `estadoBiometria != APROBADA`.
+- Componente frontend `BiometricCapture.tsx` que orquesta consentimiento + abrir
+  widget Didit en pestaña nueva.
+
+## Configuración necesaria post-merge
+
+Env vars en QA (después en prod tras validar):
+
+```
+DIDIT_ENABLED=true
+DIDIT_API_KEY=...
+DIDIT_WEBHOOK_SECRET=...
+DIDIT_WORKFLOW_ID=...
+DIDIT_CALLBACK_URL=https://qa-app.fatrans.com.ve/dashboard/kyc
+```
+
+Webhook público a exponer en nginx:
+`POST https://qa-api.fatrans.com.ve/api/v1/kyc/biometric/webhook` (sin auth JWT,
+validación HMAC en el adapter).
+
+## Trabajo diferido
+
+- Integración del consentimiento biométrico en el form de registro (paso 6 del
+  stepper) — actualmente solo se pide al entrar al flujo KYC desde el dashboard.
+- Endpoint de polling para casos donde el webhook no llega.
+- Migración a iBeta L2 cuando volumen lo justifique (Didit Premium o AWS).
+- Notificación al socio cuando el resultado biométrico llegue (correo + push).
+
+## Revisión
+
+Reevaluar a los 6 meses (octubre 2026) — métricas clave:
+- Tasa de aprobación / tasa de rechazo / tasa de spoof detectado.
+- Volumen mensual contra cuota gratis.
+- Tiempo desde inicio hasta resultado.
+- Incidentes de seguridad / quejas de socios.

--- a/frontend-web/src/app/api/kyc/biometric/consentimiento/route.ts
+++ b/frontend-web/src/app/api/kyc/biometric/consentimiento/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+/**
+ * BFF: registra el consentimiento biométrico (LOPDP) del socio autenticado.
+ * Reenvía la cookie de auth y devuelve 201 en éxito.
+ */
+export async function POST(request: NextRequest) {
+  const token = request.cookies.get('access_token')?.value;
+  if (!token) {
+    return NextResponse.json({ message: 'No autenticado' }, { status: 401 });
+  }
+
+  const body = await request.json();
+
+  const backendResponse = await fetch(`${BACKEND_URL}/api/v1/kyc/biometric/consentimiento`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token.replace(/^"|"$/g, '')}`,
+      'X-Forwarded-For': request.headers.get('x-forwarded-for') || '',
+      'User-Agent': request.headers.get('user-agent') || '',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (backendResponse.status >= 500) {
+    return NextResponse.json(
+      { message: 'Servicio temporalmente no disponible' },
+      { status: 502 },
+    );
+  }
+
+  if (!backendResponse.ok) {
+    const errorData = await backendResponse.json().catch(() => ({}));
+    return NextResponse.json(
+      { message: errorData.message || 'Error registrando consentimiento' },
+      { status: backendResponse.status },
+    );
+  }
+
+  return NextResponse.json({ success: true }, { status: 201 });
+}

--- a/frontend-web/src/app/api/kyc/biometric/iniciar/route.ts
+++ b/frontend-web/src/app/api/kyc/biometric/iniciar/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+/**
+ * BFF: inicia una sesión biométrica con el proveedor (Didit) y devuelve la URL
+ * del widget para que el frontend la abra (iframe o nueva pestaña).
+ */
+export async function POST(request: NextRequest) {
+  const token = request.cookies.get('access_token')?.value;
+  if (!token) {
+    return NextResponse.json({ message: 'No autenticado' }, { status: 401 });
+  }
+
+  const backendResponse = await fetch(`${BACKEND_URL}/api/v1/kyc/biometric/iniciar`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token.replace(/^"|"$/g, '')}`,
+      'X-Forwarded-For': request.headers.get('x-forwarded-for') || '',
+      'User-Agent': request.headers.get('user-agent') || '',
+    },
+  });
+
+  if (backendResponse.status >= 500) {
+    return NextResponse.json(
+      { message: 'Servicio temporalmente no disponible' },
+      { status: 502 },
+    );
+  }
+
+  if (!backendResponse.ok) {
+    const errorData = await backendResponse.json().catch(() => ({}));
+    return NextResponse.json(
+      { message: errorData.message || 'Error iniciando verificación biométrica' },
+      { status: backendResponse.status },
+    );
+  }
+
+  const data = await backendResponse.json();
+  return NextResponse.json(data, { status: 200 });
+}

--- a/frontend-web/src/components/features/kyc/biometric-capture.tsx
+++ b/frontend-web/src/components/features/kyc/biometric-capture.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { Loader2, Camera, ShieldCheck, AlertCircle, ExternalLink } from 'lucide-react';
+import { toast } from 'sonner';
+
+/**
+ * Captura biométrica del KYC — proxy hacia el widget de Didit (passive liveness +
+ * face match + ID document OCR).
+ *
+ * Flujo:
+ *  1. Usuario acepta consentimiento LOPDP biométrico (checkbox separado del KYC general).
+ *  2. Hacemos POST a `/api/kyc/biometric/consentimiento`.
+ *  3. Hacemos POST a `/api/kyc/biometric/iniciar` → recibimos `widgetUrl`.
+ *  4. Abrimos el widget de Didit en una nueva pestaña (más seguro que iframe; Didit
+ *     usa permisos de cámara que algunos navegadores bloquean en iframes cross-origin).
+ *  5. El widget redirige al usuario de vuelta a la app; el backend recibe el resultado
+ *     por webhook y actualiza el estado. La UI sondea (o se refresca al volver) y
+ *     muestra "Verificación en revisión".
+ */
+export function BiometricCapture({
+  onCompleted,
+}: {
+  onCompleted?: () => void;
+}) {
+  const [step, setStep] = useState<'consent' | 'ready' | 'in_progress' | 'submitted'>('consent');
+  const [aceptado, setAceptado] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleAceptarConsentimiento = async () => {
+    if (!aceptado) {
+      toast.error('Debes aceptar la política biométrica');
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const res = await fetch('/api/kyc/biometric/consentimiento', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ aceptado: true, versionPolitica: '1.0' }),
+      });
+      if (!res.ok) {
+        const e = await res.json().catch(() => ({}));
+        throw new Error(e.message || 'Error registrando consentimiento');
+      }
+      setStep('ready');
+      toast.success('Consentimiento registrado');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Error');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleIniciar = async () => {
+    setIsLoading(true);
+    try {
+      const res = await fetch('/api/kyc/biometric/iniciar', {
+        method: 'POST',
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        const e = await res.json().catch(() => ({}));
+        throw new Error(e.message || 'Error iniciando verificación');
+      }
+      const data = await res.json();
+      if (!data?.widgetUrl) {
+        throw new Error('El proveedor no devolvió URL del widget');
+      }
+      // Abrir Didit en pestaña nueva — necesita permisos de cámara propios.
+      window.open(data.widgetUrl, '_blank', 'noopener,noreferrer');
+      setStep('in_progress');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Error');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleMarcarTerminado = () => {
+    setStep('submitted');
+    onCompleted?.();
+    toast.info('La verificación está siendo procesada por el proveedor');
+  };
+
+  return (
+    <Card className="w-full max-w-xl mx-auto">
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Camera className="h-5 w-5 text-blue-600" />
+          <CardTitle>Verificación biométrica</CardTitle>
+        </div>
+        <CardDescription>
+          Necesitamos confirmar que eres tú con un selfie + tu cédula. La captura
+          se procesa en Didit (proveedor externo) bajo encriptación TLS.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {step === 'consent' && (
+          <>
+            <Alert>
+              <ShieldCheck className="h-4 w-4" />
+              <AlertTitle>Consentimiento LOPDP biométrico</AlertTitle>
+              <AlertDescription className="space-y-2 text-sm">
+                <p>
+                  Tu imagen facial es un <strong>dato biométrico sensible</strong>. Será
+                  procesada por <strong>Didit</strong> (proveedor con sede en España) bajo
+                  cifrado, solo para comparar tu selfie con tu cédula y detectar suplantación.
+                </p>
+                <p>
+                  Las imágenes se eliminan a los <strong>90 días</strong>. Puedes revocar este
+                  consentimiento en cualquier momento desde tu perfil — al revocar, también
+                  se solicitará al proveedor que elimine tus datos.
+                </p>
+              </AlertDescription>
+            </Alert>
+
+            <div className="flex items-start gap-3 p-3 border rounded-lg">
+              <Checkbox
+                id="biometric-consent"
+                checked={aceptado}
+                onCheckedChange={(c) => setAceptado(c === true)}
+                disabled={isLoading}
+              />
+              <Label htmlFor="biometric-consent" className="text-sm leading-snug cursor-pointer">
+                Acepto que mi imagen facial sea procesada por Didit (España) para verificar
+                mi identidad bajo la política biométrica de Fatrans. Entiendo que es un
+                consentimiento separado del KYC documental y que puedo revocarlo.
+              </Label>
+            </div>
+
+            <Button
+              onClick={handleAceptarConsentimiento}
+              disabled={!aceptado || isLoading}
+              className="w-full bg-green-600 hover:bg-green-700"
+            >
+              {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              Aceptar y continuar
+            </Button>
+          </>
+        )}
+
+        {step === 'ready' && (
+          <>
+            <Alert>
+              <Camera className="h-4 w-4" />
+              <AlertTitle>Lo que vas a hacer</AlertTitle>
+              <AlertDescription className="text-sm">
+                Vamos a abrir el widget de Didit en una pestaña nueva. Te pedirá permiso
+                para usar la cámara, capturar tu cédula y un selfie corto. Toma menos
+                de 1 minuto.
+              </AlertDescription>
+            </Alert>
+            <Button
+              onClick={handleIniciar}
+              disabled={isLoading}
+              className="w-full bg-blue-600 hover:bg-blue-700"
+            >
+              {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <ExternalLink className="mr-2 h-4 w-4" />}
+              Abrir verificación
+            </Button>
+          </>
+        )}
+
+        {step === 'in_progress' && (
+          <>
+            <Alert>
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>Estamos esperando el resultado</AlertTitle>
+              <AlertDescription className="text-sm">
+                Completa el flujo en la pestaña que abrimos. Cuando termines, vuelve aquí
+                y presiona <em>"Ya terminé"</em>. El proveedor nos enviará el resultado
+                automáticamente en cuanto procese tu captura.
+              </AlertDescription>
+            </Alert>
+            <Button onClick={handleMarcarTerminado} variant="outline" className="w-full">
+              Ya terminé la verificación
+            </Button>
+          </>
+        )}
+
+        {step === 'submitted' && (
+          <Alert className="border-green-200 bg-green-50">
+            <ShieldCheck className="h-4 w-4 text-green-600" />
+            <AlertTitle className="text-green-900">Verificación enviada</AlertTitle>
+            <AlertDescription className="text-green-800 text-sm">
+              Tu captura está siendo procesada. Recibirás el resultado en unos minutos.
+              Puedes cerrar esta página — la decisión llegará por correo.
+            </AlertDescription>
+          </Alert>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Resumen

POC del módulo de KYC biométrico siguiendo la decisión de [ADR 0004](docs/adr/0004-kyc-biometrico-didit.md). Hasta ahora el KYC era solo documental y trivialmente burlable (foto impresa de cédula + selfie estático ajeno = aprobado).

Proveedor elegido: **Didit** (sede España).

- **500 verificaciones gratis/mes** → cubre arranque sin costo.
- **Passive liveness iBeta L1** + face match + ID OCR + AML/PEP en un solo proveedor.
- Pago **prepago en USD** desde tarjeta venezolana internacional o stablecoin.
- Sin restricción explícita para Venezuela.
- Arquitectura hexagonal: si Didit cambia política, intercambiamos el adapter sin tocar el dominio (plan B: AWS Rekognition).

## Qué incluye este PR

### Backend (hexagonal limpio)

- **V13 migration**: `biometric_verification`, `biometric_consent`, columna `estado_biometria` en `verificacion_kyc`. **NO** almacena template biométrico — solo scores numéricos no reversibles.
- **Dominio**: `VerificacionBiometrica` (con transiciones controladas), `ConsentimientoBiometrico` (con `revocar()`), enums `EstadoBiometria` + `EstadoIntentoBiometrico`.
- **Puerto unificado** `BiometricVerificatorPort` (3 métodos + 4 records DTO).
- **Adapter Didit**: HTTP REST + HMAC-SHA256 + anti-replay timestamp + comparación constant-time + soporte prefijo `sha256=`.
- **4 Use cases**: registrar consentimiento, iniciar sesión, procesar webhook (idempotente), revocar consentimiento.
- **Controller** con 4 endpoints (consentimiento/iniciar/webhook público/revocar).
- **Integración en RevisarDocumentosUseCase**: bloquea aprobación documental si biometría ≠ APROBADA.

### Frontend MVP

- BFF routes `/api/kyc/biometric/consentimiento` y `/api/kyc/biometric/iniciar`.
- Componente `BiometricCapture` con 4 pasos: consent (LOPDP separado) → ready → in_progress → submitted. Abre widget Didit en nueva pestaña.

### Tests críticos (5/5 ✓)

`DiditKycAdapterTest` cubre los escenarios de seguridad del webhook que son **el** punto crítico (si la firma se acepta mal, un atacante marca verificaciones como APROBADAS):

- ✓ Acepta webhook con HMAC válido + timestamp en ventana.
- ✓ Rechaza HMAC inválido.
- ✓ Rechaza timestamp fuera de ventana (replay attack).
- ✓ Rechaza webhook sin firma.
- ✓ Acepta prefijo `sha256=` (compat formato alterno).

### ADR

`docs/adr/0004-kyc-biometrico-didit.md` con la decisión completa: alternativas descartadas, plan B, riesgos LOPDP, revisión a 6 meses.

## LOPDP (Venezuela) — datos biométricos sensibles

Implementación cumple:

- ✓ **Consentimiento separado** del KYC documental, versionado.
- ✓ **Transferencia internacional** informada (Didit, España) en el texto del consentimiento.
- ✓ **Trazabilidad** (IP + user-agent + timestamp).
- ✓ **Revocable** (Art. 7) con borrado verificable en el proveedor.
- ✓ **Retención corta** de artefactos: imágenes en MinIO con TTL 90 días.
- ✓ **Minimización**: no se persiste template/embedding biométrico, solo scores.

## Lo que NO incluye (diferido)

- Consentimiento dentro del form de registro (paso 6 del stepper). Hoy se pide al entrar al flujo KYC.
- Endpoint de polling para casos sin webhook (timeout del proveedor).
- Notificación push/email cuando llega el resultado.
- Integración del componente en `/dashboard/kyc/page.tsx` (componente existe; falta orquestar con estados KYC actuales).

## Configuración necesaria post-merge

Variables en QA (luego prod):

```
DIDIT_ENABLED=true
DIDIT_API_KEY=<crear en didit.me>
DIDIT_WEBHOOK_SECRET=<crear en didit.me>
DIDIT_WORKFLOW_ID=<crear en didit.me>
DIDIT_CALLBACK_URL=https://qa-app.fatrans.com.ve/dashboard/kyc
```

Exponer webhook público en nginx (sin auth JWT, validación HMAC interna):
```
POST https://qa-api.fatrans.com.ve/api/v1/kyc/biometric/webhook
```

## Test plan post-merge

- [ ] Migration V13 aplica en QA sin error.
- [ ] App arranca con `DIDIT_ENABLED=false` (adapter inactivo, no rompe el módulo KYC documental).
- [ ] Con credenciales reales: `POST /consentimiento` → 201; `POST /iniciar` → 200 con `widgetUrl` poblado.
- [ ] Completar flujo en widget Didit (sandbox) → recibir webhook → estado se actualiza en BD.
- [ ] Intentar aprobar KYC documental sin biometría → 400 con mensaje explícito.
- [ ] Revocar consentimiento → borra registros locales + llama a Didit.

## Plan de revisión

Reevaluar a los 6 meses (octubre 2026) — métricas: tasa aprobación/rechazo, volumen vs cuota gratis, tiempo de procesamiento, spoofs detectados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)