### PR TITLE
fix(security): permitir POST público al webhook biométrico de Didit

### DIFF
--- a/backend/src/main/java/com/tufondo/auth/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/com/tufondo/auth/infrastructure/security/SecurityConfig.java
@@ -67,6 +67,11 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/v1/auth/**").permitAll()
                 .requestMatchers("/api/v1/socios/solicitud").permitAll()
+                // Webhook biométrico del proveedor KYC (Didit). NO usa JWT — la
+                // autenticación es por firma HMAC verificada dentro del adapter
+                // (`DiditKycAdapter#procesarWebhook`). Si exigimos JWT aquí, Didit
+                // recibe 401 y nunca confirma el resultado de las verificaciones.
+                .requestMatchers("/api/v1/kyc/biometric/webhook").permitAll()
                 .requestMatchers("/actuator/health").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/favicon.ico").permitAll()
                 .anyRequest().authenticated()


### PR DESCRIPTION
## Bug bloqueante post-merge PR #156

El endpoint `/api/v1/kyc/biometric/webhook` **NO está en el whitelist** de `SecurityConfig`. Spring Security rechaza con 401 cualquier POST de Didit antes de llegar a mi controller. Resultado: los webhooks nunca confirman los resultados → el flujo biométrico queda colgado.

## Por qué el webhook NO necesita JWT

Didit no manda cookie ni `Authorization` header. La autenticación del endpoint la hace el adapter `DiditKycAdapter` verificando **HMAC-SHA256** sobre el raw body + ventana de timestamp anti-replay (validado por 5 tests críticos en PR #156). Pedir JWT aquí rompe el flujo y no aporta seguridad.

## Fix

Agregar una línea en `SecurityConfig.java`:

```java
.requestMatchers("/api/v1/kyc/biometric/webhook").permitAll()
```

## Verificación post-merge

- [ ] `curl -X POST https://qa-api.fatrans.com.ve/api/v1/kyc/biometric/webhook` sin auth devuelve 4xx con mensaje de HMAC inválido (no 401 de Spring).
- [ ] Click "Test Webhook" en el dashboard de Didit con la firma real → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)