### PR TITLE
fix(kyc/didit): cleanup post-validación + UI integration en /dashboard/kyc

### DIFF
--- a/backend/src/main/java/com/tufondo/kyc/api/controller/BiometricController.java
+++ b/backend/src/main/java/com/tufondo/kyc/api/controller/BiometricController.java
@@ -103,29 +103,10 @@ public class BiometricController {
             sig = http.getHeader("x-signature");
         }
 
-        // ─── LOGGING TEMPORAL DE DIAGNÓSTICO ─────────────────────────────────
-        // Habilitar mientras estamos depurando el mismatch de firma con Didit.
-        // Hay que removerlo en producción real porque el body puede contener PII.
-        try {
-            String bodyStr = new String(rawBody, java.nio.charset.StandardCharsets.UTF_8);
-            // Hash del raw body (no es secret, solo para identificar mismo cuerpo entre runs).
-            String bodyHash = java.util.HexFormat.of().formatHex(
-                    java.security.MessageDigest.getInstance("SHA-256").digest(rawBody));
-            StringBuilder hdrs = new StringBuilder();
-            java.util.Enumeration<String> names = http.getHeaderNames();
-            while (names != null && names.hasMoreElements()) {
-                String n = names.nextElement();
-                String low = n.toLowerCase();
-                if (low.startsWith("x-") || low.equals("content-type") || low.equals("content-length")) {
-                    hdrs.append(n).append("=").append(http.getHeader(n)).append("; ");
-                }
-            }
-            log.warn("[DIDIT-DEBUG] webhook recibido bytes={} sha256(body)={} headers=[{}]",
-                    rawBody.length, bodyHash, hdrs);
-            // Body completo (puede ser ~20KB) loggeado aparte para no truncarlo.
-            log.warn("[DIDIT-DEBUG] RAW_BODY: {}", bodyStr);
-        } catch (Exception ignored) { }
-        // ─────────────────────────────────────────────────────────────────────
+        // Solo logueamos metadatos (length y prefijo del sessionId si quisiéramos),
+        // nunca el body completo — Didit envía datos sensibles (nombre, cédula, foto).
+        log.info("Webhook biométrico recibido: bytes={} sigType={}",
+                rawBody.length, sigV2 != null ? "v2" : "simple");
 
         procesarWebhookUseCase.ejecutar(rawBody, sig, timestamp);
         return ResponseEntity.ok().build();

--- a/backend/src/main/java/com/tufondo/kyc/application/usecase/ProcesarWebhookBiometricoUseCase.java
+++ b/backend/src/main/java/com/tufondo/kyc/application/usecase/ProcesarWebhookBiometricoUseCase.java
@@ -1,6 +1,5 @@
 package com.tufondo.kyc.application.usecase;
 
-import com.tufondo.kyc.domain.exception.KYCException;
 import com.tufondo.kyc.domain.model.VerificacionBiometrica;
 import com.tufondo.kyc.domain.model.VerificacionKYC;
 import com.tufondo.kyc.domain.model.enums.EstadoBiometria;
@@ -35,10 +34,19 @@ public class ProcesarWebhookBiometricoUseCase {
         BiometricVerificatorPort.BiometricWebhookResult result =
                 biometricPort.procesarWebhook(rawBody, signatureHeader, timestampHeader);
 
-        VerificacionBiometrica intento = biometricaRepository
-                .findByProveedorSessionId(biometricPort.getProveedor(), result.sessionId())
-                .orElseThrow(() -> new KYCException(
-                        "No existe intento biométrico para sessionId=" + result.sessionId()));
+        // Si la sesión no existe en nuestra BD (e.g. fue creada fuera del flow normal,
+        // o un Test Webhook de Didit con session_id sintético), no es un error:
+        // devolvemos sin hacer nada para que Didit no reintente indefinidamente.
+        // Loggeamos para auditoría, pero el HTTP queda 200 (no 500).
+        java.util.Optional<VerificacionBiometrica> intentoOpt = biometricaRepository
+                .findByProveedorSessionId(biometricPort.getProveedor(), result.sessionId());
+        if (intentoOpt.isEmpty()) {
+            log.warn("Webhook ignorado: no existe intento biométrico para sessionId={} (provider={}). " +
+                    "Esto es normal para Test Webhooks o sesiones creadas fuera del flujo.",
+                    result.sessionId(), biometricPort.getProveedor());
+            return;
+        }
+        VerificacionBiometrica intento = intentoOpt.get();
 
         // Idempotencia: si ya está en estado final, no reaplicar.
         if (intento.getEstado() == com.tufondo.kyc.domain.model.enums.EstadoIntentoBiometrico.APROBADA

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/biometric/DiditKycAdapter.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/biometric/DiditKycAdapter.java
@@ -189,14 +189,7 @@ public class DiditKycAdapter implements BiometricVerificatorPort {
             expectedSignature = hmacSha256Hex(props.getWebhookSecret(), canonical);
             String provided = normalizeSignature(signatureHeader.substring("v2:".length()));
             if (!constantTimeEquals(expectedSignature, provided)) {
-                // Logging diagnóstico para debug: dump del canonical body (primeros 400
-                // chars) + firma esperada y recibida. Útil cuando Didit y nosotros
-                // canonicalizamos distinto. Eliminar este log en cuanto la verificación
-                // funcione (el body puede contener PII en producción real).
-                String canonicalStr = new String(canonical, java.nio.charset.StandardCharsets.UTF_8);
-                String preview = canonicalStr.length() > 400 ? canonicalStr.substring(0, 400) + "…" : canonicalStr;
-                log.warn("Webhook Didit firma V2 inválida (timestamp={}). expected={} provided={} canonical_preview={}",
-                        timestampHeader, expectedSignature, provided, preview);
+                log.warn("Webhook Didit firma V2 inválida (timestamp={})", timestampHeader);
                 throw new KYCException("Firma de webhook inválida");
             }
         } else {

--- a/frontend-web/src/app/(dashboard)/dashboard/kyc/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/kyc/page.tsx
@@ -10,6 +10,7 @@ import {
   Check, X, Loader2, Calendar, Image as ImageIcon, Send
 } from 'lucide-react';
 import { toast } from 'sonner';
+import { BiometricCapture } from '@/components/features/kyc/biometric-capture';
 
 interface DocumentoEstado {
   id: string;
@@ -212,6 +213,16 @@ export default function DashboardKYCPagina() {
         </Card>
       ) : (
         <>
+          {/* Captura biométrica (passive liveness + face match + OCR cédula vía Didit).
+              Lo mostramos como paso previo a los documentos manuales — si el socio
+              pasa la biometría, el analista tiene mucho más contexto al revisar.
+              El componente maneja internamente: consentimiento LOPDP, abrir widget,
+              estado del intento. Solo se muestra mientras el KYC esté en estado
+              PENDIENTE o EN_REVISION (no tiene sentido si ya está APROBADO). */}
+          {(estadoKYC.estado === 'PENDIENTE' || estadoKYC.estado === 'EN_REVISION') && (
+            <BiometricCapture onCompleted={cargarEstado} />
+          )}
+
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             <div className="lg:col-span-2 space-y-6">
               <Card>


### PR DESCRIPTION
## Cierre del feature biométrico tras validar end-to-end

El adapter Didit fue validado matemáticamente con un webhook real:
```
HMAC(secret, raw_body) == X-Signature-V2 ✓
```
Los 5 webhooks reales del flujo (Gabriel Vicent, face match 98.19%, liveness 100%) pasaron firma sin logs de error.

## Cambios

### 1. `ProcesarWebhookBiometricoUseCase`: sesión inexistente → 200, no 500
Webhooks con `session_id` desconocido (Test Webhooks, sesiones fuera de flow) ya no lanzan `KYCException` → 500. Ahora hacen `log.warn` + `return` → 200. Didit deja de reintentar y el destination no queda flageado.

### 2. Revert del logging `[DIDIT-DEBUG]`
Era esencial para diagnosticar el bug del Test Webhook de Didit, pero loggeaba PII (nombre, cédula, DOB) + tokens AWS S3. Reemplazado por `log.info` mínimo (bytes + tipo de firma).

Lo mismo en `DiditKycAdapter` — quité el dump del canonical body y los hashes esperado/recibido cuando V2 falla.

### 3. `BiometricCapture` integrado en `/dashboard/kyc`
El componente existía desde PR #156 pero estaba huérfano. Ahora se renderiza condicional a estado PENDIENTE/EN_REVISION del KYC. Flujo end-to-end completo desde el dashboard.

## Bug conocido de Didit (documentado, no actionable de nuestro lado)

El Test Webhook del dashboard de Didit firma con un secret distinto al que muestra en la UI. Reproducido y verificado en Python. Los webhooks REALES sí funcionan. Si quieren rotar el secret o regenerar el webhook, el comportamiento del Test sigue siendo erroneo en el dashboard — pero los reales no se ven afectados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)