### PR TITLE
fix(security): @PreAuthorize + ownership en 6 endpoints sensibles (#179)

### DIFF
--- a/backend/src/main/java/com/tufondo/ahorros/api/controller/AhorroController.java
+++ b/backend/src/main/java/com/tufondo/ahorros/api/controller/AhorroController.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.web.bind.annotation.*;
@@ -50,12 +51,17 @@ public class AhorroController {
     private final CalcularRendimientosBatchUseCase calcularRendimientosBatchUseCase;
 
     // 1. POST /cuentas - Crear Cuenta
+    // Issue #179: @PreAuthorize asegura autenticación; el use case valida ownership
+    // (un socio solo puede crear cuenta para sí mismo; admin puede para cualquiera).
     @PostMapping
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Crear cuenta de ahorro")
     public ResponseEntity<CuentaAhorroResponse> crearCuenta(
             @Valid @RequestBody CreateCuentaAhorroRequest request,
             Authentication authentication) {
-        CuentaAhorroResponse response = crearCuentaUseCase.ejecutar(request);
+        UUID socioIdToken = extraerSocioId(authentication);
+        boolean isAdmin = esAdmin(authentication);
+        CuentaAhorroResponse response = crearCuentaUseCase.ejecutar(request, socioIdToken, isAdmin);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 

--- a/backend/src/main/java/com/tufondo/ahorros/application/usecase/CrearCuentaAhorroUseCase.java
+++ b/backend/src/main/java/com/tufondo/ahorros/application/usecase/CrearCuentaAhorroUseCase.java
@@ -10,8 +10,11 @@ import com.tufondo.ahorros.domain.model.CuentaAhorro;
 import com.tufondo.ahorros.domain.model.valueobjects.NumeroCuenta;
 import com.tufondo.ahorros.domain.repository.CuentaAhorroRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 /**
  * Caso de uso para crear una cuenta de ahorro.
@@ -24,8 +27,41 @@ public class CrearCuentaAhorroUseCase {
     private final CuentaAhorroRepository cuentaRepository;
     private final AhorrosDTOMapper mapper;
 
+    /**
+     * @deprecated Issue #179: usar {@link #ejecutar(CreateCuentaAhorroRequest, UUID, boolean)}
+     * que valida ownership. Esta firma permitía IDOR (un socio creando cuenta a nombre
+     * de otro). Mantenida temporalmente para compatibilidad de tests legacy; será removida.
+     */
+    @Deprecated(forRemoval = true)
     @Transactional
     public CuentaAhorroResponse ejecutar(CreateCuentaAhorroRequest request) {
+        // Llamar al método con check de ownership desactivado (modo "sistema/admin").
+        // SOLO para llamadas internas o de admin que YA validaron permisos arriba.
+        return ejecutar(request, null, true);
+    }
+
+    /**
+     * Crea una cuenta de ahorro validando que el socioId del request pertenezca
+     * al usuario autenticado (anti-IDOR — issue #179).
+     *
+     * @param request datos de la cuenta
+     * @param socioIdToken socioId extraído del JWT (puede ser {@code null} si {@code isAdmin})
+     * @param isAdmin si el caller tiene rol ADMIN (puede crear cuenta para cualquier socio)
+     * @throws AccessDeniedException si NO es admin y {@code request.socioId != socioIdToken}
+     */
+    @Transactional
+    public CuentaAhorroResponse ejecutar(CreateCuentaAhorroRequest request,
+                                         UUID socioIdToken,
+                                         boolean isAdmin) {
+        // Issue #179: anti-IDOR. Un socio solo puede crear cuentas para sí mismo.
+        // Admin puede crear cuentas para cualquier socio (operación back-office).
+        if (!isAdmin) {
+            if (socioIdToken == null || !socioIdToken.equals(request.getSocioId())) {
+                throw new AccessDeniedException(
+                        "No tiene permisos para crear una cuenta a nombre de otro socio");
+            }
+        }
+
         // Verificar RN-001: Un socio solo puede tener una cuenta por tipo
         if (cuentaRepository.existePorSocioIdYTipo(request.getSocioId(), request.getTipoCuenta())) {
             throw new CuentaDuplicadaException(request.getSocioId(), request.getTipoCuenta().name());

--- a/backend/src/main/java/com/tufondo/auth/infrastructure/presentation/controller/AuthController.java
+++ b/backend/src/main/java/com/tufondo/auth/infrastructure/presentation/controller/AuthController.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseCookie;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -255,12 +256,18 @@ public class AuthController {
         return ResponseEntity.ok(validarTokenUseCase.ejecutar(token));
     }
 
+    // Issue #179: este endpoint era accesible sin token (estaba en `shouldNotFilter`
+    // del JwtAuthenticationFilter). Ahora requiere JWT + rol ADMIN. Casos de uso
+    // legítimos: back-office crea credenciales para un socio aprobado tras KYC.
     @PostMapping("/crear-usuario")
-    @Operation(summary = "Crear usuario vinculado a socio",
-               description = "Vincula un Socio existente con credenciales de acceso (Usuario)")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Crear usuario vinculado a socio (solo admin)",
+               description = "Vincula un Socio existente con credenciales de acceso (Usuario). Requiere rol ADMIN.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Usuario creado exitosamente",
                     content = @Content(schema = @Schema(implementation = CrearUsuarioResponseDTO.class))),
+            @ApiResponse(responseCode = "401", description = "No autenticado"),
+            @ApiResponse(responseCode = "403", description = "Sin permisos (rol ADMIN requerido)"),
             @ApiResponse(responseCode = "404", description = "Socio no encontrado"),
             @ApiResponse(responseCode = "409", description = "Nombre de usuario ya existe o socio ya tiene usuario vinculado")
     })
@@ -296,7 +303,11 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
+    // Issue #179: defensa en profundidad — exigir autenticación explícitamente.
+    // El use case ya extrae el userId del SecurityContext; sin autenticación el
+    // contexto está vacío y el use case lanzaría NPE. Mejor fallar temprano con 401.
     @PostMapping("/cambiar-password")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Cambiar contraseña",
                description = "Permite al usuario autenticado cambiar su contraseña actual por una nueva")
     @ApiResponses(value = {

--- a/backend/src/main/java/com/tufondo/auth/infrastructure/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/tufondo/auth/infrastructure/security/JwtAuthenticationFilter.java
@@ -107,6 +107,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getServletPath();
+        // Issue #179: /api/v1/auth/crear-usuario REMOVIDO del bypass.
+        // Era accesible sin autenticación → cualquier atacante creaba usuarios
+        // vinculados a socios existentes. Ahora requiere JWT + rol ADMIN
+        // (enforce via @PreAuthorize en AuthController.crearUsuario).
         return path.equals("/api/v1/auth/login")
             || path.equals("/api/v1/auth/login-web")
             || path.equals("/api/v1/auth/logout")
@@ -116,7 +120,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             || path.equals("/api/v1/auth/validar")
             || path.equals("/api/v1/auth/recuperar-password")
             || path.equals("/api/v1/auth/reset-password")
-            || path.equals("/api/v1/auth/crear-usuario")
             || path.equals("/api/v1/socios/solicitud");
     }
 }

--- a/backend/src/main/java/com/tufondo/auth/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/com/tufondo/auth/infrastructure/security/SecurityConfig.java
@@ -65,6 +65,11 @@ public class SecurityConfig {
                 )
             )
             .authorizeHttpRequests(auth -> auth
+                // Issue #179: crear-usuario y cambiar-password requieren autenticación
+                // y autorización específica (enforced también por @PreAuthorize en el
+                // controller para defensa en profundidad).
+                .requestMatchers("/api/v1/auth/crear-usuario").authenticated()
+                .requestMatchers("/api/v1/auth/cambiar-password").authenticated()
                 .requestMatchers("/api/v1/auth/**").permitAll()
                 .requestMatchers("/api/v1/socios/solicitud").permitAll()
                 // Webhook biométrico del proveedor KYC (Didit). NO usa JWT — la

--- a/backend/src/main/java/com/tufondo/socios/presentation/controller/SocioController.java
+++ b/backend/src/main/java/com/tufondo/socios/presentation/controller/SocioController.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -51,8 +52,11 @@ public class SocioController {
     private final EliminarSocioUseCase eliminarSocioUseCase;
     private final SocioDTOMapper socioDTOMapper;
 
+    // Issue #179: solo ADMIN puede crear socios directamente. El flujo público
+    // de auto-registro va por /api/v1/socios/solicitud (que sigue siendo permitAll).
     @PostMapping
-    @Operation(summary = "Crear un nuevo socio")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Crear un nuevo socio (solo admin)")
     public ResponseEntity<SocioResponseDTO> crearSocio(
             @Valid @RequestBody CrearSocioRequestDTO request) {
         Socio socio = crearSocioUseCase.ejecutar(request);
@@ -110,8 +114,11 @@ public class SocioController {
         return ResponseEntity.ok(socios.map(socioDTOMapper::toResponseDTO));
     }
 
+    // Issue #179: solo ADMIN puede actualizar datos de cualquier socio. La actualización
+    // de perfil propio del socio va por otro endpoint (/perfil) que sí valida ownership.
     @PutMapping("/{id}")
-    @Operation(summary = "Actualizar un socio")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Actualizar un socio (solo admin)")
     public ResponseEntity<SocioResponseDTO> actualizarSocio(
             @PathVariable UUID id,
             @Valid @RequestBody ActualizarSocioDTO request,
@@ -122,15 +129,18 @@ public class SocioController {
         return ResponseEntity.ok(response);
     }
 
+    // Issue #179: operaciones administrativas
     @PatchMapping("/{id}/activar")
-    @Operation(summary = "Activar un socio")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Activar un socio (solo admin)")
     public ResponseEntity<SocioResponseDTO> activarSocio(@PathVariable UUID id) {
         SocioResponseDTO response = activarSocioUseCase.ejecutar(id);
         return ResponseEntity.ok(response);
     }
 
     @PatchMapping("/{id}/desactivar")
-    @Operation(summary = "Desactivar un socio")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Desactivar un socio (solo admin)")
     public ResponseEntity<SocioResponseDTO> desactivarSocio(
             @PathVariable UUID id,
             @RequestParam(required = false) String motivo) {
@@ -138,8 +148,10 @@ public class SocioController {
         return ResponseEntity.ok(response);
     }
 
+    // Issue #179: eliminación es operación crítica, solo admin.
     @DeleteMapping("/{id}")
-    @Operation(summary = "Eliminar un socio (soft delete)")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Eliminar un socio (soft delete, solo admin)")
     public ResponseEntity<Map<String, String>> eliminarSocio(
             @PathVariable UUID id,
             @RequestParam(required = false) String motivo) {

--- a/backend/src/test/java/com/tufondo/ahorros/application/usecase/CrearCuentaAhorroUseCaseTest.java
+++ b/backend/src/test/java/com/tufondo/ahorros/application/usecase/CrearCuentaAhorroUseCaseTest.java
@@ -1,0 +1,127 @@
+package com.tufondo.ahorros.application.usecase;
+
+import com.tufondo.ahorros.application.dto.CreateCuentaAhorroRequest;
+import com.tufondo.ahorros.application.dto.CuentaAhorroResponse;
+import com.tufondo.ahorros.application.mapper.AhorrosDTOMapper;
+import com.tufondo.ahorros.domain.model.CuentaAhorro;
+import com.tufondo.ahorros.domain.model.enums.Moneda;
+import com.tufondo.ahorros.domain.model.enums.TipoCuenta;
+import com.tufondo.ahorros.domain.repository.CuentaAhorroRepository;
+
+import static org.mockito.ArgumentMatchers.eq;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests para issue #179: anti-IDOR en crear cuenta de ahorro.
+ *
+ * <p>Antes del fix, {@code CrearCuentaAhorroUseCase.ejecutar(request)} no
+ * validaba ownership del {@code socioId} del request contra el token JWT.
+ * Un socio A podía crear cuentas para socio B simplemente poniendo el ID
+ * de B en el body.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class CrearCuentaAhorroUseCaseTest {
+
+    @Mock
+    private CuentaAhorroRepository cuentaRepository;
+
+    @Mock
+    private AhorrosDTOMapper mapper;
+
+    @InjectMocks
+    private CrearCuentaAhorroUseCase useCase;
+
+    private CreateCuentaAhorroRequest request;
+    private UUID socioRequestId;
+
+    @BeforeEach
+    void setUp() {
+        socioRequestId = UUID.randomUUID();
+        request = new CreateCuentaAhorroRequest(
+                socioRequestId,
+                TipoCuenta.AHORRO,
+                Moneda.VES,
+                new BigDecimal("100.00"),
+                new BigDecimal("0.05")
+        );
+    }
+
+    @Test
+    @DisplayName("Issue #179: socio creando cuenta para SÍ MISMO (mismo UUID) pasa")
+    void socio_crea_cuenta_para_si_mismo_pasa() {
+        CuentaAhorro cuentaMock = mock(CuentaAhorro.class);
+        CuentaAhorroResponse responseMock = mock(CuentaAhorroResponse.class);
+        when(cuentaRepository.existePorSocioIdYTipo(any(), any())).thenReturn(false);
+        when(cuentaRepository.existePorNumeroCuenta(anyString())).thenReturn(false);
+        when(cuentaRepository.guardar(any())).thenReturn(cuentaMock);
+        when(mapper.toDomain(any(CreateCuentaAhorroRequest.class), anyString())).thenReturn(cuentaMock);
+        when(mapper.toResponse(any(CuentaAhorro.class))).thenReturn(responseMock);
+
+        // socioIdToken == request.socioId → ownership válido
+        CuentaAhorroResponse result = useCase.ejecutar(request, socioRequestId, false);
+
+        assertThat(result).isNotNull();
+        verify(cuentaRepository).guardar(any());
+    }
+
+    @Test
+    @DisplayName("Issue #179: socio intentando crear cuenta para OTRO socio → AccessDeniedException (anti-IDOR)")
+    void socio_crea_cuenta_para_otro_socio_falla() {
+        UUID otroSocio = UUID.randomUUID();
+
+        // socioIdToken (otroSocio) != request.socioId → IDOR detectado
+        assertThatThrownBy(() -> useCase.ejecutar(request, otroSocio, false))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("No tiene permisos");
+
+        // CRÍTICO: el repositorio NUNCA debe ser invocado (cuenta NO se crea)
+        verify(cuentaRepository, never()).existePorSocioIdYTipo(any(), any());
+        verify(cuentaRepository, never()).guardar(any());
+    }
+
+    @Test
+    @DisplayName("Issue #179: ADMIN puede crear cuenta para cualquier socio (back-office)")
+    void admin_crea_cuenta_para_cualquier_socio_pasa() {
+        UUID adminSinSocioId = UUID.randomUUID();  // admin no es socio
+        CuentaAhorro cuentaMock = mock(CuentaAhorro.class);
+        CuentaAhorroResponse responseMock = mock(CuentaAhorroResponse.class);
+        when(cuentaRepository.existePorSocioIdYTipo(any(), any())).thenReturn(false);
+        when(cuentaRepository.existePorNumeroCuenta(anyString())).thenReturn(false);
+        when(cuentaRepository.guardar(any())).thenReturn(cuentaMock);
+        when(mapper.toDomain(any(CreateCuentaAhorroRequest.class), anyString())).thenReturn(cuentaMock);
+        when(mapper.toResponse(any(CuentaAhorro.class))).thenReturn(responseMock);
+
+        // isAdmin = true → skip ownership check, permite crear para cualquier socio
+        CuentaAhorroResponse result = useCase.ejecutar(request, adminSinSocioId, true);
+
+        assertThat(result).isNotNull();
+        verify(cuentaRepository).guardar(any());
+    }
+
+    @Test
+    @DisplayName("Issue #179: token sin socioId (null) y no-admin → AccessDeniedException")
+    void sin_socioId_y_no_admin_falla() {
+        // Caso edge: token de un usuario que no tiene socio asociado (ej. error de
+        // sistema, token corrupto) y NO es admin → debe bloquear por seguridad.
+        assertThatThrownBy(() -> useCase.ejecutar(request, null, false))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(cuentaRepository, never()).guardar(any());
+    }
+}


### PR DESCRIPTION
Closes #179

## Resumen

Múltiples vectores IDOR y de escalación de privilegios. Cubre los 6 endpoints del issue:

| # | Endpoint | Antes | Ahora |
|---|----------|-------|-------|
| 1 | `POST /api/v1/cuentas` | IDOR: socio A creaba cuenta para socio B | Use case valida ownership; admin puede para cualquiera |
| 2 | `POST /api/v1/socios` | Cualquier autenticado | Solo ADMIN |
| 3 | `PUT /api/v1/socios/{id}` | Cualquier autenticado | Solo ADMIN |
| 4 | `DELETE /api/v1/socios/{id}` | Cualquier autenticado | Solo ADMIN |
| 5 | `POST /api/v1/auth/crear-usuario` | **SIN AUTENTICACIÓN** (bypass) | JWT + ADMIN |
| 6 | `POST /api/v1/auth/cambiar-password` | `permitAll` por catch-all `/auth/**` | Requiere autenticación explícita |

## Cambios técnicos

### Anti-IDOR cuentas (#1)
- `CrearCuentaAhorroUseCase`: nueva firma `ejecutar(request, socioIdToken, isAdmin)`. Lanza `AccessDeniedException` si NO es admin Y `socioIdToken != request.socioId`. Spring Security la traduce a `403`. Firma anterior queda `@Deprecated(forRemoval=true)`.
- `AhorroController.crearCuenta`: extrae `socioIdToken` + `isAdmin` del `Authentication` y los pasa al use case.

### @PreAuthorize en socios (#2-#4)
- `SocioController`: agregado `@PreAuthorize(\"hasRole('ADMIN')\")` a `POST`, `PUT /{id}`, `DELETE /{id}`, `PATCH /{id}/activar`, `PATCH /{id}/desactivar`.
- El flujo público de auto-registro (`POST /api/v1/socios/solicitud`) sigue siendo `permitAll`.

### Sacar /auth/crear-usuario del bypass (#5)
- `JwtAuthenticationFilter.shouldNotFilter`: removido `/api/v1/auth/crear-usuario` de la lista de bypass.
- `SecurityConfig`: agregado `requestMatchers(\"/api/v1/auth/crear-usuario\").authenticated()` ANTES del catch-all `/auth/**`.
- `AuthController.crearUsuario`: `@PreAuthorize(\"hasRole('ADMIN')\")`.

### Defensa en profundidad cambiar-password (#6)
- `SecurityConfig`: `requestMatchers(\"/api/v1/auth/cambiar-password\").authenticated()`.
- `AuthController.cambiarPassword`: `@PreAuthorize(\"isAuthenticated()\")`.

## Tests TDD verificados (experimento reverso)

`CrearCuentaAhorroUseCaseTest` (nuevo, 4 casos):

| Test | Tipo | SIN check ownership | CON check |
|------|------|---------------------|-----------|
| `socio_crea_cuenta_para_si_mismo_pasa` | feliz | ✅ PASS | ✅ PASS |
| `socio_crea_cuenta_para_otro_socio_falla` | **regression** | ❌ **FAIL** | ✅ PASS |
| `admin_crea_cuenta_para_cualquier_socio_pasa` | feliz | ✅ PASS | ✅ PASS |
| `sin_socioId_y_no_admin_falla` | **regression** | ❌ **FAIL** | ✅ PASS |

**2 tests atrapan regresión** del IDOR, **2 documentan caso feliz**.

Tests de @PreAuthorize en controllers no son unit-testables sin levantar `@SpringBootTest` completo — se verifican en QA con curl (plan abajo).

## Resultado del build

```
mvn clean test
[INFO] Tests run: 339, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS  -- Total time: 5:36 min
```

## Test plan QA

Para cada caso, necesitas un token de **socio normal** (\`socio_prueba\`) y uno de **admin** (\`admin\`).

### #1 IDOR cuentas
```bash
# Socio intenta crear cuenta para OTRO socio (UUID inventado)
curl -X POST http://qa-app.fatrans.com.ve/api/v1/cuentas \
  -H \"Authorization: Bearer <SOCIO_TOKEN>\" \
  -H 'Content-Type: application/json' \
  -d '{\"socioId\":\"00000000-0000-0000-0000-000000000999\",\"tipoCuenta\":\"AHORRO\",\"moneda\":\"VES\"}' -i
# Esperado: 403 Forbidden

# Socio crea para SÍ MISMO (su propio socioId)
curl -X POST http://qa-app.fatrans.com.ve/api/v1/cuentas \
  -H \"Authorization: Bearer <SOCIO_TOKEN>\" \
  -H 'Content-Type: application/json' \
  -d '{\"socioId\":\"<MI_SOCIO_ID>\",\"tipoCuenta\":\"AHORRO\",\"moneda\":\"VES\"}' -i
# Esperado: 201 Created (o 409 si ya existe)
```

### #2-#4 Socios admin-only
```bash
# Socio normal intenta crear/actualizar/eliminar otro socio
curl -X DELETE http://qa-app.fatrans.com.ve/api/v1/socios/<otro-id> \
  -H \"Authorization: Bearer <SOCIO_TOKEN>\" -i
# Esperado: 403 Forbidden

# Admin lo hace → 200/204 OK
curl -X DELETE http://qa-app.fatrans.com.ve/api/v1/socios/<otro-id> \
  -H \"Authorization: Bearer <ADMIN_TOKEN>\" -i
# Esperado: 200 OK
```

### #5 crear-usuario
```bash
# Sin token → 401
curl -X POST http://qa-app.fatrans.com.ve/api/v1/auth/crear-usuario \
  -H 'Content-Type: application/json' \
  -d '{\"socioId\":\"<id>\",\"nombreUsuario\":\"hack\",\"password\":\"Hack1234!\"}' -i
# Esperado: 401 Unauthorized (antes: 201 ATAQUE EXITOSO)

# Con socio normal → 403
curl -X POST ... -H \"Authorization: Bearer <SOCIO_TOKEN>\" ... -i
# Esperado: 403

# Con admin → 201
curl -X POST ... -H \"Authorization: Bearer <ADMIN_TOKEN>\" ... -i
# Esperado: 201 Created
```

### #6 cambiar-password
```bash
# Sin token → 401
curl -X POST http://qa-app.fatrans.com.ve/api/v1/auth/cambiar-password \
  -H 'Content-Type: application/json' -d '{...}' -i
# Esperado: 401
```

## Regresión a validar (caso feliz)
- Login → POST /cuentas para sí mismo con token de socio → 201 sigue funcionando.
- Auto-registro público (`POST /api/v1/socios/solicitud` sin token) sigue funcionando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)