### PR TITLE
fix(dashboard): saldo total agrega VES + USD con tasa BCV (#213)

### DIFF
--- a/frontend-web/src/app/(dashboard)/dashboard/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { Loader2, Wallet, CreditCard, TrendingUp, Plus, ArrowUpRight, ArrowDownR
 import { Card, CardContent } from '@/components/ui/card';
 import { useTipoCambio } from '@/hooks/useTipoCambio';
 import { calcularSaldoTotal } from '@/lib/utils/calcular-saldo-total';
+import { parseCuentasResponse } from '@/lib/utils/parse-cuentas-response';
 
 interface CuentaAhorro {
   id: string;
@@ -218,7 +219,11 @@ export default function SocioDashboardPage() {
       const res = await fetch(`/api/cuentas/socio/${user.socioId}`);
       if (res.ok) {
         const data = await res.json();
-        setCuentas(Array.isArray(data) ? data : []);
+        // Issue #213 (sub-bug descubierto en QA): el backend retorna
+        // `{socioId, totalCuentas, cuentas: [...]}` (CuentasPorSocioResponse),
+        // no un array directo. El check anterior `Array.isArray(data) ? data : []`
+        // siempre dejaba la lista vacía aunque el socio tuviera cuentas.
+        setCuentas(parseCuentasResponse(data));
       }
     } catch (err) {
       console.error('Error:', err);

--- a/frontend-web/src/app/(dashboard)/dashboard/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/page.tsx
@@ -5,6 +5,8 @@ import Link from 'next/link';
 import { useAuthStore } from '@/stores/auth-store';
 import { Loader2, Wallet, CreditCard, TrendingUp, Plus, ArrowUpRight, ArrowDownRight, Truck, AlertTriangle, Shield, ChevronRight, FileText, Calendar } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
+import { useTipoCambio } from '@/hooks/useTipoCambio';
+import { calcularSaldoTotal } from '@/lib/utils/calcular-saldo-total';
 
 interface CuentaAhorro {
   id: string;
@@ -204,6 +206,11 @@ export default function SocioDashboardPage() {
   const [cuentas, setCuentas] = useState<CuentaAhorro[]>([]);
   const [loadingCuentas, setLoadingCuentas] = useState(true);
 
+  // Issue #213: tasa BCV para agregar saldos multimoneda correctamente
+  const { tasaActual, loading: loadingTasa } = useTipoCambio(1);
+  // Toggle moneda de visualización (VES por defecto, mismo lado del país)
+  const [monedaVista, setMonedaVista] = useState<'VES' | 'USD'>('VES');
+
   const cargarCuentas = useCallback(async () => {
     if (!user?.socioId) return;
     setLoadingCuentas(true);
@@ -226,8 +233,10 @@ export default function SocioDashboardPage() {
     }
   }, [isLoading, user?.socioId, cargarCuentas]);
 
-  const saldoTotal = cuentas.reduce((acc, c) => acc + c.saldoActual, 0);
-  const cuentaPrincipal = cuentas.find(c => c.moneda === 'VES') || cuentas[0];
+  // Issue #213: agregación correcta de saldos multimoneda.
+  // `null` cuando la tasa todavía no se cargó (mostramos skeleton, no número).
+  const saldoAgregado = calcularSaldoTotal(cuentas, tasaActual);
+  const saldoTotalListo = saldoAgregado !== null && !loadingTasa && !loadingCuentas;
 
   const mockActividad: Actividad[] = [
     { id: '1', tipo: 'DEPOSITO', descripcion: 'Depósito en efectivo', monto: 500000, fecha: '2026-04-28', icono: 'down' },
@@ -268,13 +277,72 @@ export default function SocioDashboardPage() {
         <div className="absolute bottom-0 left-0 w-40 h-40 rounded-full bg-white/5 translate-y-1/2 -translate-x-1/2" />
 
         <div className="relative">
-          <div className="flex items-center gap-2 mb-1">
-            <Shield className="w-4 h-4 text-emerald-400" />
-            <span className="text-xs font-medium text-white/60 uppercase tracking-wider">Saldo Total Disponible</span>
+          <div className="flex items-center justify-between mb-1 flex-wrap gap-3">
+            <div className="flex items-center gap-2">
+              <Shield className="w-4 h-4 text-emerald-400" />
+              <span className="text-xs font-medium text-white/60 uppercase tracking-wider">Saldo Total Disponible</span>
+            </div>
+            {/* Issue #213: toggle moneda de visualización */}
+            <div
+              role="tablist"
+              aria-label="Moneda de visualización del saldo total"
+              className="inline-flex items-center bg-white/10 rounded-full p-1 text-xs font-semibold"
+            >
+              <button
+                role="tab"
+                aria-selected={monedaVista === 'VES'}
+                onClick={() => setMonedaVista('VES')}
+                className={`px-3 py-1 rounded-full transition-colors ${
+                  monedaVista === 'VES' ? 'bg-white text-[#0F2744]' : 'text-white/70 hover:text-white'
+                }`}
+              >
+                Bs
+              </button>
+              <button
+                role="tab"
+                aria-selected={monedaVista === 'USD'}
+                onClick={() => setMonedaVista('USD')}
+                className={`px-3 py-1 rounded-full transition-colors ${
+                  monedaVista === 'USD' ? 'bg-white text-[#0F2744]' : 'text-white/70 hover:text-white'
+                }`}
+              >
+                USD
+              </button>
+            </div>
           </div>
-          <p className="text-4xl lg:text-5xl font-bold tracking-tight mb-6">
-            {formatCurrency(saldoTotal)}
-          </p>
+
+          {/* Issue #213: muestra saldo agregado en la moneda seleccionada.
+              Mientras la tasa BCV no se haya cargado, mostramos skeleton (NO un
+              número incorrecto). */}
+          {saldoTotalListo && saldoAgregado ? (
+            <p
+              className="text-4xl lg:text-5xl font-bold tracking-tight mb-2"
+              data-testid="saldo-total-agregado"
+            >
+              {monedaVista === 'VES'
+                ? formatCurrency(saldoAgregado.totalVES, 'VES')
+                : formatCurrency(saldoAgregado.totalUSD, 'USD')}
+            </p>
+          ) : (
+            <div
+              data-testid="saldo-total-loading"
+              aria-label="Cargando saldo total"
+              className="h-12 lg:h-14 w-64 bg-white/10 rounded-lg animate-pulse mb-2"
+            />
+          )}
+
+          {/* Info de tasa usada para la conversión (transparencia) */}
+          {tasaActual && (
+            <p className="text-xs text-white/50 mb-6">
+              Tasa BCV {tasaActual.fecha}: 1 USD = Bs {tasaActual.tasaVenta.toFixed(2)} ·
+              {' '}
+              {monedaVista === 'VES' && saldoAgregado
+                ? <>Equivale a <span className="text-white/80">{formatCurrency(saldoAgregado.totalUSD, 'USD')}</span></>
+                : monedaVista === 'USD' && saldoAgregado
+                ? <>Equivale a <span className="text-white/80">{formatCurrency(saldoAgregado.totalVES, 'VES')}</span></>
+                : null}
+            </p>
+          )}
 
           {/* Quick Actions */}
           <div className="flex flex-wrap gap-3">

--- a/frontend-web/src/lib/utils/calcular-saldo-total.test.ts
+++ b/frontend-web/src/lib/utils/calcular-saldo-total.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { calcularSaldoTotal, type CuentaParaSaldo, type TasaCambio } from './calcular-saldo-total';
+
+/**
+ * Tests para issue #213: agregación de saldos multimoneda.
+ *
+ * Antes del fix, el dashboard sumaba `c.saldoActual` sin importar moneda
+ * (ej. `1.000 VES + 50 USD = 1.050`). Este utility lo reemplaza con
+ * conversión correcta usando tasa BCV.
+ */
+describe('calcularSaldoTotal (issue #213)', () => {
+  const tasa: TasaCambio = { tasaCompra: 44.5, tasaVenta: 45.0 };
+
+  describe('Casos normales (con tasa válida)', () => {
+    it('cuenta única VES → totalVES = saldo, totalUSD calculado con tasa de compra', () => {
+      const cuentas: CuentaParaSaldo[] = [
+        { moneda: 'VES', saldoActual: 100_000 },
+      ];
+
+      const result = calcularSaldoTotal(cuentas, tasa);
+
+      expect(result).not.toBeNull();
+      expect(result!.totalVES).toBe(100_000);
+      expect(result!.totalUSD).toBeCloseTo(100_000 / 44.5, 2);
+    });
+
+    it('cuenta única USD → totalVES convertido, totalUSD = saldo', () => {
+      const cuentas: CuentaParaSaldo[] = [
+        { moneda: 'USD', saldoActual: 100 },
+      ];
+
+      const result = calcularSaldoTotal(cuentas, tasa);
+
+      expect(result).not.toBeNull();
+      expect(result!.totalVES).toBe(100 * 45.0); // = 4500
+      // totalUSD = 4500 / 44.5 = ~101.12 (no es exactamente 100 por el spread compra/venta)
+      expect(result!.totalUSD).toBeCloseTo(4500 / 44.5, 2);
+    });
+
+    it('Issue #213 - escenario crítico: cuenta 100.000 VES + 100 USD a tasa 45 = 104.500 VES (NO 100.100)', () => {
+      const cuentas: CuentaParaSaldo[] = [
+        { moneda: 'VES', saldoActual: 100_000 },
+        { moneda: 'USD', saldoActual: 100 },
+      ];
+
+      const result = calcularSaldoTotal(cuentas, tasa);
+
+      expect(result).not.toBeNull();
+      // BUG: antes del fix esto era 100_100 (suma directa sin conversión)
+      // FIX: 100_000 + (100 * 45) = 104_500
+      expect(result!.totalVES).toBe(104_500);
+      // Y NUNCA debe ser la suma directa sin conversión
+      expect(result!.totalVES).not.toBe(100_100);
+    });
+
+    it('Issue #213 - escenario del backlog: 2M VES + 5000 USD a tasa 45 = 2.225.000 VES', () => {
+      const cuentas: CuentaParaSaldo[] = [
+        { moneda: 'VES', saldoActual: 2_000_000 },
+        { moneda: 'USD', saldoActual: 5_000 },
+      ];
+
+      const result = calcularSaldoTotal(cuentas, tasa);
+
+      expect(result).not.toBeNull();
+      expect(result!.totalVES).toBe(2_225_000);
+      expect(result!.totalUSD).toBeCloseTo(2_225_000 / 44.5, 2);
+    });
+
+    it('múltiples cuentas mixtas suman correctamente', () => {
+      const cuentas: CuentaParaSaldo[] = [
+        { moneda: 'VES', saldoActual: 50_000 },
+        { moneda: 'VES', saldoActual: 30_000 },
+        { moneda: 'USD', saldoActual: 200 },
+      ];
+
+      const result = calcularSaldoTotal(cuentas, tasa);
+
+      expect(result).not.toBeNull();
+      // 50_000 + 30_000 + (200 * 45) = 89_000
+      expect(result!.totalVES).toBe(89_000);
+    });
+
+    it('array vacío → totales en cero', () => {
+      const result = calcularSaldoTotal([], tasa);
+      expect(result).not.toBeNull();
+      expect(result!.totalVES).toBe(0);
+      expect(result!.totalUSD).toBe(0);
+    });
+  });
+
+  describe('Loading state (tasaCambio null)', () => {
+    it('si tasaCambio es null y hay cuentas → retorna null (loading)', () => {
+      const cuentas: CuentaParaSaldo[] = [
+        { moneda: 'VES', saldoActual: 100_000 },
+        { moneda: 'USD', saldoActual: 100 },
+      ];
+
+      const result = calcularSaldoTotal(cuentas, null);
+
+      // CRÍTICO: NO retornar un número parcial — mostrar loading en UI
+      expect(result).toBeNull();
+    });
+
+    it('si tasaCambio es null pero NO hay cuentas → totales en cero (no necesitamos tasa)', () => {
+      const result = calcularSaldoTotal([], null);
+      expect(result).not.toBeNull();
+      expect(result!.totalVES).toBe(0);
+      expect(result!.totalUSD).toBe(0);
+    });
+  });
+
+  describe('Edge cases — tasa inválida (defensive)', () => {
+    it('tasaVenta = 0 → null (evitar datos falsos)', () => {
+      const tasaCero: TasaCambio = { tasaCompra: 44.5, tasaVenta: 0 };
+      const result = calcularSaldoTotal([{ moneda: 'USD', saldoActual: 100 }], tasaCero);
+      expect(result).toBeNull();
+    });
+
+    it('tasaCompra = 0 → null (evitar división por cero)', () => {
+      const tasaCero: TasaCambio = { tasaCompra: 0, tasaVenta: 45 };
+      const result = calcularSaldoTotal([{ moneda: 'VES', saldoActual: 100_000 }], tasaCero);
+      expect(result).toBeNull();
+    });
+
+    it('saldoActual con NaN se ignora (no corrompe el total)', () => {
+      const cuentas: CuentaParaSaldo[] = [
+        { moneda: 'VES', saldoActual: 100_000 },
+        { moneda: 'VES', saldoActual: NaN },
+      ];
+
+      const result = calcularSaldoTotal(cuentas, tasa);
+
+      expect(result).not.toBeNull();
+      expect(result!.totalVES).toBe(100_000);
+    });
+
+    it('moneda desconocida se ignora (no corrompe el total)', () => {
+      const cuentas: CuentaParaSaldo[] = [
+        { moneda: 'VES', saldoActual: 100_000 },
+        { moneda: 'EUR', saldoActual: 999 }, // moneda no soportada
+      ];
+
+      const result = calcularSaldoTotal(cuentas, tasa);
+
+      expect(result).not.toBeNull();
+      expect(result!.totalVES).toBe(100_000);
+    });
+  });
+});

--- a/frontend-web/src/lib/utils/calcular-saldo-total.ts
+++ b/frontend-web/src/lib/utils/calcular-saldo-total.ts
@@ -1,0 +1,82 @@
+/**
+ * Calcula el saldo agregado de cuentas en distintas monedas (issue #213).
+ *
+ * Reemplaza la lógica buggy del dashboard que sumaba VES + USD directamente
+ * (ej. `1.000 VES + 50 USD = 1.050`, matemáticamente sin sentido).
+ *
+ * Estrategia:
+ *  - Sumamos cuentas VES como están (moneda base).
+ *  - Convertimos cuentas USD a VES con la tasa de VENTA (la que pagaría
+ *    el socio si quisiera comprar bolívares con esos dólares).
+ *  - El total en USD se obtiene dividiendo el total VES entre la tasa de
+ *    COMPRA (lo que recibiría si vendiera bolívares por dólares).
+ *
+ * Cuando {@code tasaCambio} es {@code null} (la tasa aún no se cargó), no
+ * podemos calcular un total agregado correcto. Retornamos `null` para
+ * que el caller muestre un loading state en vez de un número incorrecto.
+ */
+
+export interface CuentaParaSaldo {
+  moneda: string;
+  saldoActual: number;
+}
+
+export interface TasaCambio {
+  tasaCompra: number;
+  tasaVenta: number;
+}
+
+export interface SaldoAgregado {
+  totalVES: number;
+  totalUSD: number;
+}
+
+/**
+ * @returns saldo agregado en VES y USD, o `null` si {@code tasaCambio} es null
+ *          (en cuyo caso el caller debe mostrar loading).
+ */
+export function calcularSaldoTotal(
+  cuentas: ReadonlyArray<CuentaParaSaldo>,
+  tasaCambio: TasaCambio | null
+): SaldoAgregado | null {
+  if (!cuentas || cuentas.length === 0) {
+    return { totalVES: 0, totalUSD: 0 };
+  }
+
+  // Solo VES → no necesitamos tasa para el total en VES, pero sí para mostrar USD.
+  const tieneUSD = cuentas.some((c) => c.moneda === 'USD');
+  const tieneVES = cuentas.some((c) => c.moneda === 'VES');
+
+  // Si hay USD o queremos mostrar también el equivalente en USD, necesitamos tasa.
+  if (tasaCambio === null) {
+    return null;
+  }
+
+  if (tasaCambio.tasaVenta <= 0 || tasaCambio.tasaCompra <= 0) {
+    // Tasa inválida (división por cero o negativos). Mejor null que datos falsos.
+    return null;
+  }
+
+  let totalVES = 0;
+  for (const cuenta of cuentas) {
+    const saldo = Number(cuenta.saldoActual);
+    if (!Number.isFinite(saldo)) continue;
+
+    if (cuenta.moneda === 'VES') {
+      totalVES += saldo;
+    } else if (cuenta.moneda === 'USD') {
+      totalVES += saldo * tasaCambio.tasaVenta;
+    }
+    // Cualquier otra moneda se ignora — sería un dato no soportado.
+  }
+
+  // El total en USD es el total VES convertido a la inversa (tasa de compra).
+  const totalUSD = totalVES / tasaCambio.tasaCompra;
+
+  // Marcas no-op solo para evitar warnings de TS de variables no usadas en
+  // implementaciones futuras (defensive, sirve también de documentación).
+  void tieneUSD;
+  void tieneVES;
+
+  return { totalVES, totalUSD };
+}

--- a/frontend-web/src/lib/utils/parse-cuentas-response.test.ts
+++ b/frontend-web/src/lib/utils/parse-cuentas-response.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { parseCuentasResponse } from './parse-cuentas-response';
+
+/**
+ * Tests para issue #213 — sub-bug descubierto en QA:
+ * `Array.isArray(data) ? data : []` siempre caía a `[]` porque el backend
+ * retorna `{cuentas: [...]}`, no un array directo.
+ */
+describe('parseCuentasResponse', () => {
+  const cuentaSample = {
+    id: 'a1',
+    numeroCuenta: '0134-001',
+    tipoCuenta: 'CORRIENTE',
+    moneda: 'VES',
+    saldoActual: 12450.5,
+    estado: 'ACTIVA',
+  };
+
+  describe('Caso real del backend (issue #213 sub-bug)', () => {
+    it('formato `{socioId, totalCuentas, cuentas: [...]}` (CuentasPorSocioResponse) → extrae las cuentas', () => {
+      const respuestaBackend = {
+        socioId: '550e8400-e29b-41d4-a716-446655440000',
+        totalCuentas: 2,
+        cuentas: [cuentaSample, { ...cuentaSample, id: 'a2', moneda: 'USD', saldoActual: 500 }],
+      };
+
+      const result = parseCuentasResponse(respuestaBackend);
+
+      // Caso crítico: NO debe retornar [] (que era el bug original)
+      expect(result).toHaveLength(2);
+      expect(result[0].moneda).toBe('VES');
+      expect(result[1].moneda).toBe('USD');
+    });
+
+    it('regresión del bug exacto reportado: respuesta wrap con 2 cuentas reales', () => {
+      // Réplica exacta del QA: 1 cuenta VES 12.450,50 + 1 cuenta USD 500
+      const respuestaBackend = {
+        socioId: '550e8400-e29b-41d4-a716-446655440000',
+        totalCuentas: 2,
+        cuentas: [
+          { id: 'c1', numeroCuenta: '01340001000000005678', tipoCuenta: 'CORRIENTE',
+            moneda: 'VES', saldoActual: 12450.5, estado: 'ACTIVA' },
+          { id: 'c2', numeroCuenta: '01340001000000009999', tipoCuenta: 'CORRIENTE',
+            moneda: 'USD', saldoActual: 500, estado: 'ACTIVA' },
+        ],
+      };
+
+      const result = parseCuentasResponse(respuestaBackend);
+
+      expect(result).toHaveLength(2);
+      // Verificamos que el bug NO retorna []
+      expect(result).not.toEqual([]);
+    });
+  });
+
+  describe('Formato alternativo (array directo, por si el backend cambia)', () => {
+    it('array directo → lo retorna tal cual', () => {
+      const respuesta = [cuentaSample];
+      const result = parseCuentasResponse(respuesta);
+      expect(result).toEqual([cuentaSample]);
+    });
+
+    it('array vacío directo → array vacío', () => {
+      const result = parseCuentasResponse([]);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('Defensive (formas inesperadas no deben romper la UI)', () => {
+    it('null → array vacío', () => {
+      expect(parseCuentasResponse(null)).toEqual([]);
+    });
+
+    it('undefined → array vacío', () => {
+      expect(parseCuentasResponse(undefined)).toEqual([]);
+    });
+
+    it('string → array vacío', () => {
+      expect(parseCuentasResponse('error message')).toEqual([]);
+    });
+
+    it('objeto sin `cuentas` → array vacío', () => {
+      expect(parseCuentasResponse({ message: 'Error', code: 500 })).toEqual([]);
+    });
+
+    it('objeto con `cuentas` que NO es array → array vacío', () => {
+      expect(parseCuentasResponse({ cuentas: 'no es array' })).toEqual([]);
+    });
+
+    it('objeto con `cuentas` vacío → array vacío', () => {
+      expect(parseCuentasResponse({ cuentas: [] })).toEqual([]);
+    });
+  });
+});

--- a/frontend-web/src/lib/utils/parse-cuentas-response.ts
+++ b/frontend-web/src/lib/utils/parse-cuentas-response.ts
@@ -1,0 +1,49 @@
+/**
+ * Parsea la respuesta del endpoint `/api/cuentas/socio/{socioId}` (issue #213
+ * — bug pre-existente descubierto durante QA del fix de saldo multimoneda).
+ *
+ * El backend retorna {@code CuentasPorSocioResponse}:
+ * ```json
+ * { "socioId": "...", "totalCuentas": 2, "cuentas": [ {...}, {...} ] }
+ * ```
+ *
+ * Pero la página `/dashboard` (home del socio) hacía `Array.isArray(data) ? data : []`,
+ * esperando un array directo → siempre caía a `[]` y mostraba "No tienes cuentas
+ * activas aún" aunque el socio tuviera cuentas. El bug se notaba poco antes
+ * del fix de saldo (todo se veía como Bs 0,00 de todas formas), pero con el
+ * fix de toggle y skeleton se volvió obvio.
+ *
+ * Este helper acepta ambos formatos (array directo y objeto envoltura) para
+ * ser robusto ante cambios futuros del API.
+ */
+
+export interface CuentaParseada {
+  id: string;
+  numeroCuenta: string;
+  tipoCuenta: string;
+  moneda: string;
+  saldoActual: number;
+  estado: string;
+}
+
+/**
+ * @param data respuesta cruda del fetch (ya parseada como JSON)
+ * @returns array de cuentas (vacío si la forma no se reconoce)
+ */
+export function parseCuentasResponse(data: unknown): CuentaParseada[] {
+  // Caso 1: array directo
+  if (Array.isArray(data)) {
+    return data as CuentaParseada[];
+  }
+
+  // Caso 2: objeto envoltura `{cuentas: [...]}` (forma del backend actual)
+  if (data && typeof data === 'object' && 'cuentas' in data) {
+    const cuentas = (data as { cuentas: unknown }).cuentas;
+    if (Array.isArray(cuentas)) {
+      return cuentas as CuentaParseada[];
+    }
+  }
+
+  // Forma desconocida → array vacío (defensive)
+  return [];
+}


### PR DESCRIPTION
Closes #213

## Resumen

El home del socio mostraba un saldo total **matemáticamente sin sentido**:

```typescript
// frontend-web/src/app/(dashboard)/dashboard/page.tsx:229 (antes)
const saldoTotal = cuentas.reduce((acc, c) => acc + c.saldoActual, 0);
//                                              ^^^^^^^^^^^^^^^ sin importar moneda
```

→ Un socio con `Bs 1.000.000` + `USD 50` veía `Bs 1.000.050,00`. **Bug financiero visible al socio en la primera pantalla**, erosiona la confianza al instante.

## Cambios

### Utility puro reutilizable
- `frontend-web/src/lib/utils/calcular-saldo-total.ts` — función `calcularSaldoTotal(cuentas, tasaCambio)`:
  - Convierte cuentas USD a VES con `tasaVenta` (lo que pagaría el socio).
  - Calcula `totalUSD = totalVES / tasaCompra`.
  - **Retorna `null` cuando `tasaCambio === null`** → caller debe mostrar loading, no un número parcial.
  - Defensive: tasa ≤ 0 → null, NaN se ignora, monedas desconocidas se ignoran.

### UI del home
- `dashboard/page.tsx`:
  - Importa `useTipoCambio(1)` para obtener la tasa BCV actual.
  - **Toggle Bs/USD** en el hero balance (segmented control con `role=\"tablist\"` accesible).
  - **Skeleton mientras la tasa carga** (no mostrar cifras incorrectas).
  - Línea de transparencia debajo del saldo: `\"Tasa BCV YYYY-MM-DD: 1 USD = Bs X.XX · Equivale a $Y.YY\"`.

## Tests TDD verificados

`calcular-saldo-total.test.ts` (nuevo, 12 casos):

| Test | Tipo | SIN conversión | CON conversión |
|------|------|----------------|----------------|
| Escenario crítico: 100k VES + 100 USD = 104.500 VES | **regression** | ❌ FAIL (= 100.100) | ✅ PASS |
| Escenario backlog: 2M VES + 5000 USD = 2.225.000 VES | **regression** | ❌ FAIL | ✅ PASS |
| Solo USD: convertir a VES | **regression** | ❌ FAIL | ✅ PASS |
| Múltiples cuentas mixtas | **regression** | ❌ FAIL | ✅ PASS |
| Moneda desconocida (EUR) ignorada | **regression** | ❌ FAIL | ✅ PASS |
| Solo VES, varias cuentas | happy path | ✅ PASS | ✅ PASS |
| Array vacío | happy path | ✅ PASS | ✅ PASS |
| Loading: tasa null + cuentas → retorna null | loading state | ✅ PASS | ✅ PASS |
| Loading: tasa null + sin cuentas → totales 0 | loading state | ✅ PASS | ✅ PASS |
| Defensive: tasaVenta = 0 → null | edge | ✅ PASS | ✅ PASS |
| Defensive: tasaCompra = 0 → null | edge | ✅ PASS | ✅ PASS |
| NaN en saldo se ignora | edge | ✅ PASS | ✅ PASS |

**5 tests atrapan regresión real**, 7 son casos felices/defensive (documentan el comportamiento esperado).

### Verificación TDD reverso documentada

Antes de commitear, reemplacé la conversión por la suma directa (bug original) y ejecuté el test:

```
SIN conversión:
 Test Files  1 failed (1)
      Tests  5 failed | 7 passed (12)
```

Después restauré la conversión:

```
CON conversión:
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

## Suite completa

- **Mis tests + dashboard-multi-currency (existente): 24/24 pasan** ✅
- 17 tests fallan en el suite completo, **todos pre-existentes en `develop`** y ninguno importa mis archivos. Archivos afectados: `admin-dashboard.test.tsx`, `admin-socios.test.tsx`, `dashboard-kyc.test.tsx`, `admin-reportes-estado-cuenta.test.tsx`. Verificado por inspección: ninguno hace `import` de `calcular-saldo-total` ni del `dashboard/page.tsx`.

## Test plan QA

1. **Login como `socio_prueba`** y ver el home (`/dashboard`).
2. **Saldo en VES**: el toggle \"Bs\" debe estar activo por defecto. El saldo mostrado debe ser:
   - Cuentas VES sumadas como están + (cuentas USD × tasa BCV).
3. **Click \"USD\"**: el saldo cambia al equivalente en dólares (totalVES ÷ tasaCompra).
4. **Línea inferior**: debajo del saldo aparece `Tasa BCV YYYY-MM-DD: 1 USD = Bs X.XX · Equivale a $Y.YY`.
5. **Loading**: si la API de tipos de cambio tarda, aparece un skeleton pulsante (NO un número parcial).
6. **Caso edge**: socio con solo cuentas en VES → muestra suma simple en Bs; al cambiar a USD muestra equivalente.

## Scope no incluido (otros mocks visibles en el dashboard)

Los mocks de `Toyota Hilux`, beneficiarios ficticios, actividad reciente hardcoded — son issue **#212** separado. Este PR se enfoca solo en el bug aritmético del saldo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)