### PR TITLE
fix(dashboard): fallback transparente cuando tasa BCV no responde (#230)

### DIFF
--- a/frontend-web/src/app/(dashboard)/dashboard/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { useAuthStore } from '@/stores/auth-store';
 import { Loader2, Wallet, CreditCard, TrendingUp, Plus, ArrowUpRight, ArrowDownRight, Truck, AlertTriangle, Shield, ChevronRight, FileText, Calendar } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { useTipoCambio } from '@/hooks/useTipoCambio';
-import { calcularSaldoTotal } from '@/lib/utils/calcular-saldo-total';
+import { calcularSaldoTotal, calcularSaldosPorMoneda } from '@/lib/utils/calcular-saldo-total';
 import { parseCuentasResponse } from '@/lib/utils/parse-cuentas-response';
 
 interface CuentaAhorro {
@@ -239,9 +239,22 @@ export default function SocioDashboardPage() {
   }, [isLoading, user?.socioId, cargarCuentas]);
 
   // Issue #213: agregación correcta de saldos multimoneda.
-  // `null` cuando la tasa todavía no se cargó (mostramos skeleton, no número).
+  // `null` cuando la tasa todavía no se cargó (mostramos fallback, no número).
   const saldoAgregado = calcularSaldoTotal(cuentas, tasaActual);
   const saldoTotalListo = saldoAgregado !== null && !loadingTasa && !loadingCuentas;
+
+  // Issue #230: fallback transparente cuando no hay tasa BCV.
+  // Si la API de tipos-cambio no responde o devuelve vacío, agregamos a un
+  // total agregado sería engañoso. Mostramos los saldos por moneda separados.
+  const saldosPorMoneda = calcularSaldosPorMoneda(cuentas);
+  // Mostramos el fallback cuando: ya terminaron de cargar las cuentas, hay
+  // cuentas, pero la tasa no nos permite agregar (loading ya pasó pero saldoAgregado
+  // sigue null).
+  const debeMostrarFallback =
+    !loadingCuentas &&
+    !loadingTasa &&
+    cuentas.length > 0 &&
+    saldoAgregado === null;
 
   const mockActividad: Actividad[] = [
     { id: '1', tipo: 'DEPOSITO', descripcion: 'Depósito en efectivo', monto: 500000, fecha: '2026-04-28', icono: 'down' },
@@ -316,10 +329,14 @@ export default function SocioDashboardPage() {
             </div>
           </div>
 
-          {/* Issue #213: muestra saldo agregado en la moneda seleccionada.
-              Mientras la tasa BCV no se haya cargado, mostramos skeleton (NO un
-              número incorrecto). */}
+          {/* Issue #213/#230: tres estados posibles:
+                1. Cargando (cuentas o tasa) → skeleton (no número incorrecto).
+                2. Tasa disponible → saldo agregado con toggle Bs/USD.
+                3. Tasa NO disponible pero hay cuentas → fallback con saldos
+                   separados (estilo Wise/Revolut) en vez de skeleton infinito.
+          */}
           {saldoTotalListo && saldoAgregado ? (
+            // Caso 2: agregado correcto
             <p
               className="text-4xl lg:text-5xl font-bold tracking-tight mb-2"
               data-testid="saldo-total-agregado"
@@ -328,7 +345,33 @@ export default function SocioDashboardPage() {
                 ? formatCurrency(saldoAgregado.totalVES, 'VES')
                 : formatCurrency(saldoAgregado.totalUSD, 'USD')}
             </p>
+          ) : debeMostrarFallback ? (
+            // Caso 3: fallback transparente sin tasa
+            <div data-testid="saldo-total-fallback" className="mb-2">
+              <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+                {saldosPorMoneda.ves > 0 && (
+                  <span className="text-3xl lg:text-4xl font-bold tracking-tight">
+                    {formatCurrency(saldosPorMoneda.ves, 'VES')}
+                  </span>
+                )}
+                {saldosPorMoneda.ves > 0 && saldosPorMoneda.usd > 0 && (
+                  <span className="text-2xl text-white/40">·</span>
+                )}
+                {saldosPorMoneda.usd > 0 && (
+                  <span className="text-3xl lg:text-4xl font-bold tracking-tight">
+                    {formatCurrency(saldosPorMoneda.usd, 'USD')}
+                  </span>
+                )}
+                {/* Edge: si ambos son 0 pero hay cuentas con saldo en otras monedas */}
+                {saldosPorMoneda.ves === 0 && saldosPorMoneda.usd === 0 && (
+                  <span className="text-3xl lg:text-4xl font-bold tracking-tight">
+                    Sin saldo
+                  </span>
+                )}
+              </div>
+            </div>
           ) : (
+            // Caso 1: cargando
             <div
               data-testid="saldo-total-loading"
               aria-label="Cargando saldo total"
@@ -336,16 +379,19 @@ export default function SocioDashboardPage() {
             />
           )}
 
-          {/* Info de tasa usada para la conversión (transparencia) */}
-          {tasaActual && (
+          {/* Info debajo del saldo: tasa BCV cuando hay agregado, o aviso de fallback */}
+          {tasaActual && saldoAgregado && (
             <p className="text-xs text-white/50 mb-6">
               Tasa BCV {tasaActual.fecha}: 1 USD = Bs {tasaActual.tasaVenta.toFixed(2)} ·
               {' '}
-              {monedaVista === 'VES' && saldoAgregado
+              {monedaVista === 'VES'
                 ? <>Equivale a <span className="text-white/80">{formatCurrency(saldoAgregado.totalUSD, 'USD')}</span></>
-                : monedaVista === 'USD' && saldoAgregado
-                ? <>Equivale a <span className="text-white/80">{formatCurrency(saldoAgregado.totalVES, 'VES')}</span></>
-                : null}
+                : <>Equivale a <span className="text-white/80">{formatCurrency(saldoAgregado.totalVES, 'VES')}</span></>}
+            </p>
+          )}
+          {debeMostrarFallback && (
+            <p className="text-xs text-white/50 mb-6">
+              Tasa BCV no disponible — saldos mostrados por moneda
             </p>
           )}
 

--- a/frontend-web/src/lib/utils/calcular-saldo-total.test.ts
+++ b/frontend-web/src/lib/utils/calcular-saldo-total.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { calcularSaldoTotal, type CuentaParaSaldo, type TasaCambio } from './calcular-saldo-total';
+import {
+  calcularSaldoTotal,
+  calcularSaldosPorMoneda,
+  type CuentaParaSaldo,
+  type TasaCambio,
+} from './calcular-saldo-total';
 
 /**
  * Tests para issue #213: agregación de saldos multimoneda.
@@ -145,5 +150,99 @@ describe('calcularSaldoTotal (issue #213)', () => {
       expect(result).not.toBeNull();
       expect(result!.totalVES).toBe(100_000);
     });
+  });
+});
+
+/**
+ * Tests para issue #230 — fallback cuando la tasa BCV no está disponible.
+ * NO requiere tasa; agrupa saldos por moneda sin convertir entre ellas.
+ */
+describe('calcularSaldosPorMoneda (issue #230)', () => {
+  it('Issue #230 — réplica del QA reportado: cuentas Bs 12.450,50 + USD 500 sin tasa', () => {
+    const cuentas: CuentaParaSaldo[] = [
+      { moneda: 'VES', saldoActual: 12_450.5 },
+      { moneda: 'USD', saldoActual: 500 },
+    ];
+
+    const result = calcularSaldosPorMoneda(cuentas);
+
+    // CRÍTICO: los saldos NO se mezclan en un único número
+    expect(result.ves).toBe(12_450.5);
+    expect(result.usd).toBe(500);
+    expect(result.otras).toEqual([]);
+  });
+
+  it('cuentas vacías → todo en cero', () => {
+    const result = calcularSaldosPorMoneda([]);
+    expect(result.ves).toBe(0);
+    expect(result.usd).toBe(0);
+    expect(result.otras).toEqual([]);
+  });
+
+  it('solo cuentas VES → usd = 0', () => {
+    const result = calcularSaldosPorMoneda([
+      { moneda: 'VES', saldoActual: 100 },
+      { moneda: 'VES', saldoActual: 200 },
+    ]);
+    expect(result.ves).toBe(300);
+    expect(result.usd).toBe(0);
+  });
+
+  it('solo cuentas USD → ves = 0', () => {
+    const result = calcularSaldosPorMoneda([
+      { moneda: 'USD', saldoActual: 50 },
+      { moneda: 'USD', saldoActual: 75 },
+    ]);
+    expect(result.ves).toBe(0);
+    expect(result.usd).toBe(125);
+  });
+
+  it('Issue #230 — diferencia vs calcularSaldoTotal: NUNCA retorna null (no necesita tasa)', () => {
+    const cuentas: CuentaParaSaldo[] = [
+      { moneda: 'VES', saldoActual: 12_450.5 },
+      { moneda: 'USD', saldoActual: 500 },
+    ];
+
+    // calcularSaldoTotal SIN tasa → null (no podemos agregar)
+    const conTasa = calcularSaldoTotal(cuentas, null);
+    expect(conTasa).toBeNull();
+
+    // calcularSaldosPorMoneda SIN tasa → objeto válido (no agregamos, solo agrupamos)
+    const porMoneda = calcularSaldosPorMoneda(cuentas);
+    expect(porMoneda).not.toBeNull();
+    expect(porMoneda.ves).toBe(12_450.5);
+    expect(porMoneda.usd).toBe(500);
+  });
+
+  it('monedas no soportadas (EUR, BRL) van a `otras` agrupadas', () => {
+    const cuentas: CuentaParaSaldo[] = [
+      { moneda: 'VES', saldoActual: 100 },
+      { moneda: 'EUR', saldoActual: 50 },
+      { moneda: 'EUR', saldoActual: 30 },
+      { moneda: 'BRL', saldoActual: 200 },
+    ];
+
+    const result = calcularSaldosPorMoneda(cuentas);
+
+    expect(result.ves).toBe(100);
+    expect(result.usd).toBe(0);
+    expect(result.otras).toEqual(
+      expect.arrayContaining([
+        { moneda: 'EUR', total: 80 },
+        { moneda: 'BRL', total: 200 },
+      ])
+    );
+  });
+
+  it('NaN en saldo se ignora (no corrompe)', () => {
+    const cuentas: CuentaParaSaldo[] = [
+      { moneda: 'VES', saldoActual: 100 },
+      { moneda: 'VES', saldoActual: NaN },
+      { moneda: 'USD', saldoActual: 50 },
+    ];
+
+    const result = calcularSaldosPorMoneda(cuentas);
+    expect(result.ves).toBe(100);
+    expect(result.usd).toBe(50);
   });
 });

--- a/frontend-web/src/lib/utils/calcular-saldo-total.ts
+++ b/frontend-web/src/lib/utils/calcular-saldo-total.ts
@@ -31,6 +31,50 @@ export interface SaldoAgregado {
   totalUSD: number;
 }
 
+export interface SaldosPorMoneda {
+  ves: number;
+  usd: number;
+  /** Otras monedas detectadas que no pudimos clasificar (ej. EUR futuro). */
+  otras: Array<{ moneda: string; total: number }>;
+}
+
+/**
+ * Agrupa saldos por moneda SIN convertir entre ellas (issue #230 — fallback
+ * cuando la tasa BCV no está disponible).
+ *
+ * <p>Distinto de {@link calcularSaldoTotal}: este NO necesita tasa y NO
+ * agrega entre monedas. Se usa para mostrar al socio sus saldos lado-a-lado
+ * (estilo Wise/Revolut) cuando no podemos calcular un total agregado
+ * confiable.</p>
+ */
+export function calcularSaldosPorMoneda(
+  cuentas: ReadonlyArray<CuentaParaSaldo>
+): SaldosPorMoneda {
+  let ves = 0;
+  let usd = 0;
+  const otrasMap = new Map<string, number>();
+
+  for (const cuenta of cuentas ?? []) {
+    const saldo = Number(cuenta.saldoActual);
+    if (!Number.isFinite(saldo)) continue;
+
+    if (cuenta.moneda === 'VES') {
+      ves += saldo;
+    } else if (cuenta.moneda === 'USD') {
+      usd += saldo;
+    } else if (cuenta.moneda) {
+      otrasMap.set(cuenta.moneda, (otrasMap.get(cuenta.moneda) ?? 0) + saldo);
+    }
+  }
+
+  const otras = Array.from(otrasMap.entries()).map(([moneda, total]) => ({
+    moneda,
+    total,
+  }));
+
+  return { ves, usd, otras };
+}
+
 /**
  * @returns saldo agregado en VES y USD, o `null` si {@code tasaCambio} es null
  *          (en cuyo caso el caller debe mostrar loading).


### PR DESCRIPTION
Closes #230
Related: #213 (PR previo de saldo VES+USD), #231 (seed Flyway de tipos_cambio)

## Resumen

Tras desplegar el fix #213 a QA, el socio veía sus 2 cuentas (Bs 12.450,50 + USD 500) listadas correctamente, pero el bloque \"Saldo Total Disponible\" quedaba en **skeleton infinito** porque \`/api/tipos-cambio\` devolvía \`[]\` (no hay seed BCV en BD QA).

UX rota: el agregado nunca llega, sin explicación al socio.

## Fix UX (estilo Wise/Revolut/N26)

Cuando no podemos calcular un total agregado confiable (sin tasa BCV), mostramos los saldos **lado-a-lado por moneda** en vez de skeleton infinito.

**Antes** (sin tasa BCV):
```
🛡️ SALDO TOTAL DISPONIBLE
[████████████ skeleton infinito ████████████]
```

**Después** (sin tasa BCV):
```
🛡️ SALDO TOTAL DISPONIBLE         [Bs] [USD]
Bs.S 12.450,50  ·  USD 500,00
Tasa BCV no disponible — saldos mostrados por moneda
```

**Cuando la tasa SÍ existe**: comportamiento del fix #213 sin cambios (agregado con toggle).

## Cambios técnicos

### `calcular-saldo-total.ts` — nuevo helper
- `calcularSaldosPorMoneda(cuentas) → {ves, usd, otras}`.
- NO requiere tasa.
- Agrupa por moneda sin convertir entre ellas.
- Monedas no soportadas (futuro EUR/BRL) van a `otras`.
- Defensive contra NaN.

### `dashboard/page.tsx` — tres estados de render
1. **Loading** (cuentas o tasa) → skeleton.
2. **Tasa disponible + cuentas** → agregado con toggle Bs/USD (caso ideal, sin cambios).
3. **Tasa NO disponible + cuentas** (nuevo) → saldos separados Bs · USD.

Bajo el saldo:
- Caso 2: \`Tasa BCV 2026-05-16: 1 USD = Bs 46.00 · Equivale a $X\`.
- Caso 3: \`Tasa BCV no disponible — saldos mostrados por moneda\`.

## Tests TDD verificados

`calcularSaldosPorMoneda` (7 nuevos):

| Test | Tipo | SIN lógica nueva | CON lógica nueva |
|------|------|------------------|------------------|
| Réplica QA: Bs 12.450,50 + USD 500 → ves=12450.5, usd=500 | **regression** | ❌ FAIL | ✅ PASS |
| Solo USD → ves=0, usd=125 | **regression** | ❌ FAIL | ✅ PASS |
| Diferencia vs calcularSaldoTotal: nunca null sin tasa | **regression** | ❌ FAIL | ✅ PASS |
| Monedas no soportadas (EUR/BRL) van a `otras` | **regression** | ❌ FAIL | ✅ PASS |
| NaN se ignora | **regression** | ❌ FAIL | ✅ PASS |
| Cuentas vacías → todo cero | happy | ✅ PASS | ✅ PASS |
| Solo VES → usd=0 | happy | ✅ PASS | ✅ PASS |

**5 tests atrapan regresión real**, 2 son happy paths.

### Verificación reverso documentada

Antes del commit, reemplacé el helper por una versión buggy y ejecuté:
```
SIN lógica correcta:  Tests  5 failed | 14 passed (19)
CON lógica correcta:  Tests  19 passed (19)
```

## Resultado del build

```
vitest run (calcular-saldo + parse-cuentas + dashboard-multi-currency)
 Test Files  3 passed (3)
      Tests  41 passed (41)
```

TypeScript clean en mis archivos.

## Test plan QA

1. **Hard refresh** (Ctrl+Shift+R) en \`qa-app.fatrans.com.ve/dashboard\`.
2. **Estado actual de QA** (sin seed BCV): debe mostrar:
   - \`Bs.S 12.450,50  ·  USD 500,00\` lado-a-lado
   - Texto debajo: \"Tasa BCV no disponible — saldos mostrados por moneda\"
   - **NO** skeleton infinito.
3. Una vez que se resuelva #231 (seed BCV), el dashboard pasará automáticamente al modo agregado con toggle.

## Causa raíz (issue paralelo)

El verdadero motivo del fallback es que la tabla \`tipos_cambio\` está vacía en QA. Esto se resuelve en #231 (seed Flyway + estrategia de actualización).

🤖 Generated with [Claude Code](https://claude.com/claude-code)