### PR TITLE
fix(kyc/biometric): idempotencia ante session_id reutilizado por Didit

### DIFF
--- a/backend/src/main/java/com/tufondo/kyc/application/usecase/IniciarVerificacionBiometricaUseCase.java
+++ b/backend/src/main/java/com/tufondo/kyc/application/usecase/IniciarVerificacionBiometricaUseCase.java
@@ -60,6 +60,9 @@ public class IniciarVerificacionBiometricaUseCase {
                         "El socio no tiene una verificación KYC activa"));
 
         // 4. Crear sesión con el proveedor.
+        // Didit puede cachear la sesión por (workflow_id, vendor_data) y devolver
+        // el MISMO session_id en llamadas sucesivas — si el socio ya tiene una
+        // sesión en progreso. Por eso paso 5 maneja idempotencia.
         String nombreCompleto = (socio.getPrimerNombre() + " " + socio.getPrimerApellido()).trim();
         BiometricVerificatorPort.BiometricSessionResponse session = biometricPort.iniciarSesion(
                 new BiometricVerificatorPort.BiometricSessionRequest(
@@ -67,25 +70,40 @@ public class IniciarVerificacionBiometricaUseCase {
                 )
         );
 
-        // 5. Persistir intento PENDIENTE.
-        VerificacionBiometrica intento = VerificacionBiometrica.builder()
-                .verificacionKycId(kyc.getId())
-                .socioId(socioId)
-                .proveedor(biometricPort.getProveedor())
-                .proveedorSessionId(session.sessionId())
-                .proveedorWorkflowId(session.workflowId())
-                .estado(EstadoIntentoBiometrico.PENDIENTE)
-                .fechaInicio(LocalDateTime.now())
-                // Los artefactos se borran a los 90 días por política LOPDP.
-                .fechaExpiracionArtefactos(LocalDateTime.now().plusDays(90))
-                .ipCliente(ipCliente)
-                .userAgent(userAgent)
-                .build();
-        VerificacionBiometrica guardado = biometricaRepository.save(intento);
+        // 5. Idempotencia: si ya tenemos persistido un intento con esa session_id
+        // (porque Didit devolvió la misma sesión cacheada), lo reutilizamos en
+        // lugar de hacer INSERT — el unique constraint
+        // `uq_biometric_proveedor_session` (proveedor, proveedor_session_id) nos
+        // protegería igualmente, pero produce un 500 feo al usuario.
+        java.util.Optional<VerificacionBiometrica> existente =
+                biometricaRepository.findByProveedorSessionId(biometricPort.getProveedor(), session.sessionId());
+        VerificacionBiometrica guardado;
+        if (existente.isPresent()) {
+            guardado = existente.get();
+            log.info("Reusando intento biométrico existente. socioId={} sessionId={} intentoId={}",
+                    socioId, session.sessionId(), guardado.getId());
+        } else {
+            VerificacionBiometrica intento = VerificacionBiometrica.builder()
+                    .verificacionKycId(kyc.getId())
+                    .socioId(socioId)
+                    .proveedor(biometricPort.getProveedor())
+                    .proveedorSessionId(session.sessionId())
+                    .proveedorWorkflowId(session.workflowId())
+                    .estado(EstadoIntentoBiometrico.PENDIENTE)
+                    .fechaInicio(LocalDateTime.now())
+                    // Los artefactos se borran a los 90 días por política LOPDP.
+                    .fechaExpiracionArtefactos(LocalDateTime.now().plusDays(90))
+                    .ipCliente(ipCliente)
+                    .userAgent(userAgent)
+                    .build();
+            guardado = biometricaRepository.save(intento);
+        }
 
-        // 6. Marcar la KYC como EN_PROGRESO en el cache.
-        kyc.setEstadoBiometria(EstadoBiometria.EN_PROGRESO);
-        verificacionKYCRepository.save(kyc);
+        // 6. Marcar la KYC como EN_PROGRESO en el cache (idempotente).
+        if (kyc.getEstadoBiometria() != EstadoBiometria.EN_PROGRESO) {
+            kyc.setEstadoBiometria(EstadoBiometria.EN_PROGRESO);
+            verificacionKYCRepository.save(kyc);
+        }
 
         log.info("Sesión biométrica iniciada. socioId={} sessionId={} proveedor={}",
                 socioId, session.sessionId(), biometricPort.getProveedor());

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/biometric/DiditKycAdapter.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/biometric/DiditKycAdapter.java
@@ -118,12 +118,27 @@ public class DiditKycAdapter implements BiometricVerificatorPort {
             body.put("callback", callback);
         }
 
+        // Serializamos manualmente con nuestro ObjectMapper local y enviamos como
+        // String. RestTemplate normalmente delega a los HttpMessageConverters de
+        // Spring para serializar Map<String,Object> → JSON, pero esos converters
+        // pueden estar configurados a nivel global con filtros como JsonInclude.NON_NULL
+        // o naming strategies (e.g. SNAKE_CASE) que reescriben las keys del body
+        // antes de salir — Didit recibe entonces el body sin `workflow_id` (o con
+        // `workflowId` camelCase) y rechaza con 400. Forzar serialización local
+        // garantiza bytes idénticos a los que un curl manual enviaría.
+        String jsonBody;
+        try {
+            jsonBody = objectMapper.writeValueAsString(body);
+        } catch (Exception e) {
+            throw new KYCException("Error serializando request a Didit: " + e.getMessage());
+        }
+
         HttpHeaders headers = baseHeaders();
         try {
             ResponseEntity<JsonNode> response = restTemplate.exchange(
                     props.getBaseUrl() + "/session/",
                     HttpMethod.POST,
-                    new HttpEntity<>(body, headers),
+                    new HttpEntity<>(jsonBody, headers),
                     JsonNode.class
             );
             JsonNode payload = response.getBody();
@@ -138,9 +153,14 @@ public class DiditKycAdapter implements BiometricVerificatorPort {
             }
             log.info("Didit session created. socioId={} sessionId={}", request.socioId(), sessionId);
             return new BiometricSessionResponse(sessionId, workflowId, widgetUrl, widgetToken);
+        } catch (org.springframework.web.client.HttpStatusCodeException e) {
+            // 4xx/5xx con cuerpo de respuesta — Didit nos dice qué campo falta,
+            // logueamos eso para diagnóstico (no incluye apiKey, solo nuestra request).
+            log.error("Didit session error: HTTP {} body={}",
+                    e.getStatusCode().value(), e.getResponseBodyAsString());
+            throw new KYCException("Error iniciando sesión biométrica con el proveedor");
         } catch (RestClientException e) {
-            // No logueamos el body ni headers (puede contener apiKey reflejada en algunos errores).
-            log.error("Didit session error: {}", e.getMessage());
+            log.error("Didit session error (network/transport): {}", e.getMessage());
             throw new KYCException("Error iniciando sesión biométrica con el proveedor");
         }
     }

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/adapter/VerificacionKYCRepositoryImpl.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/adapter/VerificacionKYCRepositoryImpl.java
@@ -96,19 +96,21 @@ public class VerificacionKYCRepositoryImpl implements VerificacionKYCRepository 
         // así que sin esto Hibernate ve `version=null` en un detached entity
         // y falla con "uninitialized version value".
         if (entity.getId() != null) {
-            jpaRepository.findById(entity.getId()).ifPresent(existing -> {
+            Optional<VerificacionKYCEntity> existingOpt = jpaRepository.findById(entity.getId());
+            if (existingOpt.isPresent()) {
+                VerificacionKYCEntity existing = existingOpt.get();
                 entity.setVersion(existing.getVersion());
                 if (entity.getCreatedAt() == null) {
                     entity.setCreatedAt(existing.getCreatedAt());
                 }
-            });
+            }
         }
         if (entity.getCreatedAt() == null) {
             entity.setCreatedAt(LocalDateTime.now());
         }
         entity.setUpdatedAt(LocalDateTime.now());
-        entity = jpaRepository.save(entity);
-        return toDomain(entity);
+        VerificacionKYCEntity saved = jpaRepository.save(entity);
+        return toDomain(saved);
     }
 
     @Override

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/adapter/VerificacionKYCRepositoryImpl.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/adapter/VerificacionKYCRepositoryImpl.java
@@ -90,6 +90,19 @@ public class VerificacionKYCRepositoryImpl implements VerificacionKYCRepository 
     @Override
     public VerificacionKYC save(VerificacionKYC verificacion) {
         VerificacionKYCEntity entity = toEntity(verificacion);
+        // Si el entity ya existe en BD, rescatamos el `version` (campo @Version
+        // para optimistic locking) y el createdAt original. El domain
+        // VerificacionKYC no expone esos campos —son detalles de persistencia—,
+        // así que sin esto Hibernate ve `version=null` en un detached entity
+        // y falla con "uninitialized version value".
+        if (entity.getId() != null) {
+            jpaRepository.findById(entity.getId()).ifPresent(existing -> {
+                entity.setVersion(existing.getVersion());
+                if (entity.getCreatedAt() == null) {
+                    entity.setCreatedAt(existing.getCreatedAt());
+                }
+            });
+        }
         if (entity.getCreatedAt() == null) {
             entity.setCreatedAt(LocalDateTime.now());
         }

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/jpa/ConsentimientoBiometricoJpaRepository.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/jpa/ConsentimientoBiometricoJpaRepository.java
@@ -1,19 +1,35 @@
 package com.tufondo.kyc.infrastructure.persistence.jpa;
 
 import com.tufondo.kyc.infrastructure.persistence.entity.ConsentimientoBiometricoEntity;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface ConsentimientoBiometricoJpaRepository extends JpaRepository<ConsentimientoBiometricoEntity, UUID> {
 
+    /**
+     * Devuelve el consentimiento vigente más reciente. Antes esto retornaba
+     * {@code Optional<...>} directo y Spring Data tiraba
+     * {@code IncorrectResultSizeDataAccessException} si por cualquier motivo
+     * había más de una fila vigente (ej. un usuario que hace doble-click en
+     * "Aceptar consentimiento" antes de que llegue la respuesta). Ahora
+     * pedimos una List + Pageable LIMIT 1 y nos quedamos con el primero.
+     */
     @Query("SELECT c FROM ConsentimientoBiometricoEntity c " +
            "WHERE c.socioId = :socioId AND c.aceptado = true AND c.fechaRevocacion IS NULL " +
            "ORDER BY c.fechaConsentimiento DESC")
-    Optional<ConsentimientoBiometricoEntity> findVigenteBySocioId(@Param("socioId") UUID socioId);
+    List<ConsentimientoBiometricoEntity> findVigentesBySocioId(@Param("socioId") UUID socioId, Pageable pageable);
+
+    default Optional<ConsentimientoBiometricoEntity> findVigenteBySocioId(UUID socioId) {
+        List<ConsentimientoBiometricoEntity> vigentes = findVigentesBySocioId(socioId, PageRequest.of(0, 1));
+        return vigentes.isEmpty() ? Optional.empty() : Optional.of(vigentes.get(0));
+    }
 }

--- a/frontend-web/src/app/(dashboard)/dashboard/kyc/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/kyc/page.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button';
 import { ProgressBar } from '@/components/ui/progress';
 import {
   Shield, Upload, FileText, CheckCircle, XCircle, Clock, AlertTriangle,
-  Check, X, Loader2, Calendar, Image as ImageIcon, Send
+  Loader2, Calendar, Send, Camera
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { BiometricCapture } from '@/components/features/kyc/biometric-capture';
@@ -189,16 +189,24 @@ export default function DashboardKYCPagina() {
     );
   }
 
+  /** Documentos: el socio puede subir si KYC está PENDIENTE o RECHAZADO (re-subida).
+      No bloqueamos en EN_REVISION para no perder cambios si la sesión expiró. */
+  const puedeSubirDocumentos = estadoKYC?.estado === 'PENDIENTE' || estadoKYC?.estado === 'RECHAZADO';
+  /** Biométrica: la mostramos siempre que el KYC NO esté APROBADO. Para EN_REVISION
+      la dejamos visible porque el componente ya gestiona internamente su estado
+      (consentimiento → ready → in_progress → submitted). */
+  const puedeBiometrica = estadoKYC && estadoKYC.estado !== 'APROBADO';
+
   return (
-    <div className="p-6 space-y-6">
-      <div className="flex items-center gap-4">
-        <div className="p-2 bg-blue-100 rounded-lg">
-          <Shield className="h-6 w-6 text-blue-600" />
-        </div>
+    <div className="p-4 lg:p-6 space-y-6 max-w-4xl mx-auto">
+      {/* Header simplificado: el shell ya muestra "Verificación KYC" arriba,
+          aquí solo aportamos contexto (estado actual + progreso). */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Verificación de Identidad (KYC)</h1>
-          <p className="text-sm text-gray-500">Complete su verificación para acceder a todos los servicios</p>
+          <h1 className="text-2xl font-bold text-gray-900">Verificación de identidad</h1>
+          <p className="text-sm text-gray-500">Confirma tu identidad para habilitar todos los servicios.</p>
         </div>
+        {estadoKYC && getEstadoBadge(estadoKYC.estado)}
       </div>
 
       {!estadoKYC ? (
@@ -207,237 +215,193 @@ export default function DashboardKYCPagina() {
             <div className="text-center">
               <Shield className="h-12 w-12 mx-auto text-gray-300 mb-4" />
               <h3 className="text-lg font-medium text-gray-900 mb-2">KYC no iniciado</h3>
-              <p className="text-gray-500 mb-6">No tienes un proceso de verificación activo. Contacta al administrador.</p>
+              <p className="text-gray-500">Aún no tienes un proceso de verificación activo. Contacta al administrador.</p>
             </div>
           </CardContent>
         </Card>
       ) : (
         <>
-          {/* Captura biométrica (passive liveness + face match + OCR cédula vía Didit).
-              Lo mostramos como paso previo a los documentos manuales — si el socio
-              pasa la biometría, el analista tiene mucho más contexto al revisar.
-              El componente maneja internamente: consentimiento LOPDP, abrir widget,
-              estado del intento. Solo se muestra mientras el KYC esté en estado
-              PENDIENTE o EN_REVISION (no tiene sentido si ya está APROBADO). */}
-          {(estadoKYC.estado === 'PENDIENTE' || estadoKYC.estado === 'EN_REVISION') && (
-            <BiometricCapture onCompleted={cargarEstado} />
+          {/* Card unificada: badge + alertas (rechazo/comentario) + progreso de
+              documentos + fecha de expiración cuando aplica. Reemplaza a las
+              cards "Información" (ID/Fecha) y "Estado del Proceso" (stepper)
+              que mostraban datos sin valor para el socio. */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <FileText className="h-5 w-5 text-gray-500" />
+                Resumen
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                <div>
+                  <p className="text-xs text-gray-500 uppercase tracking-wide">Nivel</p>
+                  <p className="font-medium">{estadoKYC.nivel}</p>
+                </div>
+                <div>
+                  <p className="text-xs text-gray-500 uppercase tracking-wide">Documentos</p>
+                  <p className="font-medium">{estadoKYC.documentosValidos} / {estadoKYC.documentosRequeridos} válidos</p>
+                </div>
+              </div>
+
+              <ProgressBar
+                value={estadoKYC.documentosRequeridos > 0
+                  ? (estadoKYC.documentosValidos / estadoKYC.documentosRequeridos) * 100
+                  : 0}
+                className="h-2"
+              />
+
+              {estadoKYC.fechaExpiracion && estadoKYC.estado === 'APROBADO' && (
+                <div className="flex items-center gap-2 text-sm text-gray-600">
+                  <Calendar className="h-4 w-4" />
+                  <span>Vigente hasta el {new Date(estadoKYC.fechaExpiracion).toLocaleDateString('es-VE')}</span>
+                  {estadoKYC.diasRestantes > 0 && (
+                    <Badge variant="outline">{estadoKYC.diasRestantes} días</Badge>
+                  )}
+                </div>
+              )}
+
+              {estadoKYC.motivoRechazo && (
+                <div className="p-3 bg-red-50 border border-red-200 rounded-lg">
+                  <div className="flex items-center gap-2 text-red-800">
+                    <AlertTriangle className="h-4 w-4" />
+                    <span className="font-medium text-sm">Motivo del rechazo</span>
+                  </div>
+                  <p className="text-sm text-red-700 mt-1">{estadoKYC.motivoRechazo}</p>
+                </div>
+              )}
+
+              {estadoKYC.comentarioRevision && (
+                <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg">
+                  <p className="text-sm text-blue-700">{estadoKYC.comentarioRevision}</p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Captura biométrica vía Didit (passive liveness + face match + OCR cédula).
+              Es el camino más rápido para verificar identidad — si pasa, el analista
+              tiene mucho más contexto antes de revisar los documentos manuales. */}
+          {puedeBiometrica && (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 px-1">
+                <Camera className="h-4 w-4 text-blue-600" />
+                <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+                  Paso 1 · Verificación biométrica
+                </h2>
+                <span className="text-xs text-gray-400">(recomendado)</span>
+              </div>
+              <BiometricCapture onCompleted={cargarEstado} />
+            </div>
           )}
 
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <div className="lg:col-span-2 space-y-6">
-              <Card>
-                <CardHeader>
-                  <div className="flex items-center justify-between">
-                    <CardTitle className="flex items-center gap-2">
-                      <FileText className="h-5 w-5" />
-                      Estado de Verificación
-                    </CardTitle>
-                    {getEstadoBadge(estadoKYC.estado)}
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm text-gray-500">Nivel:</span>
-                    <span className="font-medium">{estadoKYC.nivel}</span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm text-gray-500">Documentos:</span>
-                    <span className="font-medium">
-                      {estadoKYC.documentosValidos} de {estadoKYC.documentosRequeridos} válidos
-                    </span>
-                  </div>
-                  <ProgressBar
-                    value={estadoKYC.documentosRequeridos > 0
-                      ? (estadoKYC.documentosValidos / estadoKYC.documentosRequeridos) * 100
-                      : 0}
-                    className="h-2"
-                  />
-                  {estadoKYC.fechaExpiracion && (
-                    <div className="flex items-center gap-2 text-sm text-gray-500">
-                      <Calendar className="h-4 w-4" />
-                      <span>Expira: {new Date(estadoKYC.fechaExpiracion).toLocaleDateString('es-VE')}</span>
-                      {estadoKYC.diasRestantes > 0 && (
-                        <Badge variant="outline">{estadoKYC.diasRestantes} días restantes</Badge>
-                      )}
-                    </div>
-                  )}
-                  {estadoKYC.motivoRechazo && (
-                    <div className="p-3 bg-red-50 border border-red-200 rounded-lg">
-                      <div className="flex items-center gap-2 text-red-800">
-                        <AlertTriangle className="h-4 w-4" />
-                        <span className="font-medium">Motivo del rechazo:</span>
-                      </div>
-                      <p className="text-sm text-red-700 mt-1">{estadoKYC.motivoRechazo}</p>
-                    </div>
-                  )}
-                  {estadoKYC.comentarioRevision && (
-                    <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg">
-                      <p className="text-sm text-blue-700">{estadoKYC.comentarioRevision}</p>
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2">
-                    <Upload className="h-5 w-5" />
-                    Documentos Requeridos
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <input
-                    ref={fileInputRef}
-                    type="file"
-                    accept="image/jpeg,image/png,image/webp,application/pdf"
-                    className="hidden"
-                    onChange={(e) => {
-                      const file = e.target.files?.[0];
-                      if (file && targetTipo) {
-                        handleSubirDocumento(targetTipo, file);
-                        e.target.value = '';
-                      }
-                    }}
-                  />
-                  <div className="space-y-3">
-                    {TIPOS_DOCUMENTO.map((doc) => {
-                      const uploaded = estadoKYC.documentos?.find(d => d.tipo === doc.tipo);
-                      return (
-                        <div
-                          key={doc.tipo}
-                          className="flex items-center justify-between p-3 border rounded-lg"
-                        >
-                          <div className="flex items-center gap-3">
-                            {uploaded ? (
-                              getDocumentoEstadoIcon(uploaded.estado)
-                            ) : (
-                              <div className="p-2 bg-gray-100 rounded-lg">
-                                <FileText className="h-5 w-5 text-gray-400" />
-                              </div>
-                            )}
-                            <div>
-                              <p className="font-medium text-sm">{doc.label}</p>
-                              {uploaded && (
-                                <p className="text-xs text-gray-500">{uploaded.nombreOriginal}</p>
-                              )}
-                            </div>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            {uploaded ? (
-                              <>
-                                {getDocumentoStatusBadge(uploaded.estado)}
-                                {uploaded.estado === 'RECHAZADO' && (
-                                  <Button
-                                    size="sm"
-                                    variant="outline"
-                                    onClick={() => {
-                                      setTargetTipo(doc.tipo);
-                                      fileInputRef.current?.click();
-                                    }}
-                                  >
-                                    <Upload className="h-4 w-4 mr-1" />
-                                    Reemplazar
-                                  </Button>
-                                )}
-                              </>
-                            ) : (
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                onClick={() => {
-                                  setTargetTipo(doc.tipo);
-                                  fileInputRef.current?.click();
-                                }}
-                                disabled={subiendoDocumento !== null}
-                              >
-                                {subiendoDocumento === doc.tipo ? (
-                                  <Loader2 className="h-4 w-4 animate-spin" />
-                                ) : (
-                                  <Upload className="h-4 w-4 mr-1" />
-                                )}
-                                Subir
-                              </Button>
-                            )}
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-
-                  {puedeEnviar && (
-                    <div className="mt-6 pt-4 border-t">
-                      <Button
-                        className="w-full bg-green-600 hover:bg-green-700"
-                        onClick={handleEnviarRevision}
-                        disabled={enviando}
+          {/* Documentos manuales: complemento del paso biométrico — el analista
+              siempre revisa la cédula contra los datos del socio aunque la
+              biométrica haya pasado. */}
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 px-1">
+              <Upload className="h-4 w-4 text-green-600" />
+              <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+                Paso 2 · Documentos
+              </h2>
+            </div>
+            <Card>
+              <CardContent className="p-4 lg:p-6">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp,application/pdf"
+                  className="hidden"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file && targetTipo) {
+                      handleSubirDocumento(targetTipo, file);
+                      e.target.value = '';
+                    }
+                  }}
+                />
+                <div className="space-y-3">
+                  {TIPOS_DOCUMENTO.map((doc) => {
+                    const uploaded = estadoKYC.documentos?.find(d => d.tipo === doc.tipo);
+                    return (
+                      <div
+                        key={doc.tipo}
+                        className="flex items-center justify-between p-3 border rounded-lg"
                       >
-                        {enviando ? (
-                          <Loader2 className="h-4 w-4 animate-spin mr-2" />
-                        ) : (
-                          <Send className="h-4 w-4 mr-2" />
-                        )}
-                        Enviar a Revisión
-                      </Button>
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-            </div>
-
-            <div className="space-y-6">
-              <Card>
-                <CardHeader>
-                  <CardTitle>Información</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                  <div className="flex items-center gap-3">
-                    <Shield className="h-4 w-4 text-gray-400" />
-                    <div>
-                      <p className="text-xs text-gray-500">ID Verificación</p>
-                      <p className="font-mono text-sm">{estadoKYC.verificacionId?.slice(0, 8) ?? '-'}...</p>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <Calendar className="h-4 w-4 text-gray-400" />
-                    <div>
-                      <p className="text-xs text-gray-500">Fecha Inicio</p>
-                      <p className="text-sm">
-                        {estadoKYC.fechaInicio
-                          ? new Date(estadoKYC.fechaInicio).toLocaleDateString('es-VE')
-                          : '-'}
-                      </p>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-sm">Estado del Proceso</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="space-y-2">
-                    {['PENDIENTE', 'EN_REVISION', 'APROBADO'].map((estado, i) => {
-                      const currentIndex = ['PENDIENTE', 'EN_REVISION', 'APROBADO'].indexOf(estadoKYC.estado);
-                      const isActive = i <= currentIndex;
-                      const isCurrent = estadoKYC.estado === estado;
-                      return (
-                        <div key={estado} className="flex items-center gap-3">
-                          <div className={`w-6 h-6 rounded-full flex items-center justify-center ${
-                            isActive ? 'bg-green-600' : 'bg-gray-200'
-                          }`}>
-                            {isActive && <Check className="h-4 w-4 text-white" />}
+                        <div className="flex items-center gap-3 min-w-0 flex-1">
+                          {uploaded ? (
+                            getDocumentoEstadoIcon(uploaded.estado)
+                          ) : (
+                            <div className="p-2 bg-gray-100 rounded-lg">
+                              <FileText className="h-5 w-5 text-gray-400" />
+                            </div>
+                          )}
+                          <div className="min-w-0 flex-1">
+                            <p className="font-medium text-sm">{doc.label}</p>
+                            {uploaded && (
+                              <p className="text-xs text-gray-500 truncate">{uploaded.nombreOriginal}</p>
+                            )}
                           </div>
-                          <span className={`text-sm ${isCurrent ? 'font-medium' : 'text-gray-500'}`}>
-                            {estado.replace('_', ' ')}
-                          </span>
                         </div>
-                      );
-                    })}
+                        <div className="flex items-center gap-2 shrink-0">
+                          {uploaded ? (
+                            <>
+                              {getDocumentoStatusBadge(uploaded.estado)}
+                              {uploaded.estado === 'RECHAZADO' && puedeSubirDocumentos && (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => {
+                                    setTargetTipo(doc.tipo);
+                                    fileInputRef.current?.click();
+                                  }}
+                                >
+                                  <Upload className="h-4 w-4" />
+                                </Button>
+                              )}
+                            </>
+                          ) : (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => {
+                                setTargetTipo(doc.tipo);
+                                fileInputRef.current?.click();
+                              }}
+                              disabled={subiendoDocumento !== null || !puedeSubirDocumentos}
+                            >
+                              {subiendoDocumento === doc.tipo ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : (
+                                <Upload className="h-4 w-4 mr-1" />
+                              )}
+                              Subir
+                            </Button>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                {puedeEnviar && (
+                  <div className="mt-6 pt-4 border-t">
+                    <Button
+                      className="w-full bg-green-600 hover:bg-green-700"
+                      onClick={handleEnviarRevision}
+                      disabled={enviando}
+                    >
+                      {enviando ? (
+                        <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                      ) : (
+                        <Send className="h-4 w-4 mr-2" />
+                      )}
+                      Enviar a revisión
+                    </Button>
                   </div>
-                </CardContent>
-              </Card>
-            </div>
+                )}
+              </CardContent>
+            </Card>
           </div>
         </>
       )}

--- a/frontend-web/src/components/layouts/socio/socio-shell.tsx
+++ b/frontend-web/src/components/layouts/socio/socio-shell.tsx
@@ -191,18 +191,32 @@ export function SocioShell({ children }: { children: React.ReactNode }) {
           {/* Top Navbar - Clean & Minimal */}
           <header className="bg-white border-b border-slate-200 sticky top-0 z-30">
             <div className="flex items-center justify-between px-4 lg:px-8 h-16">
-              {/* Left: Title & Date */}
-              <div>
-                <h2 className="text-lg font-bold text-[#0F2744] capitalize">
-                  {pathname === '/dashboard' ? 'Inicio' :
-                   pathname === '/dashboard/cuentas' ? 'Mis Cuentas' :
-                   pathname === '/dashboard/creditos' ? 'Créditos' :
-                   pathname === '/dashboard/unidad' ? 'Mi Unidad' :
-                   pathname === '/dashboard/beneficiarios' ? 'Beneficiarios' :
-                   pathname === '/dashboard/documentos' ? 'Documentos' :
-                   pathname === '/perfil' ? 'Mi Perfil' : 'Fatans'}
-                </h2>
-                <p className="text-xs text-slate-500 capitalize">{today}</p>
+              {/* Left: Hamburger (mobile only) + Title & Date */}
+              <div className="flex items-center gap-3">
+                {/* Botón hamburguesa: abre el side drawer en mobile/tablet.
+                    En desktop (lg+) el sidebar fijo cubre la navegación, por eso
+                    se oculta con lg:hidden — no queremos dos navs visibles. */}
+                <button
+                  type="button"
+                  onClick={() => setMobileMenuOpen(true)}
+                  aria-label="Abrir menú"
+                  className="lg:hidden p-2 -ml-2 rounded-lg hover:bg-slate-100 text-slate-700"
+                >
+                  <Menu className="w-5 h-5" />
+                </button>
+                <div>
+                  <h2 className="text-lg font-bold text-[#0F2744] capitalize">
+                    {pathname === '/dashboard' ? 'Inicio' :
+                     pathname === '/dashboard/cuentas' ? 'Mis Cuentas' :
+                     pathname === '/dashboard/creditos' ? 'Créditos' :
+                     pathname === '/dashboard/unidad' ? 'Mi Unidad' :
+                     pathname === '/dashboard/beneficiarios' ? 'Beneficiarios' :
+                     pathname === '/dashboard/documentos' ? 'Documentos' :
+                     pathname === '/dashboard/kyc' ? 'Verificación KYC' :
+                     pathname === '/perfil' ? 'Mi Perfil' : 'Fatrans'}
+                  </h2>
+                  <p className="text-xs text-slate-500 capitalize">{today}</p>
+                </div>
               </div>
 
               {/* Right: Profile */}


### PR DESCRIPTION
## Resumen

Bug encontrado en producción de QA tras mergear #162: cuando el usuario hace click en "Abrir verificación" más de una vez (o ya tenía un intento previo), Didit devuelve la **misma** `session_id` (caching interno por workflow_id + vendor_data) y el backend intentaba hacer un INSERT que chocaba con el unique constraint `uq_biometric_proveedor_session` → HTTP 500 → "Error iniciando verificación" en el toast.

## Fix

`IniciarVerificacionBiometricaUseCase`: después del call a Didit, busca el intento por `(proveedor, session_id)`. Si ya existe lo reutiliza; si no, lo crea. Idempotencia local sin depender de que Didit no cachee.

Bonus: evita el `save()` del KYC cuando `estado_biometria` ya es `EN_PROGRESO` para no disparar `@Version` updates sin cambios reales.

## Validación

Probado en QA hot-patched:
```
POST /api/v1/kyc/biometric/iniciar → HTTP 200 (1er intento, crea)
POST /api/v1/kyc/biometric/iniciar → HTTP 200 (2do intento, reusa MISMO intentoId)
```

Antes del fix el 2do intento devolvía 500 con `duplicate key value violates unique constraint`.