### PR TITLE
fix(auth): eliminar enumeración de usuarios en login (#206)

### DIFF
--- a/backend/src/main/java/com/tufondo/auth/application/usecase/AuthUseCase.java
+++ b/backend/src/main/java/com/tufondo/auth/application/usecase/AuthUseCase.java
@@ -30,6 +30,19 @@ public class AuthUseCase {
     private static final int MAX_INTENTOS_FALLIDOS = 5;
     private static final int MINUTOS_BLOQUEO = 30;
 
+    /**
+     * Hash BCrypt válido de una password dummy (no usado para autenticar).
+     * Se evalúa contra {@link PasswordEncoder#matches} cuando el usuario NO existe,
+     * para que el tiempo de respuesta sea indistinguible del caso "password mala"
+     * (mitigación de enumeración por timing attack — issue #206).
+     *
+     * <p>El hash corresponde a la cadena fija "dummy-password-no-real" generada
+     * con BCrypt 10 rounds. Es seguro publicarlo: no autentica a ningún usuario
+     * real (no hay registro en BD con este hash).</p>
+     */
+    private static final String DUMMY_BCRYPT_HASH =
+            "$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy";
+
     private final UsuarioRepository usuarioRepository;
     private final SesionRepository sesionRepository;
     private final JwtService jwtService;
@@ -47,6 +60,11 @@ public class AuthUseCase {
         }
 
         Usuario usuario = usuarioOpt.orElseThrow(() -> {
+            // Mitigación timing attack (issue #206): ejecutamos un BCrypt dummy para
+            // que el tiempo de respuesta sea similar al de un usuario existente con
+            // password mala. Sin esto, el atacante distingue "user no existe" en ms
+            // vs "password mala" en ~100ms (BCrypt es deliberadamente lento).
+            passwordEncoder.matches(request.password(), DUMMY_BCRYPT_HASH);
             auditService.logLoginFallido(request.identificador(), clientIp, "usuario_no_encontrado");
             return new CredencialesInvalidasException("Credenciales inválidas");
         });

--- a/backend/src/main/java/com/tufondo/auth/infrastructure/presentation/exception/AuthExceptionHandler.java
+++ b/backend/src/main/java/com/tufondo/auth/infrastructure/presentation/exception/AuthExceptionHandler.java
@@ -16,20 +16,42 @@ import java.time.Instant;
 @Schema(description = "Manejo centralizado de excepciones")
 public class AuthExceptionHandler {
 
-    @ExceptionHandler(CredencialesInvalidasException.class)
-    @Schema(description = "Error cuando las credenciales son incorrectas")
-    public ResponseEntity<ErrorResponse> manejarCredencialesInvalidas(CredencialesInvalidasException ex) {
-        log.warn("Credenciales inválidas: {}", ex.getMessage());
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(new ErrorResponse("CREDENCIALES_INVALIDAS", ex.getMessage()));
-    }
+    /**
+     * Mensaje genérico anti-enumeración (issue #206).
+     *
+     * <p>Cualquier fallo relacionado con la identidad del usuario en flujos de
+     * autenticación devuelve el mismo cuerpo. Esto impide que un atacante
+     * distinga "usuario no existe" vs "password incorrecta" vs "sesión inválida"
+     * y enumere usuarios válidos del sistema.</p>
+     */
+    private static final String MENSAJE_CREDENCIALES_GENERICO =
+            "Credenciales inválidas. Verifica tu usuario y contraseña.";
 
-    @ExceptionHandler(UsuarioNoEncontradoException.class)
-    @Schema(description = "Error cuando el usuario no existe")
-    public ResponseEntity<ErrorResponse> manejarUsuarioNoEncontrado(UsuarioNoEncontradoException ex) {
-        log.warn("Usuario no encontrado: {}", ex.getMessage());
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponse("USUARIO_NO_ENCONTRADO", ex.getMessage()));
+    /**
+     * Handler unificado anti-enumeración para fallos de autenticación.
+     *
+     * <p>Agrupa tres excepciones que antes producían respuestas distinguibles:
+     * <ul>
+     *   <li>{@code CredencialesInvalidasException} → era 401 + mensaje específico</li>
+     *   <li>{@code UsuarioNoEncontradoException}  → era 404 + "Usuario no encontrado"</li>
+     *   <li>{@code SesionNoEncontradaException}   → era 404 + mensaje específico</li>
+     * </ul>
+     * Ahora todas devuelven exactamente el mismo body (mismo status, código y
+     * mensaje), eliminando el vector de enumeración de usuarios. La causa real
+     * se preserva en el log (warn) para detección forense.</p>
+     */
+    @ExceptionHandler({
+            CredencialesInvalidasException.class,
+            UsuarioNoEncontradoException.class,
+            SesionNoEncontradaException.class
+    })
+    @Schema(description = "Error genérico de credenciales/identidad (anti-enumeración)")
+    public ResponseEntity<ErrorResponse> manejarFalloCredenciales(RuntimeException ex) {
+        // Forensics: registramos la causa real internamente, no la propagamos al cliente.
+        log.warn("Login/credenciales fallido [{}]: {}",
+                ex.getClass().getSimpleName(), ex.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new ErrorResponse("CREDENCIALES_INVALIDAS", MENSAJE_CREDENCIALES_GENERICO));
     }
 
     @ExceptionHandler(CuentaBloqueadaException.class)
@@ -64,13 +86,7 @@ public class AuthExceptionHandler {
                 .body(new ErrorResponse("TOKEN_INVALIDO", ex.getMessage()));
     }
 
-    @ExceptionHandler(SesionNoEncontradaException.class)
-    @Schema(description = "Error cuando la sesión no existe")
-    public ResponseEntity<ErrorResponse> manejarSesionNoEncontrada(SesionNoEncontradaException ex) {
-        log.warn("Sesión no encontrada: {}", ex.getMessage());
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponse("SESION_NO_ENCONTRADA", ex.getMessage()));
-    }
+    // Nota: SesionNoEncontradaException ahora se maneja en manejarFalloCredenciales (issue #206)
 
     @ExceptionHandler(SocioNoEncontradoException.class)
     @Schema(description = "Error cuando el socio no existe")

--- a/backend/src/test/java/com/tufondo/auth/application/usecase/AuthUseCaseTest.java
+++ b/backend/src/test/java/com/tufondo/auth/application/usecase/AuthUseCaseTest.java
@@ -31,6 +31,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -158,6 +160,59 @@ class AuthUseCaseTest {
                 .isInstanceOf(CredencialesInvalidasException.class);
 
         verify(auditService).logLoginFallido(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("Issue #206: login con usuario inexistente ejecuta dummy passwordEncoder.matches (anti timing-attack)")
+    void login_usuario_inexistente_ejecuta_dummy_password_matches() {
+        // Arrange: usuario no existe ni por nombre ni por correo
+        when(usuarioRepository.buscarPorNombreUsuario("admin_test"))
+                .thenReturn(Optional.empty());
+        when(usuarioRepository.buscarPorCorreoElectronico("admin_test"))
+                .thenReturn(Optional.empty());
+
+        // Act
+        assertThatThrownBy(() -> authUseCase.login(loginRequest))
+                .isInstanceOf(CredencialesInvalidasException.class)
+                .hasMessage("Credenciales inválidas");
+
+        // Assert: passwordEncoder.matches debe haberse ejecutado UNA vez con el hash
+        // dummy. Sin esto, el atacante distingue "user no existe" (rápido) vs
+        // "password mala" (lento por BCrypt) por timing.
+        verify(passwordEncoder).matches(eq("password123"), startsWith("$2"));
+    }
+
+    @Test
+    @DisplayName("Issue #206: mensaje de login fallido por usuario inexistente es idéntico al de password incorrecta")
+    void login_usuario_inexistente_y_password_mala_producen_mismo_mensaje() {
+        // Caso A: usuario no existe
+        when(usuarioRepository.buscarPorNombreUsuario("admin_test"))
+                .thenReturn(Optional.empty(), Optional.of(usuarioTest));  // 1ra llamada vacía, 2da con user
+        when(usuarioRepository.buscarPorCorreoElectronico("admin_test"))
+                .thenReturn(Optional.empty());
+        when(passwordEncoder.matches(eq("password123"), startsWith("$2"))).thenReturn(false);
+        when(passwordEncoder.matches("password123", "passwordhash")).thenReturn(false);
+
+        String msgUsuarioInexistente = null;
+        String msgPasswordMala = null;
+
+        try {
+            authUseCase.login(loginRequest);
+        } catch (CredencialesInvalidasException e) {
+            msgUsuarioInexistente = e.getMessage();
+        }
+
+        // Caso B: usuario existe pero password mala (segunda llamada al stub)
+        try {
+            authUseCase.login(loginRequest);
+        } catch (CredencialesInvalidasException e) {
+            msgPasswordMala = e.getMessage();
+        }
+
+        assertThat(msgUsuarioInexistente)
+                .as("Ambos casos deben tirar la misma excepción con el mismo mensaje (anti-enumeración)")
+                .isNotNull()
+                .isEqualTo(msgPasswordMala);
     }
 
     @Test

--- a/backend/src/test/java/com/tufondo/auth/infrastructure/presentation/exception/AuthExceptionHandlerTest.java
+++ b/backend/src/test/java/com/tufondo/auth/infrastructure/presentation/exception/AuthExceptionHandlerTest.java
@@ -1,0 +1,73 @@
+package com.tufondo.auth.infrastructure.presentation.exception;
+
+import com.tufondo.auth.domain.exception.CredencialesInvalidasException;
+import com.tufondo.auth.domain.exception.SesionNoEncontradaException;
+import com.tufondo.auth.domain.exception.UsuarioNoEncontradoException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests para issue #206: verificar que distintas excepciones de identidad
+ * producen exactamente la misma respuesta al cliente (anti-enumeración).
+ */
+class AuthExceptionHandlerTest {
+
+    private final AuthExceptionHandler handler = new AuthExceptionHandler();
+
+    @Test
+    @DisplayName("Issue #206: CredencialesInvalidasException produce 401 con código y mensaje genéricos")
+    void credencialesInvalidas_produce_response_generico() {
+        var ex = new CredencialesInvalidasException("usuario tal-y-cual está mal");
+
+        ResponseEntity<AuthExceptionHandler.ErrorResponse> response =
+                handler.manejarFalloCredenciales(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().codigo()).isEqualTo("CREDENCIALES_INVALIDAS");
+        assertThat(response.getBody().mensaje())
+                .as("El mensaje NO debe contener detalles internos (no propaga ex.getMessage())")
+                .doesNotContain("tal-y-cual")
+                .isEqualTo("Credenciales inválidas. Verifica tu usuario y contraseña.");
+    }
+
+    @Test
+    @DisplayName("Issue #206: UsuarioNoEncontradoException produce EXACTAMENTE el mismo response que CredencialesInvalidas")
+    void usuarioNoEncontrado_produce_mismo_response_que_credenciales_invalidas() {
+        var exUsuario = new UsuarioNoEncontradoException("Usuario 'admin' no existe en BD");
+        var exCreds = new CredencialesInvalidasException("password mala");
+
+        var responseUsuario = handler.manejarFalloCredenciales(exUsuario);
+        var responseCreds = handler.manejarFalloCredenciales(exCreds);
+
+        // El cliente debe recibir respuestas indistinguibles en status, código y mensaje
+        assertThat(responseUsuario.getStatusCode()).isEqualTo(responseCreds.getStatusCode());
+        assertThat(responseUsuario.getBody().codigo()).isEqualTo(responseCreds.getBody().codigo());
+        assertThat(responseUsuario.getBody().mensaje()).isEqualTo(responseCreds.getBody().mensaje());
+
+        // Y específicamente NO debe ser el 404 + "USUARIO_NO_ENCONTRADO" del bug
+        assertThat(responseUsuario.getStatusCode()).isNotEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(responseUsuario.getBody().codigo()).isNotEqualTo("USUARIO_NO_ENCONTRADO");
+    }
+
+    @Test
+    @DisplayName("Issue #206: SesionNoEncontradaException también queda unificado en el mismo response genérico")
+    void sesionNoEncontrada_produce_mismo_response_que_credenciales_invalidas() {
+        var exSesion = new SesionNoEncontradaException("Sesión abc-123 no encontrada");
+        var exCreds = new CredencialesInvalidasException("password mala");
+
+        var responseSesion = handler.manejarFalloCredenciales(exSesion);
+        var responseCreds = handler.manejarFalloCredenciales(exCreds);
+
+        assertThat(responseSesion.getStatusCode()).isEqualTo(responseCreds.getStatusCode());
+        assertThat(responseSesion.getBody().codigo()).isEqualTo(responseCreds.getBody().codigo());
+        assertThat(responseSesion.getBody().mensaje()).isEqualTo(responseCreds.getBody().mensaje());
+
+        // No debe filtrar el ID de sesión
+        assertThat(responseSesion.getBody().mensaje()).doesNotContain("abc-123");
+    }
+}


### PR DESCRIPTION
Closes #206

## Resumen

Dos vectores complementarios de enumeración de usuarios en el flujo de login:

### Vector 1 — Respuestas distinguibles por excepción
`AuthExceptionHandler` devolvía cuerpos distintos según la causa raíz:

| Excepción | Response |
|-----------|----------|
| `CredencialesInvalidasException` | `401` + `CREDENCIALES_INVALIDAS` + `ex.message` |
| `UsuarioNoEncontradoException`   | `404` + `USUARIO_NO_ENCONTRADO` + `ex.message` |
| `SesionNoEncontradaException`    | `404` + `SESION_NO_ENCONTRADA` + `ex.message` |

→ Un atacante distinguía "usuario válido con password mala" vs "usuario no existe" y enumeraba la base de socios.

### Vector 2 — Timing attack
`AuthUseCase.login()` cuando el usuario no existía saltaba el `passwordEncoder.matches()` (BCrypt es deliberadamente lento). Respondía en milisegundos vs ~100ms del caso "password mala" → enumeración por tiempos.

## Cambios

- **`AuthExceptionHandler`**: un solo `@ExceptionHandler` unificado para las 3 excepciones de identidad, devolviendo siempre `401` + `CREDENCIALES_INVALIDAS` con mensaje hardcoded (`"Credenciales inválidas. Verifica tu usuario y contraseña."`). **No propaga `ex.getMessage()`**. El log `warn` preserva la causa real (clase de excepción + mensaje interno) para forensics.
- **`AuthUseCase.login()`**: ejecuta `passwordEncoder.matches(request.password(), DUMMY_BCRYPT_HASH)` cuando el usuario no existe. El hash dummy es un BCrypt válido pero no autentica a nadie. Iguala el tiempo de respuesta al caso "password mala".
- **`AuthUseCaseTest`** (+2 tests):
  - `login_usuario_inexistente_ejecuta_dummy_password_matches` verifica que `passwordEncoder.matches` se llama con un hash que empieza con `$2` (BCrypt prefix).
  - `login_usuario_inexistente_y_password_mala_producen_mismo_mensaje` verifica equivalencia exacta.
- **`AuthExceptionHandlerTest`** (nuevo, 3 tests):
  - Mensaje genérico no contiene detalles internos.
  - `UsuarioNoEncontradoException` produce response idéntico a `CredencialesInvalidasException`.
  - `SesionNoEncontradaException` también queda unificado.

## Resultado del build

```
mvn clean test
[INFO] Tests run: 321, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS  -- Total time: 5:42 min
```

(316 previos + 5 nuevos del fix.)

## Test plan
- [x] Suite completa del backend con `mvn clean test` (321/321)
- [x] Tests específicos del módulo auth (86/86)
- [x] Tests específicos del bug pasan
- [ ] **QA con curl/Swagger**:
  ```bash
  # Caso A: usuario inexistente
  time curl -X POST http://qa-app.fatrans.com.ve/api/v1/auth/login \
    -H 'Content-Type: application/json' \
    -d '{"identificador":"usuario_inventado","password":"loquesea"}' -i

  # Caso B: usuario válido con password mala
  time curl -X POST http://qa-app.fatrans.com.ve/api/v1/auth/login \
    -H 'Content-Type: application/json' \
    -d '{"identificador":"socio_prueba","password":"passwordMala"}' -i
  ```
  **Esperado:**
  - **Mismo status** (`401 Unauthorized`)
  - **Mismo body** exacto: `{"codigo":"CREDENCIALES_INVALIDAS","mensaje":"Credenciales inválidas. Verifica tu usuario y contraseña.","timestamp":"..."}`
  - **Tiempos similares** (ambos ~100-200ms, no uno en 10ms y otro en 200ms)
- [ ] **QA — login válido** con `socio_prueba / Admin123!` sigue funcionando correctamente.

## Scope no incluido (para issues separados)
- **BFF**: 66+ archivos en `frontend-web/src/app/api/**/route.ts` propagan `errorData.message`. No es necesario tocarlos porque el backend ya devuelve mensajes genéricos, pero queda como deuda para defensa en profundidad.
- **Registro**: `NombreUsuarioYaExisteException` también permite enumerar (al registrarse). Es un vector distinto, scope de otra issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)