### PR TITLE
feat(socios): validar mayoría de edad (≥18) en registro (#204)

### DIFF
--- a/backend/src/main/java/com/tufondo/socios/application/dto/SolicitudRegistroRequestDTO.java
+++ b/backend/src/main/java/com/tufondo/socios/application/dto/SolicitudRegistroRequestDTO.java
@@ -1,6 +1,7 @@
 // 📁 com/tufondo/socios/application/dto/SolicitudRegistroRequestDTO.java
 package com.tufondo.socios.application.dto;
 
+import com.tufondo.socios.application.validation.MayorDeEdad;
 import com.tufondo.socios.domain.model.enums.EstadoCivil;
 import com.tufondo.socios.domain.model.enums.Genero;
 import com.tufondo.socios.domain.model.enums.TipoDocumento;
@@ -35,6 +36,7 @@ public class SolicitudRegistroRequestDTO {
 
     @NotNull(message = "La fecha de nacimiento es obligatoria")
     @Past(message = "La fecha de nacimiento debe ser una fecha pasada")
+    @MayorDeEdad(edadMinima = 18, message = "Debes tener al menos 18 años para registrarte")
     private LocalDate fechaNacimiento;
 
     @NotNull(message = "El género es obligatorio")

--- a/backend/src/main/java/com/tufondo/socios/application/validation/MayorDeEdad.java
+++ b/backend/src/main/java/com/tufondo/socios/application/validation/MayorDeEdad.java
@@ -1,0 +1,42 @@
+package com.tufondo.socios.application.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Valida que un {@link java.time.LocalDate} representa una fecha de nacimiento
+ * de una persona con al menos {@link #edadMinima()} años cumplidos al día de hoy.
+ *
+ * <p>Bloqueante legal (issue #204): Venezuela exige mayoría de edad (≥18) para
+ * operaciones financieras (LOPNNA y Sudeban). Permitir registro de menores
+ * expone a la institución a multas regulatorias.</p>
+ *
+ * <p>Acepta {@code null}; combinar con {@code @NotNull} si el campo es requerido.</p>
+ *
+ * <pre>{@code
+ *  @NotNull
+ *  @MayorDeEdad
+ *  private LocalDate fechaNacimiento;
+ * }</pre>
+ */
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MayorDeEdadValidator.class)
+public @interface MayorDeEdad {
+
+    /**
+     * Edad mínima requerida en años cumplidos. Default: 18.
+     */
+    int edadMinima() default 18;
+
+    String message() default "Debes tener al menos {edadMinima} años para registrarte";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/com/tufondo/socios/application/validation/MayorDeEdadValidator.java
+++ b/backend/src/main/java/com/tufondo/socios/application/validation/MayorDeEdadValidator.java
@@ -1,0 +1,44 @@
+package com.tufondo.socios.application.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.ZoneId;
+
+/**
+ * Validator de {@link MayorDeEdad}. Calcula edad cumplida al día de hoy
+ * (zona horaria del servidor) usando {@link Period#between}.
+ *
+ * <p>{@code null} se considera válido — el caller debe combinar con
+ * {@code @NotNull} si la fecha es requerida.</p>
+ */
+public class MayorDeEdadValidator implements ConstraintValidator<MayorDeEdad, LocalDate> {
+
+    private int edadMinima;
+
+    @Override
+    public void initialize(MayorDeEdad constraintAnnotation) {
+        this.edadMinima = constraintAnnotation.edadMinima();
+    }
+
+    @Override
+    public boolean isValid(LocalDate fechaNacimiento, ConstraintValidatorContext context) {
+        if (fechaNacimiento == null) {
+            // Delegar la validación de null a @NotNull. No validamos aquí para
+            // permitir composición flexible.
+            return true;
+        }
+
+        LocalDate hoy = LocalDate.now(ZoneId.systemDefault());
+
+        // Si la fecha está en el futuro o es hoy mismo, no hay edad válida.
+        if (!fechaNacimiento.isBefore(hoy)) {
+            return false;
+        }
+
+        int edadCumplida = Period.between(fechaNacimiento, hoy).getYears();
+        return edadCumplida >= edadMinima;
+    }
+}

--- a/backend/src/test/java/com/tufondo/socios/application/dto/SolicitudRegistroRequestDTOTest.java
+++ b/backend/src/test/java/com/tufondo/socios/application/dto/SolicitudRegistroRequestDTOTest.java
@@ -163,6 +163,51 @@ class SolicitudRegistroRequestDTOTest {
                     .collect(java.util.stream.Collectors.toSet());
             assertThat(violations).doesNotContain("fechaNacimiento");
         }
+
+        @Test
+        @DisplayName("Issue #204: persona con exactamente 18 años recién cumplidos pasa")
+        void edad_18_exacta_Pasa() {
+            SolicitudRegistroRequestDTO request = createValidRequest();
+            request.setFechaNacimiento(LocalDate.now().minusYears(18));
+            Set<String> violations = validator.validate(request).stream()
+                    .map(v -> v.getPropertyPath().toString())
+                    .collect(java.util.stream.Collectors.toSet());
+            assertThat(violations).doesNotContain("fechaNacimiento");
+        }
+
+        @Test
+        @DisplayName("Issue #204: persona con 17 años NO debe pasar (bloqueo LOPNNA)")
+        void edad_17_Falla() {
+            SolicitudRegistroRequestDTO request = createValidRequest();
+            request.setFechaNacimiento(LocalDate.now().minusYears(17));
+            Set<String> violations = validator.validate(request).stream()
+                    .map(v -> v.getPropertyPath().toString())
+                    .collect(java.util.stream.Collectors.toSet());
+            assertThat(violations).contains("fechaNacimiento");
+        }
+
+        @Test
+        @DisplayName("Issue #204: persona con 17 años y 364 días NO debe pasar")
+        void edad_17_y_364_dias_Falla() {
+            SolicitudRegistroRequestDTO request = createValidRequest();
+            // Fecha que da exactamente 17 años + 364 días (un día antes del 18 cumpleaños)
+            request.setFechaNacimiento(LocalDate.now().minusYears(18).plusDays(1));
+            Set<String> violations = validator.validate(request).stream()
+                    .map(v -> v.getPropertyPath().toString())
+                    .collect(java.util.stream.Collectors.toSet());
+            assertThat(violations).contains("fechaNacimiento");
+        }
+
+        @Test
+        @DisplayName("Issue #204: fecha futura falla (cubre tanto @Past como @MayorDeEdad)")
+        void fechaFutura_Falla() {
+            SolicitudRegistroRequestDTO request = createValidRequest();
+            request.setFechaNacimiento(LocalDate.now().plusDays(1));
+            Set<String> violations = validator.validate(request).stream()
+                    .map(v -> v.getPropertyPath().toString())
+                    .collect(java.util.stream.Collectors.toSet());
+            assertThat(violations).contains("fechaNacimiento");
+        }
     }
 
     @Nested

--- a/backend/src/test/java/com/tufondo/socios/application/validation/MayorDeEdadValidatorTest.java
+++ b/backend/src/test/java/com/tufondo/socios/application/validation/MayorDeEdadValidatorTest.java
@@ -1,0 +1,108 @@
+package com.tufondo.socios.application.validation;
+
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests para issue #204: validación de mayoría de edad en registro.
+ */
+class MayorDeEdadValidatorTest {
+
+    private MayorDeEdadValidator validator;
+    private ConstraintValidatorContext context;
+
+    @BeforeEach
+    void setUp() {
+        validator = new MayorDeEdadValidator();
+        context = Mockito.mock(ConstraintValidatorContext.class);
+        // Default: edadMinima = 18
+        validator.initialize(annotation(18));
+    }
+
+    @Test
+    @DisplayName("null se considera válido (delegar a @NotNull)")
+    void null_es_valido() {
+        assertThat(validator.isValid(null, context)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Persona con 18 años recién cumplidos es válida")
+    void edad_exacta_18_es_valida() {
+        LocalDate hace18Anios = LocalDate.now().minusYears(18);
+        assertThat(validator.isValid(hace18Anios, context)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Persona con 18 años + 1 día es válida")
+    void edad_18_y_un_dia_es_valida() {
+        LocalDate fecha = LocalDate.now().minusYears(18).minusDays(1);
+        assertThat(validator.isValid(fecha, context)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Persona con 17 años + 364 días NO es válida (todavía no cumplió 18)")
+    void edad_17_y_364_dias_no_es_valida() {
+        // Justo el día antes del cumpleaños 18: aún tiene 17 años cumplidos
+        LocalDate fecha = LocalDate.now().minusYears(18).plusDays(1);
+        assertThat(validator.isValid(fecha, context)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Persona de 17 años (un año antes) NO es válida")
+    void edad_17_no_es_valida() {
+        LocalDate hace17Anios = LocalDate.now().minusYears(17);
+        assertThat(validator.isValid(hace17Anios, context)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Persona de 10 años NO es válida")
+    void edad_10_no_es_valida() {
+        LocalDate hace10Anios = LocalDate.now().minusYears(10);
+        assertThat(validator.isValid(hace10Anios, context)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Fecha futura NO es válida")
+    void fecha_futura_no_es_valida() {
+        LocalDate manana = LocalDate.now().plusDays(1);
+        assertThat(validator.isValid(manana, context)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Fecha igual a hoy NO es válida (recién nacido)")
+    void fecha_hoy_no_es_valida() {
+        assertThat(validator.isValid(LocalDate.now(), context)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Persona de 21 años con edadMinima=21 es válida")
+    void edad_minima_configurable_21() {
+        validator.initialize(annotation(21));
+        LocalDate hace21Anios = LocalDate.now().minusYears(21);
+        assertThat(validator.isValid(hace21Anios, context)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Persona de 20 años con edadMinima=21 NO es válida")
+    void edad_minima_configurable_20_falla() {
+        validator.initialize(annotation(21));
+        LocalDate hace20Anios = LocalDate.now().minusYears(20);
+        assertThat(validator.isValid(hace20Anios, context)).isFalse();
+    }
+
+    /**
+     * Crea un mock de la anotación con la edad mínima configurada.
+     */
+    private MayorDeEdad annotation(int edadMinima) {
+        MayorDeEdad ann = Mockito.mock(MayorDeEdad.class);
+        Mockito.when(ann.edadMinima()).thenReturn(edadMinima);
+        return ann;
+    }
+}

--- a/frontend-web/src/lib/utils/validators.test.ts
+++ b/frontend-web/src/lib/utils/validators.test.ts
@@ -221,6 +221,71 @@ describe('registroSchema - Validaciones Issue #99', () => {
       expect(result.success).toBe(false);
     });
 
+    // ===== Issue #204: Validación de mayoría de edad (≥18) =====
+
+    /**
+     * Formatea una fecha de cumpleaños relativa a hoy en formato "YYYY-MM-DD".
+     * Helper para tests independientes del año en que se ejecutan.
+     */
+    const fechaConOffset = (anios: number, dias: number = 0): string => {
+      const hoy = new Date();
+      const f = new Date(hoy.getFullYear() - anios, hoy.getMonth(), hoy.getDate() + dias);
+      const yyyy = f.getFullYear();
+      const mm = String(f.getMonth() + 1).padStart(2, '0');
+      const dd = String(f.getDate()).padStart(2, '0');
+      return `${yyyy}-${mm}-${dd}`;
+    };
+
+    const baseValido = {
+      nombreCompleto: 'Juan Pérez',
+      tipoDocumento: 'CEDULA' as const,
+      cedula: 'V-12345678',
+      genero: 'MASCULINO' as const,
+      estadoCivil: 'SOLTERO' as const,
+      correoElectronico: 'juan@test.com',
+      telefono: '04121234567',
+      empresa: 'Empresa Test',
+      aceptaTerminos: true as const,
+      aceptaLopdp: true as const,
+    };
+
+    it('Issue #204: persona con exactamente 18 años recién cumplidos pasa', () => {
+      const result = registroSchema.safeParse({
+        ...baseValido,
+        fechaNacimiento: fechaConOffset(18, 0),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('Issue #204: persona con 17 años falla con mensaje claro', () => {
+      const result = registroSchema.safeParse({
+        ...baseValido,
+        fechaNacimiento: fechaConOffset(17, 0),
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issueFecha = result.error.issues.find(i => i.path.includes('fechaNacimiento'));
+        expect(issueFecha?.message).toBe('Debes tener al menos 18 años para registrarte');
+      }
+    });
+
+    it('Issue #204: persona con 17 años y 364 días falla (1 día antes del 18)', () => {
+      const result = registroSchema.safeParse({
+        ...baseValido,
+        // Nacimiento mañana hace 18 años → todavía tiene 17 hoy
+        fechaNacimiento: fechaConOffset(18, 1),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('Issue #204: persona con 30 años pasa (caso típico)', () => {
+      const result = registroSchema.safeParse({
+        ...baseValido,
+        fechaNacimiento: fechaConOffset(30, 0),
+      });
+      expect(result.success).toBe(true);
+    });
+
   });
 
   describe('5. Género', () => {

--- a/frontend-web/src/lib/utils/validators.ts
+++ b/frontend-web/src/lib/utils/validators.ts
@@ -81,10 +81,18 @@ export const registroSchema = z.object({
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/, 'Fecha inválida. Formato: YYYY-MM-DD')
     .refine((val) => {
-      const date = new Date(val);
-      const now = new Date();
-      return date < now;
-    }, 'La fecha de nacimiento debe ser pasada'),
+      // Issue #204: validar mayoría de edad (≥18). Bloqueante legal (LOPNNA).
+      // Parseamos manualmente para evitar problemas de timezone con `new Date(val)`,
+      // que interpreta "YYYY-MM-DD" como UTC y puede restar un día en zonas negativas.
+      const [year, month, day] = val.split('-').map(Number);
+      const hoy = new Date();
+      const cumpleEste = new Date(hoy.getFullYear(), month - 1, day);
+      let edad = hoy.getFullYear() - year;
+      if (hoy < cumpleEste) {
+        edad -= 1; // aún no ha cumplido años este año
+      }
+      return edad >= 18;
+    }, 'Debes tener al menos 18 años para registrarte'),
   genero: z.enum(GENEROS, { required_error: 'El género es obligatorio' }),
   estadoCivil: z.enum(ESTADOS_CIVILES, { required_error: 'El estado civil es obligatorio' }),
   correoElectronico: z


### PR DESCRIPTION
Closes #204

## Resumen

Bloqueante legal P0 — Venezuela exige mayoría de edad para operaciones bancarias:
- **LOPNNA**: prohibición de tratamiento de datos de menores sin consentimiento parental.
- **Sudeban**: banca requiere mayoría de edad para abrir cuentas / contratar.

`SolicitudRegistroRequestDTO.fechaNacimiento` solo tenía `@Past`. Un menor con cualquier fecha pasada se podía registrar. Mismo problema en frontend (`registroSchema.fechaNacimiento` solo validaba \`date < now\`).

## Cambios

### Backend
- **Nueva anotación reutilizable** `@MayorDeEdad(edadMinima = 18)` (`socios.application.validation`):
  - Validator implementa `ConstraintValidator<MayorDeEdad, LocalDate>`.
  - Cálculo de edad con `Period.between` (maneja años bisiestos correctamente).
  - Acepta \`null\` (delega a `@NotNull` para composición flexible).
  - `edadMinima` configurable (default 18, también permite 21 u otros para casos especiales).
- **`SolicitudRegistroRequestDTO`**: aplicado en `fechaNacimiento` combinado con `@NotNull` + `@Past`.

### Frontend
- **`registroSchema.fechaNacimiento`**: refine con cálculo de edad por componentes (parsea \`YYYY-MM-DD\` manualmente para evitar bug de timezone — \`new Date(\"YYYY-MM-DD\")\` interpreta como UTC y resta un día en zonas negativas como Venezuela GMT-4).

## Tests (TDD verificado con experimento reverso)

| Test | Tipo | SIN fix | CON fix |
|------|------|---------|---------|
| `MayorDeEdadValidatorTest` (10 casos) | unitario validator | N/A (sin código no compila) | ✅ 10/10 |
| `SolicitudRegistroRequestDTOTest.edad_17_Falla` | DTO regression | ❌ FAIL (acepta menor) | ✅ PASS |
| `SolicitudRegistroRequestDTOTest.edad_17_y_364_dias_Falla` | DTO regression | ❌ FAIL | ✅ PASS |
| `validators.test.ts > 17 años falla con mensaje claro` | frontend regression | ❌ FAIL | ✅ PASS |
| `validators.test.ts > 17 años y 364 días falla` | frontend regression | ❌ FAIL | ✅ PASS |
| Casos felices (18 exacto, 30 años) | documentación | ✅ PASS | ✅ PASS |

**Total: 14 tests que detectan regresión real del fix** (10 validator + 2 DTO + 2 frontend).

Helper `fechaConOffset(anios, dias)` en frontend para tests independientes del año en que se ejecutan.

## Resultado del build

```
mvn clean test
[INFO] Tests run: 335, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS  -- Total time: 6:59 min

vitest run src/lib/utils/validators.test.ts
Tests  51 passed (51)
```

## Test plan QA

- [ ] **Registro frontend**: probar formulario con fecha de hace 17 años → error inline \"Debes tener al menos 18 años para registrarte\".
- [ ] **Registro frontend**: fecha de hace 18 años exactos → pasa al siguiente paso.
- [ ] **Bypass al backend con curl** (defensa en profundidad):
  ```bash
  curl -X POST http://qa-app.fatrans.com.ve/api/v1/auth/registro \
    -H 'Content-Type: application/json' \
    -d '{
      \"nombreCompleto\":\"Test Menor\",
      \"tipoDocumento\":\"CEDULA\",
      \"cedula\":\"V-99999999\",
      \"fechaNacimiento\":\"2010-01-01\",
      \"genero\":\"MASCULINO\",
      \"estadoCivil\":\"SOLTERO\",
      \"correoElectronico\":\"test@menor.com\",
      \"telefono\":\"04121234567\",
      \"empresa\":\"Test\",
      \"aceptaTerminos\":true,
      \"aceptaLopdp\":true
    }' -i
  ```
  Esperado: \`400\` con violación en \`fechaNacimiento\` y mensaje \"Debes tener al menos 18 años para registrarte\".
- [ ] **Registro válido** con fecha que da 30 años → 201 Created como hasta ahora.

## Scope no incluido (para issues separados)

- `profileSchema.fechaNacimiento` (perfil de usuario, no registro) → aplicar mismo refine si en algún momento se permite editar.
- KYC: si el flujo permite cambiar fecha de nacimiento, también debería usar `@MayorDeEdad`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)