### PR TITLE
fix(auth): refresh token expiration usaba epoch absoluto como offset (#178)

### DIFF
--- a/backend/src/main/java/com/tufondo/auth/application/usecase/AuthUseCase.java
+++ b/backend/src/main/java/com/tufondo/auth/application/usecase/AuthUseCase.java
@@ -126,9 +126,11 @@ public class AuthUseCase {
         String nuevoRefreshToken = jwtService.generarRefreshToken(usuario);
         String nuevoRefreshTokenHash = argon2Hasher.hash(nuevoRefreshToken);
 
-        Instant accessTokenExpiracion = jwtService.extraerExpiracionAccessToken(nuevoAccessToken);
-        Instant refreshTokenExpiracion = Instant.now()
-                .plusSeconds(refreshTokenExpiracion(nuevoRefreshToken));
+        Instant accessTokenExpiracion = jwtService.extraerExpiracion(nuevoAccessToken);
+        // FIX issue #178: el claim `exp` ya es un instante absoluto (segundos epoch),
+        // no segundos relativos. Antes se sumaba a Instant.now() generando expiraciones
+        // en el año ~3025 → sesiones efectivamente eternas.
+        Instant refreshTokenExpiracion = jwtService.extraerExpiracion(nuevoRefreshToken);
 
         Sesion nuevaSesion = Sesion.desdeParametros(
                 UUID.randomUUID(),
@@ -196,9 +198,11 @@ public class AuthUseCase {
         String refreshToken = jwtService.generarRefreshToken(usuario);
         String refreshTokenHash = argon2Hasher.hash(refreshToken);
 
-        Instant accessTokenExpiracion = jwtService.extraerExpiracionAccessToken(accessToken);
-        Instant refreshTokenExpiracion = Instant.now()
-                .plusSeconds(refreshTokenExpiracion(refreshToken));
+        Instant accessTokenExpiracion = jwtService.extraerExpiracion(accessToken);
+        // FIX issue #178: el claim `exp` ya es un instante absoluto (segundos epoch),
+        // no segundos relativos. Antes se sumaba a Instant.now() generando expiraciones
+        // en el año ~3025 → sesiones efectivamente eternas.
+        Instant refreshTokenExpiracion = jwtService.extraerExpiracion(refreshToken);
 
         Sesion sesion = Sesion.desdeParametros(
                 UUID.randomUUID(),
@@ -233,7 +237,4 @@ public class AuthUseCase {
         );
     }
 
-    private long refreshTokenExpiracion(String refreshToken) {
-        return jwtService.extraerExpiracionAccessToken(refreshToken).getEpochSecond();
-    }
 }

--- a/backend/src/main/java/com/tufondo/auth/application/usecase/ValidarTokenUseCase.java
+++ b/backend/src/main/java/com/tufondo/auth/application/usecase/ValidarTokenUseCase.java
@@ -45,7 +45,7 @@ public class ValidarTokenUseCase {
                     usuario.nombreUsuario(),
                     usuario.correoElectronico(),
                     rol,
-                    jwtService.extraerExpiracionAccessToken(token),
+                    jwtService.extraerExpiracion(token),
                     true
             );
 

--- a/backend/src/main/java/com/tufondo/auth/infrastructure/service/JwtService.java
+++ b/backend/src/main/java/com/tufondo/auth/infrastructure/service/JwtService.java
@@ -117,8 +117,25 @@ public class JwtService {
         return socioIdStr != null ? UUID.fromString(socioIdStr) : null;
     }
 
-    public Instant extraerExpiracionAccessToken(String token) {
+    /**
+     * Extrae el claim {@code exp} de cualquier JWT (access o refresh) y lo devuelve
+     * como un {@link Instant} absoluto en UTC.
+     *
+     * <p>Reemplaza al método mal nombrado {@link #extraerExpiracionAccessToken(String)},
+     * que sugería que solo aplicaba a access tokens. Usar este método tanto para
+     * access como para refresh tokens.</p>
+     */
+    public Instant extraerExpiracion(String token) {
         Claims claims = validarToken(token);
         return claims.getExpiration().toInstant();
+    }
+
+    /**
+     * @deprecated Usar {@link #extraerExpiracion(String)}. El claim {@code exp} es
+     * el mismo para access y refresh tokens; el nombre anterior inducía a error.
+     */
+    @Deprecated(forRemoval = true)
+    public Instant extraerExpiracionAccessToken(String token) {
+        return extraerExpiracion(token);
     }
 }

--- a/backend/src/main/resources/db/migration/V15__fix_sesiones_refresh_token_expiracion_corrupta.sql
+++ b/backend/src/main/resources/db/migration/V15__fix_sesiones_refresh_token_expiracion_corrupta.sql
@@ -1,0 +1,47 @@
+-- =============================================================================
+-- V15: Issue #178 - Limpieza de sesiones con refresh_token_expiracion corrupta
+-- =============================================================================
+--
+-- CONTEXTO
+-- --------
+-- Antes del fix de issue #178, `AuthUseCase.refreshTokenExpiracion(String)`
+-- usaba `Instant.now().plusSeconds(jwtService.extraerExpiracionAccessToken(token)
+-- .getEpochSecond())`. El método `getEpochSecond()` retorna un epoch ABSOLUTO
+-- (segundos desde 1970), pero el código lo sumaba a `Instant.now()` como si
+-- fuera un offset RELATIVO. Resultado: las filas insertadas durante ese período
+-- tienen `refresh_token_expiracion` en el año ~3025+, lo cual:
+--
+--   1. Hace que la verificación `Sesion.estaExpirado()` nunca retorne true
+--      por expiración (solo por `activo = false`).
+--   2. Si se roba un refresh token, sigue siendo válido por años.
+--
+-- ACCIÓN
+-- ------
+-- Invalidar (`activo = false`) toda sesión cuya `refresh_token_expiracion`
+-- esté más allá del rango razonable (> 1 año desde ahora). Esto obliga a
+-- los usuarios afectados a re-autenticarse, generando una nueva sesión con
+-- expiración correcta tras el fix.
+--
+-- SEGURIDAD: Usamos `to_regclass` porque la tabla `sesiones` es creada por
+-- Hibernate `ddl-auto: update`, no por Flyway. En entornos limpios o
+-- ambientes donde la tabla aún no exista al momento de aplicar esta
+-- migración, evitamos el fallo del script.
+-- =============================================================================
+
+DO $$
+BEGIN
+    IF to_regclass('public.sesiones') IS NOT NULL THEN
+        UPDATE sesiones
+        SET activo = false
+        WHERE activo = true
+          AND refresh_token_expiracion > (now() + INTERVAL '1 year');
+
+        -- Log informativo: cuántas filas fueron afectadas
+        RAISE NOTICE 'V15: invalidadas % sesiones con refresh_token_expiracion corrupta',
+            (SELECT count(*) FROM sesiones
+             WHERE activo = false
+               AND refresh_token_expiracion > (now() + INTERVAL '1 year'));
+    ELSE
+        RAISE NOTICE 'V15: tabla sesiones no existe aún, skip (será creada por Hibernate)';
+    END IF;
+END $$;

--- a/backend/src/test/java/com/tufondo/auth/application/usecase/AuthUseCaseTest.java
+++ b/backend/src/test/java/com/tufondo/auth/application/usecase/AuthUseCaseTest.java
@@ -20,12 +20,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.tufondo.auth.domain.model.Sesion;
+
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -85,7 +89,7 @@ class AuthUseCaseTest {
         when(passwordEncoder.matches("password123", "passwordhash")).thenReturn(true);
         when(jwtService.generarAccessToken(any())).thenReturn("access_token");
         when(jwtService.generarRefreshToken(any())).thenReturn("refresh_token");
-        when(jwtService.extraerExpiracionAccessToken(any())).thenReturn(Instant.now().plusSeconds(900));
+        when(jwtService.extraerExpiracion(any())).thenReturn(Instant.now().plusSeconds(900));
         when(argon2Hasher.hash(any())).thenReturn("hash");
 
         var result = authUseCase.login(loginRequest);
@@ -96,6 +100,50 @@ class AuthUseCaseTest {
         assertThat(result.usuario().nombreUsuario()).isEqualTo("admin_test");
         verify(sesionRepository).guardar(any());
         verify(auditService).logLoginExitoso(any(), any());
+    }
+
+    @Test
+    @DisplayName("Issue #178: refreshTokenExpiracion en sesión persistida está dentro de rango razonable (no año 3025)")
+    void login_persiste_refresh_token_expiracion_en_rango_razonable() {
+        // Arrange: simulamos el comportamiento real de JwtService.extraerExpiracion()
+        // devolviendo un Instant absoluto (epoch). Antes del fix, el código sumaba
+        // este epoch a Instant.now() generando una fecha en el año ~3025.
+        Instant accessTokenExp = Instant.now().plusSeconds(15 * 60L);          // 15 min
+        Instant refreshTokenExp = Instant.now().plusSeconds(7 * 24 * 60 * 60L); // 7 días
+
+        when(usuarioRepository.buscarPorNombreUsuario("admin_test"))
+                .thenReturn(Optional.of(usuarioTest));
+        when(passwordEncoder.matches("password123", "passwordhash")).thenReturn(true);
+        when(jwtService.generarAccessToken(any())).thenReturn("access_token");
+        when(jwtService.generarRefreshToken(any())).thenReturn("refresh_token");
+        when(jwtService.extraerExpiracion("access_token")).thenReturn(accessTokenExp);
+        when(jwtService.extraerExpiracion("refresh_token")).thenReturn(refreshTokenExp);
+        when(argon2Hasher.hash(any())).thenReturn("hash");
+
+        // Act
+        authUseCase.login(loginRequest);
+
+        // Assert: capturamos la Sesion que se persistió y validamos sus expiraciones
+        var captor = forClass(Sesion.class);
+        verify(sesionRepository).guardar(captor.capture());
+        Sesion persisted = captor.getValue();
+
+        // El refresh debe estar entre ahora y un año (TTL configurable es 7d por default)
+        Instant ahora = Instant.now();
+        assertThat(persisted.refreshTokenExpiracion())
+                .as("refresh_token_expiracion no debe estar en el pasado")
+                .isAfter(ahora.minusSeconds(5));
+        assertThat(persisted.refreshTokenExpiracion())
+                .as("refresh_token_expiracion no debe exceder 1 año (bug: año ~3025)")
+                .isBefore(ahora.plus(Duration.ofDays(365)));
+
+        // Access y refresh deben ser distintos (access ~15min, refresh ~7d)
+        assertThat(persisted.accessTokenExpiracion())
+                .as("accessTokenExpiracion debe ser distinto al refresh (TTL diferentes)")
+                .isNotEqualTo(persisted.refreshTokenExpiracion());
+        assertThat(persisted.refreshTokenExpiracion())
+                .as("refresh debe expirar después que el access")
+                .isAfter(persisted.accessTokenExpiracion());
     }
 
     @Test


### PR DESCRIPTION
Closes #178

## Resumen

`AuthUseCase.refreshTokenExpiracion(String)` calculaba la expiración del refresh token con:

```java
Instant.now().plusSeconds(jwtService.extraerExpiracionAccessToken(token).getEpochSecond())
```

`getEpochSecond()` retorna un **epoch absoluto** (segundos desde 1970), pero el código lo trataba como **offset relativo**. Resultado: `refresh_token_expiracion` en BD quedaba en el año ~3025 → la verificación `Sesion.estaExpirado()` nunca se disparaba por expiración. **Un refresh token robado quedaba válido por años.**

## Cambios

- **`AuthUseCase`**: usa `jwtService.extraerExpiracion(token)` directo. El claim `exp` ya es un `Instant` absoluto correcto. Elimina método privado buggy.
- **`JwtService`**: agrega `extraerExpiracion(String)` (semánticamente neutro para access y refresh). Deja `extraerExpiracionAccessToken` como `@Deprecated(forRemoval=true)` delegando al nuevo método.
- **`ValidarTokenUseCase`**: migra al método nuevo.
- **`AuthUseCaseTest`**: nuevo test `login_persiste_refresh_token_expiracion_en_rango_razonable` que captura la `Sesion` persistida y valida que `refreshTokenExpiracion < ahora + 1 año` y `≠ accessTokenExpiracion`.
- **`V15__fix_sesiones_refresh_token_expiracion_corrupta.sql`** (Flyway): invalida (`activo=false`) sesiones existentes con `refresh_token_expiracion > ahora + 1 año`. Usa `to_regclass` para no fallar en entornos donde la tabla aún no fue creada por Hibernate (`ddl-auto: update`).

## Resultado del build

```
mvn clean test
[INFO] Tests run: 316, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS  -- Total time: 5:32 min
```

## Test plan
- [x] Suite completa de tests del backend (316/316)
- [x] Tests específicos del módulo auth (81/81)
- [x] Nuevo test del bug pasa y valida el rango de expiración
- [ ] **QA — verificar en BD antes del deploy** cuántas sesiones están corruptas:
      ```sql
      SELECT count(*) FROM sesiones WHERE refresh_token_expiracion > now() + interval '1 year';
      ```
- [ ] **QA — después del deploy** (Flyway aplica V15 al arrancar):
      ```sql
      SELECT count(*) FROM sesiones
      WHERE refresh_token_expiracion > now() + interval '1 year' AND activo = false;
      ```
      Los dos números deben coincidir (todas las corruptas quedaron desactivadas).
- [ ] **QA funcional** con Swagger:
      - `POST /api/v1/auth/login` con `socio_prueba / Admin123!`
      - Verificar en BD: `SELECT refresh_token_expiracion FROM sesiones ORDER BY fecha_creacion DESC LIMIT 1;` debe estar en `now() + 7 días` (NO año 3025).
      - `POST /api/v1/auth/refresh` con el refresh token recibido → misma validación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)