### PR TITLE
feat(tipocambio): scraper BCV + job diario + endpoint admin (#231)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -122,6 +122,13 @@
             <version>8.5.7</version>
         </dependency>
 
+        <!-- Jsoup - HTML parsing para scraper BCV (issue #231) -->
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.18.1</version>
+        </dependency>
+
         <!-- Flyway - Database Migration -->
         <dependency>
             <groupId>org.flywaydb</groupId>

--- a/backend/src/main/java/com/tufondo/FondoApplication.java
+++ b/backend/src/main/java/com/tufondo/FondoApplication.java
@@ -4,9 +4,11 @@ import com.tufondo.auth.infrastructure.configuration.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableConfigurationProperties(JwtProperties.class)
+@EnableScheduling  // Issue #231: necesario para BcvScraperJob
 public class FondoApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/tufondo/tipocambio/infrastructure/scraper/BcvHtmlParser.java
+++ b/backend/src/main/java/com/tufondo/tipocambio/infrastructure/scraper/BcvHtmlParser.java
@@ -1,0 +1,134 @@
+package com.tufondo.tipocambio.infrastructure.scraper;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+/**
+ * Parser HTML puro del sitio del BCV (issue #231).
+ *
+ * <p>Separado de {@link BcvScraperService} para que sea testeable de forma
+ * unitaria sin necesidad de red. Los tests le pasan HTML fixture (capturado
+ * de bcv.org.ve en un momento conocido) y validan que extrae los valores
+ * correctos.</p>
+ *
+ * <p>Selectores conocidos del sitio actual (Drupal):
+ * <ul>
+ *   <li>USD: {@code #dolar .centrado strong}</li>
+ *   <li>EUR: {@code #euro .centrado strong}</li>
+ *   <li>Fecha valor: {@code .date-display-single[content]} → atributo
+ *       {@code content} con ISO 8601</li>
+ * </ul>
+ * Si el BCV cambia su HTML, los métodos lanzan {@link BcvHtmlParseException}
+ * con detalle del selector que falló, para que la alerta sea accionable.</p>
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class BcvHtmlParser {
+
+    /**
+     * Parsea la tasa USD del HTML del BCV.
+     *
+     * @return monto en bolívares por 1 USD (ej. {@code 517.96190000})
+     * @throws BcvHtmlParseException si el selector no encuentra el valor o
+     *         el número no se puede parsear
+     */
+    public static BigDecimal parsearTasaUsd(String html) {
+        Document doc = Jsoup.parse(html);
+        Element strong = doc.selectFirst("#dolar .centrado strong");
+        if (strong == null) {
+            throw new BcvHtmlParseException(
+                    "No se encontró el selector '#dolar .centrado strong' en el HTML del BCV. " +
+                    "Posible cambio en la estructura del sitio.");
+        }
+        String texto = strong.text().trim();
+        return parsearNumeroBcv(texto, "USD");
+    }
+
+    /**
+     * Parsea la fecha valor (Fecha Valor: ...) del HTML.
+     *
+     * <p>Estructura conocida:
+     * <pre>{@code
+     *   <span class="date-display-single" content="2026-05-19T00:00:00-04:00">
+     *     Martes, 19 Mayo 2026
+     *   </span>
+     * }</pre>
+     * Preferimos el atributo {@code content} porque ya viene en ISO 8601 y
+     * no depende del idioma de Drupal.</p>
+     *
+     * @return la fecha valor publicada por el BCV
+     * @throws BcvHtmlParseException si el selector no se encuentra o la
+     *         fecha no se puede parsear
+     */
+    public static LocalDate parsearFechaValor(String html) {
+        Document doc = Jsoup.parse(html);
+        Element span = doc.selectFirst(".date-display-single[content]");
+        if (span == null) {
+            throw new BcvHtmlParseException(
+                    "No se encontró el selector '.date-display-single[content]' en el HTML del BCV.");
+        }
+        String iso = span.attr("content").trim();
+        if (iso.isEmpty()) {
+            throw new BcvHtmlParseException(
+                    "El atributo 'content' de '.date-display-single' está vacío.");
+        }
+        try {
+            return OffsetDateTime.parse(iso).toLocalDate();
+        } catch (Exception e) {
+            throw new BcvHtmlParseException(
+                    "No se pudo parsear la fecha BCV '" + iso + "' como ISO 8601.", e);
+        }
+    }
+
+    /**
+     * Parsea un número en formato BCV (coma decimal, sin separador de miles).
+     *
+     * <p>Ejemplos válidos:
+     * <ul>
+     *   <li>{@code "517,96190000"} → {@code 517.96190000}</li>
+     *   <li>{@code "602,18768455"} → {@code 602.18768455}</li>
+     *   <li>{@code "11,37268028"} → {@code 11.37268028}</li>
+     * </ul>
+     */
+    static BigDecimal parsearNumeroBcv(String texto, String contextoLabel) {
+        if (texto == null || texto.isEmpty()) {
+            throw new BcvHtmlParseException(
+                    "Valor de " + contextoLabel + " vacío en el HTML del BCV.");
+        }
+        // BCV usa coma decimal. Convertimos a punto para BigDecimal.
+        // Eliminamos también cualquier whitespace o caracteres no numéricos
+        // (excepto la coma decimal) por seguridad.
+        String limpio = texto.replace(',', '.').replaceAll("[^0-9.]", "");
+        try {
+            BigDecimal valor = new BigDecimal(limpio);
+            if (valor.signum() <= 0) {
+                throw new BcvHtmlParseException(
+                        "Tasa " + contextoLabel + " del BCV es <= 0: " + valor);
+            }
+            return valor;
+        } catch (NumberFormatException e) {
+            throw new BcvHtmlParseException(
+                    "No se pudo parsear el número '" + texto + "' (tasa " +
+                    contextoLabel + ") del BCV.", e);
+        }
+    }
+
+    /**
+     * Excepción específica del parsing del BCV. Distinta de errores de red
+     * o de cert SSL — esta indica que el HTML cambió o trae datos inesperados.
+     */
+    public static class BcvHtmlParseException extends RuntimeException {
+        public BcvHtmlParseException(String mensaje) {
+            super(mensaje);
+        }
+        public BcvHtmlParseException(String mensaje, Throwable causa) {
+            super(mensaje, causa);
+        }
+    }
+}

--- a/backend/src/main/java/com/tufondo/tipocambio/infrastructure/scraper/BcvScraperService.java
+++ b/backend/src/main/java/com/tufondo/tipocambio/infrastructure/scraper/BcvScraperService.java
@@ -1,0 +1,151 @@
+package com.tufondo.tipocambio.infrastructure.scraper;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.cert.X509Certificate;
+import java.time.LocalDate;
+
+/**
+ * Cliente HTTP que scrapea bcv.org.ve para obtener la tasa USD oficial
+ * (issue #231).
+ *
+ * <p>El sitio del BCV tiene un certificado SSL problemático (auto-firmado
+ * o vencido en algunos momentos), lo cual normalmente bloquearía la conexión.
+ * Aceptamos el certificado SOLO para el host {@code bcv.org.ve} — no
+ * deshabilitamos la validación globalmente. Esto es un riesgo aceptado y
+ * documentado: la fuente oficial del BCV es lo que es, y la alternativa
+ * (no consumirla) es peor.</p>
+ *
+ * <p>El parsing del HTML se delega a {@link BcvHtmlParser} (puro, testeable
+ * sin red).</p>
+ */
+@Slf4j
+@Service
+public class BcvScraperService {
+
+    private static final String BCV_HOST = "www.bcv.org.ve";
+    private static final int CONNECT_TIMEOUT_MS = 10_000;
+    private static final int READ_TIMEOUT_MS = 15_000;
+    private static final String USER_AGENT =
+            "Mozilla/5.0 (TuFondo/Fatrans Bot; +https://fatrans.com.ve) Java/21";
+
+    private final String baseUrl;
+
+    public BcvScraperService(@Value("${bcv.base-url:https://www.bcv.org.ve}") String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    /**
+     * Descarga el HTML del home del BCV y extrae la tasa USD + fecha valor.
+     *
+     * @return resultado con la tasa USD (Bs/USD), tasa compra (=tasaVenta para BCV,
+     *         no publica spread), y la fecha valor publicada.
+     * @throws BcvScrapingException si falla la red, el SSL, o el parsing.
+     */
+    public TasaScrapeada scrapearTasaBcv() {
+        String html = descargarHtml();
+        BigDecimal tasaUsd = BcvHtmlParser.parsearTasaUsd(html);
+        LocalDate fecha = BcvHtmlParser.parsearFechaValor(html);
+
+        log.info("Scraping BCV exitoso: USD={} Bs, fechaValor={}", tasaUsd, fecha);
+        return new TasaScrapeada(tasaUsd, fecha);
+    }
+
+    private String descargarHtml() {
+        try {
+            URL url = URI.create(baseUrl).toURL();
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+            // Solo aplica el SSL relajado si es HTTPS hacia el host del BCV
+            if (conn instanceof HttpsURLConnection https
+                    && BCV_HOST.equalsIgnoreCase(url.getHost())) {
+                aplicarSslRelajadoSoloParaBcv(https);
+            }
+
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(READ_TIMEOUT_MS);
+            conn.setRequestProperty("User-Agent", USER_AGENT);
+            conn.setRequestProperty("Accept", "text/html,application/xhtml+xml");
+
+            int status = conn.getResponseCode();
+            if (status < 200 || status >= 300) {
+                throw new BcvScrapingException(
+                        "BCV respondió HTTP " + status + " — el sitio no está disponible.");
+            }
+
+            try (InputStream is = conn.getInputStream()) {
+                return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            }
+        } catch (IOException | GeneralSecurityException e) {
+            throw new BcvScrapingException(
+                    "Error de red/SSL al consultar bcv.org.ve: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Acepta el cert del BCV SOLO para esta conexión específica.
+     * El TrustManager y HostnameVerifier se setean en la instancia
+     * {@link HttpsURLConnection} (no globalmente).
+     */
+    private void aplicarSslRelajadoSoloParaBcv(HttpsURLConnection conn)
+            throws GeneralSecurityException {
+        TrustManager[] trustAll = new TrustManager[]{
+                new X509TrustManager() {
+                    @Override
+                    public void checkClientTrusted(X509Certificate[] chain, String authType) {
+                        // No-op: aceptamos cualquier cert (solo aplicado a esta conexión).
+                    }
+                    @Override
+                    public void checkServerTrusted(X509Certificate[] chain, String authType) {
+                        // No-op: aceptamos cualquier cert del BCV.
+                    }
+                    @Override
+                    public X509Certificate[] getAcceptedIssuers() {
+                        return new X509Certificate[0];
+                    }
+                }
+        };
+        SSLContext ctx = SSLContext.getInstance("TLS");
+        ctx.init(null, trustAll, new java.security.SecureRandom());
+        conn.setSSLSocketFactory(ctx.getSocketFactory());
+
+        // Hostname verifier permisivo solo para esta conexión
+        HostnameVerifier permisivo = new HostnameVerifier() {
+            @Override
+            public boolean verify(String hostname, SSLSession session) {
+                return BCV_HOST.equalsIgnoreCase(hostname);
+            }
+        };
+        conn.setHostnameVerifier(permisivo);
+    }
+
+    /** Resultado del scraping del BCV: tasa USD y fecha valor. */
+    public record TasaScrapeada(BigDecimal tasaUsdEnBs, LocalDate fechaValor) {}
+
+    /** Error específico del scraper (distinto de parsing y de tasa inválida). */
+    public static class BcvScrapingException extends RuntimeException {
+        public BcvScrapingException(String mensaje) {
+            super(mensaje);
+        }
+        public BcvScrapingException(String mensaje, Throwable causa) {
+            super(mensaje, causa);
+        }
+    }
+}

--- a/backend/src/main/java/com/tufondo/tipocambio/infrastructure/scraper/BcvSyncService.java
+++ b/backend/src/main/java/com/tufondo/tipocambio/infrastructure/scraper/BcvSyncService.java
@@ -1,0 +1,108 @@
+package com.tufondo.tipocambio.infrastructure.scraper;
+
+import com.tufondo.tipocambio.domain.model.TipoCambio;
+import com.tufondo.tipocambio.domain.repository.TipoCambioRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Servicio que orquesta el scraping + persistencia del tipo de cambio BCV
+ * (issue #231).
+ *
+ * <p>Dos puntos de entrada:
+ * <ul>
+ *   <li>{@link #sincronizarDesdeBcv()} — llamado por el job programado y por
+ *       el endpoint admin manual.</li>
+ *   <li>{@link #ejecutarJobDiario()} — cron a las 08:30 hora Venezuela
+ *       (después de que BCV publique la tasa del día).</li>
+ * </ul>
+ * Si el scraping falla, NO se borra la tasa anterior — preferimos servir un
+ * valor stale (de hace 1+ día) que dejar al frontend sin datos.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BcvSyncService {
+
+    private final BcvScraperService bcvScraperService;
+    private final TipoCambioRepository tipoCambioRepository;
+
+    /**
+     * Job programado: 08:30 AM hora Venezuela, todos los días.
+     * El BCV usualmente publica la tasa del día entre 6 y 8 AM.
+     */
+    @Scheduled(cron = "0 30 8 * * *", zone = "America/Caracas")
+    public void ejecutarJobDiario() {
+        log.info("Iniciando job programado de sincronización BCV");
+        try {
+            SincronizacionResultado resultado = sincronizarDesdeBcv();
+            log.info("Job BCV diario completado: {}", resultado);
+        } catch (Exception e) {
+            // CRÍTICO: el job nunca debe lanzar excepción (rompería el scheduler).
+            log.error("Error en job programado BCV — la tasa anterior se preserva: {}",
+                    e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Sincroniza la tasa del BCV con la BD.
+     *
+     * <ul>
+     *   <li>Si ya existe una tasa para la fecha valor del BCV → no hace nada
+     *       (idempotente).</li>
+     *   <li>Si no existe → la inserta.</li>
+     * </ul>
+     *
+     * Para BCV usamos {@code tasaCompra = tasaVenta} porque el BCV no publica
+     * spread (es una tasa de referencia única). Los servicios cambiarios reales
+     * aplican spread por su cuenta.
+     *
+     * @return resultado con detalle (insertada / ya existente / error)
+     */
+    @Transactional
+    public SincronizacionResultado sincronizarDesdeBcv() {
+        BcvScraperService.TasaScrapeada scrapeada = bcvScraperService.scrapearTasaBcv();
+
+        Optional<TipoCambio> existente = tipoCambioRepository.buscarPorFecha(scrapeada.fechaValor());
+        if (existente.isPresent()) {
+            log.info("Tasa BCV para {} ya existe en BD ({}), skip insert.",
+                    scrapeada.fechaValor(), existente.get().getTasaVenta());
+            return new SincronizacionResultado(false, scrapeada.fechaValor(),
+                    scrapeada.tasaUsdEnBs(), "Ya existía en BD");
+        }
+
+        TipoCambio nuevo = TipoCambio.builder()
+                .fecha(scrapeada.fechaValor())
+                .tasaCompra(scrapeada.tasaUsdEnBs())  // BCV: sin spread, compra = venta
+                .tasaVenta(scrapeada.tasaUsdEnBs())
+                .fuente("BCV")
+                .creadoPor(null)  // origen sistema, no admin
+                .createdAt(Instant.now())
+                .build();
+
+        tipoCambioRepository.guardar(nuevo);
+        log.info("Tasa BCV insertada en BD: fecha={} tasa={}",
+                scrapeada.fechaValor(), scrapeada.tasaUsdEnBs());
+        return new SincronizacionResultado(true, scrapeada.fechaValor(),
+                scrapeada.tasaUsdEnBs(), "Insertada");
+    }
+
+    /**
+     * Resultado de una ejecución de sincronización.
+     *
+     * @param insertada {@code true} si se insertó una fila nueva, {@code false}
+     *                  si ya existía la tasa para esa fecha.
+     */
+    public record SincronizacionResultado(
+            boolean insertada,
+            java.time.LocalDate fecha,
+            java.math.BigDecimal tasa,
+            String detalle
+    ) {}
+}

--- a/backend/src/main/java/com/tufondo/tipocambio/presentation/controller/AdminTipoCambioController.java
+++ b/backend/src/main/java/com/tufondo/tipocambio/presentation/controller/AdminTipoCambioController.java
@@ -1,0 +1,63 @@
+package com.tufondo.tipocambio.presentation.controller;
+
+import com.tufondo.tipocambio.infrastructure.scraper.BcvScraperService;
+import com.tufondo.tipocambio.infrastructure.scraper.BcvSyncService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * Endpoints administrativos del módulo de tipo de cambio (issue #231).
+ *
+ * <p>Separado del {@code TipoCambioController} público porque estos endpoints
+ * son exclusivos de administradores y tocan el job de sincronización BCV.</p>
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/admin/tipos-cambio")
+@RequiredArgsConstructor
+@Tag(name = "Admin - Tipos de Cambio", description = "Sincronización BCV (solo admin)")
+public class AdminTipoCambioController {
+
+    private final BcvSyncService bcvSyncService;
+
+    /**
+     * Fuerza una sincronización inmediata con el BCV (sin esperar al cron diario).
+     * Útil cuando el BCV publicó una tasa de emergencia o el job falló.
+     */
+    @PostMapping("/sync-bcv")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Sincronizar tasa BCV manualmente",
+               description = "Scrapea bcv.org.ve, extrae la tasa USD del día y la persiste en BD. " +
+                             "Idempotente: si ya existe la tasa para esa fecha, no la duplica. " +
+                             "Solo ADMIN.")
+    public ResponseEntity<Map<String, Object>> sincronizarManual() {
+        log.info("Sincronización BCV manual disparada por admin");
+        try {
+            BcvSyncService.SincronizacionResultado r = bcvSyncService.sincronizarDesdeBcv();
+            return ResponseEntity.ok(Map.of(
+                    "exito", true,
+                    "insertada", r.insertada(),
+                    "fecha", r.fecha().toString(),
+                    "tasa", r.tasa(),
+                    "detalle", r.detalle()
+            ));
+        } catch (BcvScraperService.BcvScrapingException e) {
+            log.error("Sync BCV manual falló (red/SSL/parsing): {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(Map.of(
+                    "exito", false,
+                    "error", "BCV_UNREACHABLE_OR_INVALID_HTML",
+                    "mensaje", e.getMessage()
+            ));
+        }
+    }
+}

--- a/backend/src/main/resources/db/migration/V16__seed_tipos_cambio_bcv_inicial.sql
+++ b/backend/src/main/resources/db/migration/V16__seed_tipos_cambio_bcv_inicial.sql
@@ -1,0 +1,71 @@
+-- =============================================================================
+-- V16: Issue #231 - Seed inicial de tipo de cambio BCV
+-- =============================================================================
+--
+-- CONTEXTO
+-- --------
+-- La tabla `tipos_cambio` la crea Hibernate (`ddl-auto: update`) pero NO tiene
+-- seed. El dashboard del socio depende de un valor inicial para mostrar el
+-- saldo agregado VES+USD (issue #213 + #230). Sin seed:
+--   1. En entornos limpios (QA reciente, dev), el dashboard cae al modo
+--      fallback (saldos separados) — funciona pero no es ideal.
+--   2. El job programado de scraping BCV (`BcvSyncService.ejecutarJobDiario`)
+--      corre 1x al día a las 08:30 hora Venezuela. Si el deploy es a otra
+--      hora, hay una ventana donde no hay tasa.
+--
+-- ACCIÓN
+-- ------
+-- Insertar una tasa BCV inicial usando el valor del día del deploy
+-- (2026-05-19, capturado de bcv.org.ve: 1 USD = Bs 517,96190000).
+--
+-- IDEMPOTENTE: usamos `ON CONFLICT DO NOTHING` sobre la fecha — si ya hay
+-- una tasa para esa fecha (ej. el job ya corrió antes que la migración),
+-- no se duplica.
+--
+-- USO DE `to_regclass`: la tabla `tipos_cambio` es creada por Hibernate, no
+-- por Flyway. En el primer arranque limpio, esta migración corre ANTES de
+-- que Hibernate cree la tabla. Skip silencioso si no existe.
+--
+-- NOTA: el valor se actualiza luego automáticamente por el job BCV.
+-- Esta migración solo asegura que haya UN valor inicial para evitar el
+-- estado "vacío".
+-- =============================================================================
+
+DO $$
+BEGIN
+    IF to_regclass('public.tipos_cambio') IS NOT NULL THEN
+        -- Crear índice único en `fecha` si no existe (necesario para ON CONFLICT)
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND tablename = 'tipos_cambio'
+              AND indexname = 'uk_tipos_cambio_fecha'
+        ) THEN
+            BEGIN
+                CREATE UNIQUE INDEX uk_tipos_cambio_fecha
+                    ON tipos_cambio(fecha);
+            EXCEPTION WHEN unique_violation THEN
+                RAISE NOTICE 'V16: índice uk_tipos_cambio_fecha ya existe, skip.';
+            END;
+        END IF;
+
+        -- Insert idempotente del seed BCV inicial.
+        -- Valor capturado de bcv.org.ve el 2026-05-19.
+        INSERT INTO tipos_cambio (
+            id, fecha, tasa_compra, tasa_venta, fuente, creado_por, created_at
+        ) VALUES (
+            gen_random_uuid(),
+            DATE '2026-05-19',
+            517.96190000,
+            517.96190000,
+            'BCV',
+            NULL,
+            now()
+        )
+        ON CONFLICT (fecha) DO NOTHING;
+
+        RAISE NOTICE 'V16: seed BCV inicial procesado (insertado o ya existente).';
+    ELSE
+        RAISE NOTICE 'V16: tabla tipos_cambio no existe aún, skip (la creará Hibernate).';
+    END IF;
+END $$;

--- a/backend/src/test/java/com/tufondo/tipocambio/infrastructure/scraper/BcvHtmlParserTest.java
+++ b/backend/src/test/java/com/tufondo/tipocambio/infrastructure/scraper/BcvHtmlParserTest.java
@@ -1,0 +1,110 @@
+package com.tufondo.tipocambio.infrastructure.scraper;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests para issue #231: parser HTML del BCV.
+ *
+ * <p>Usa un fixture en {@code src/test/resources/bcv/bcv-home-fixture.html}
+ * con HTML real capturado de bcv.org.ve. Si el BCV cambia su HTML, este
+ * fixture y el parser deben actualizarse juntos — el fallo en este test es
+ * la alerta temprana.</p>
+ */
+class BcvHtmlParserTest {
+
+    private static String htmlFixture;
+
+    @BeforeAll
+    static void loadFixture() throws IOException {
+        try (InputStream is = BcvHtmlParserTest.class.getResourceAsStream(
+                "/bcv/bcv-home-fixture.html")) {
+            if (is == null) {
+                throw new IOException("Fixture bcv-home-fixture.html no encontrado en classpath");
+            }
+            htmlFixture = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    @Test
+    @DisplayName("Issue #231: parsea tasa USD del HTML real del BCV (517,96190000 → 517.96190000)")
+    void parseaTasaUsd_desdeHtmlRealBcv() {
+        BigDecimal tasa = BcvHtmlParser.parsearTasaUsd(htmlFixture);
+
+        // El valor exacto del fixture: 517,96190000
+        assertThat(tasa).isEqualByComparingTo(new BigDecimal("517.96190000"));
+    }
+
+    @Test
+    @DisplayName("Issue #231: parsea Fecha Valor del atributo content (ISO 8601 robusto)")
+    void parseaFechaValor_desdeAtributoContent() {
+        LocalDate fecha = BcvHtmlParser.parsearFechaValor(htmlFixture);
+
+        // El fixture tiene content="2026-05-19T00:00:00-04:00"
+        assertThat(fecha).isEqualTo(LocalDate.of(2026, 5, 19));
+    }
+
+    @Test
+    @DisplayName("Issue #231: parsearNumeroBcv convierte coma decimal a punto correctamente")
+    void parsearNumeroBcv_convierteComa() {
+        assertThat(BcvHtmlParser.parsearNumeroBcv("517,96190000", "USD"))
+                .isEqualByComparingTo(new BigDecimal("517.96190000"));
+        assertThat(BcvHtmlParser.parsearNumeroBcv("76,07", "CNY"))
+                .isEqualByComparingTo(new BigDecimal("76.07"));
+    }
+
+    @Test
+    @DisplayName("Issue #231: parsearNumeroBcv rechaza valores <= 0 (defensive)")
+    void parsearNumeroBcv_rechazaNoPositivos() {
+        assertThatThrownBy(() -> BcvHtmlParser.parsearNumeroBcv("0,00", "USD"))
+                .isInstanceOf(BcvHtmlParser.BcvHtmlParseException.class)
+                .hasMessageContaining("<= 0");
+    }
+
+    @Test
+    @DisplayName("Issue #231: parsearTasaUsd lanza error claro si el selector no existe")
+    void parsearTasaUsd_selectorAusente() {
+        String htmlSinDolar = "<html><body><div>algo distinto</div></body></html>";
+
+        assertThatThrownBy(() -> BcvHtmlParser.parsearTasaUsd(htmlSinDolar))
+                .isInstanceOf(BcvHtmlParser.BcvHtmlParseException.class)
+                .hasMessageContaining("#dolar .centrado strong")
+                .hasMessageContaining("Posible cambio");
+    }
+
+    @Test
+    @DisplayName("Issue #231: parsearFechaValor lanza error claro si el span no existe")
+    void parsearFechaValor_selectorAusente() {
+        String htmlSinFecha = "<html><body></body></html>";
+
+        assertThatThrownBy(() -> BcvHtmlParser.parsearFechaValor(htmlSinFecha))
+                .isInstanceOf(BcvHtmlParser.BcvHtmlParseException.class)
+                .hasMessageContaining(".date-display-single");
+    }
+
+    @Test
+    @DisplayName("Issue #231: parsearNumeroBcv rechaza texto vacío")
+    void parsearNumeroBcv_textoVacio() {
+        assertThatThrownBy(() -> BcvHtmlParser.parsearNumeroBcv("", "USD"))
+                .isInstanceOf(BcvHtmlParser.BcvHtmlParseException.class);
+        assertThatThrownBy(() -> BcvHtmlParser.parsearNumeroBcv(null, "USD"))
+                .isInstanceOf(BcvHtmlParser.BcvHtmlParseException.class);
+    }
+
+    @Test
+    @DisplayName("Issue #231: parsearNumeroBcv rechaza basura no-numérica")
+    void parsearNumeroBcv_basura() {
+        assertThatThrownBy(() -> BcvHtmlParser.parsearNumeroBcv("hola mundo", "USD"))
+                .isInstanceOf(BcvHtmlParser.BcvHtmlParseException.class);
+    }
+}

--- a/backend/src/test/java/com/tufondo/tipocambio/infrastructure/scraper/BcvSyncServiceTest.java
+++ b/backend/src/test/java/com/tufondo/tipocambio/infrastructure/scraper/BcvSyncServiceTest.java
@@ -1,0 +1,123 @@
+package com.tufondo.tipocambio.infrastructure.scraper;
+
+import com.tufondo.tipocambio.domain.model.TipoCambio;
+import com.tufondo.tipocambio.domain.repository.TipoCambioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests para issue #231: orquestación del sync BCV.
+ *
+ * <p>Mockeamos {@link BcvScraperService} (no queremos red real en tests
+ * unitarios) y verificamos que la lógica de persistencia es correcta.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class BcvSyncServiceTest {
+
+    @Mock
+    private BcvScraperService bcvScraperService;
+
+    @Mock
+    private TipoCambioRepository tipoCambioRepository;
+
+    @InjectMocks
+    private BcvSyncService bcvSyncService;
+
+    private LocalDate fechaBcv;
+    private BigDecimal tasaBcv;
+    private BcvScraperService.TasaScrapeada scrapeada;
+
+    @BeforeEach
+    void setUp() {
+        fechaBcv = LocalDate.of(2026, 5, 19);
+        tasaBcv = new BigDecimal("517.96190000");
+        scrapeada = new BcvScraperService.TasaScrapeada(tasaBcv, fechaBcv);
+    }
+
+    @Test
+    @DisplayName("Issue #231: tasa NO existe en BD → la inserta como fuente='BCV', compra==venta")
+    void sincronizar_insertaCuandoNoExiste() {
+        when(bcvScraperService.scrapearTasaBcv()).thenReturn(scrapeada);
+        when(tipoCambioRepository.buscarPorFecha(fechaBcv)).thenReturn(Optional.empty());
+
+        BcvSyncService.SincronizacionResultado r = bcvSyncService.sincronizarDesdeBcv();
+
+        ArgumentCaptor<TipoCambio> captor = ArgumentCaptor.forClass(TipoCambio.class);
+        verify(tipoCambioRepository).guardar(captor.capture());
+
+        TipoCambio guardado = captor.getValue();
+        assertThat(guardado.getFecha()).isEqualTo(fechaBcv);
+        assertThat(guardado.getFuente()).isEqualTo("BCV");
+        assertThat(guardado.getTasaCompra()).isEqualByComparingTo(tasaBcv);
+        assertThat(guardado.getTasaVenta()).isEqualByComparingTo(tasaBcv);
+        // BCV no publica spread → compra == venta
+        assertThat(guardado.getTasaCompra()).isEqualByComparingTo(guardado.getTasaVenta());
+        assertThat(guardado.getCreadoPor()).isNull();
+
+        assertThat(r.insertada()).isTrue();
+        assertThat(r.tasa()).isEqualByComparingTo(tasaBcv);
+    }
+
+    @Test
+    @DisplayName("Issue #231: tasa YA existe para la fecha → NO duplica (idempotente)")
+    void sincronizar_idempotenteCuandoYaExiste() {
+        when(bcvScraperService.scrapearTasaBcv()).thenReturn(scrapeada);
+        TipoCambio existente = TipoCambio.builder()
+                .fecha(fechaBcv)
+                .tasaCompra(tasaBcv)
+                .tasaVenta(tasaBcv)
+                .fuente("BCV")
+                .build();
+        when(tipoCambioRepository.buscarPorFecha(fechaBcv)).thenReturn(Optional.of(existente));
+
+        BcvSyncService.SincronizacionResultado r = bcvSyncService.sincronizarDesdeBcv();
+
+        // CRÍTICO: no debe llamar `guardar` cuando ya existe
+        verify(tipoCambioRepository, never()).guardar(any());
+        assertThat(r.insertada()).isFalse();
+        assertThat(r.detalle()).contains("Ya existía");
+    }
+
+    @Test
+    @DisplayName("Issue #231: si el scraper falla, la excepción se propaga (caller maneja)")
+    void sincronizar_propagaErrorDelScraper() {
+        when(bcvScraperService.scrapearTasaBcv()).thenThrow(
+                new BcvScraperService.BcvScrapingException("BCV inalcanzable"));
+
+        assertThatThrownBy(() -> bcvSyncService.sincronizarDesdeBcv())
+                .isInstanceOf(BcvScraperService.BcvScrapingException.class)
+                .hasMessageContaining("BCV inalcanzable");
+
+        // Nada se guarda si el scraping falla
+        verify(tipoCambioRepository, never()).guardar(any());
+    }
+
+    @Test
+    @DisplayName("Issue #231: job programado captura excepciones (no rompe el scheduler)")
+    void jobDiario_capturaExcepciones() {
+        when(bcvScraperService.scrapearTasaBcv()).thenThrow(
+                new BcvScraperService.BcvScrapingException("error simulado"));
+
+        // No debe lanzar nada — el scheduler de Spring se rompería.
+        bcvSyncService.ejecutarJobDiario();
+
+        verify(tipoCambioRepository, never()).guardar(any());
+    }
+}

--- a/backend/src/test/resources/bcv/bcv-home-fixture.html
+++ b/backend/src/test/resources/bcv/bcv-home-fixture.html
@@ -1,0 +1,65 @@
+<!--
+  Fixture: HTML reducido de bcv.org.ve capturado el 2026-05-17.
+  Reproduce la estructura real (Drupal + bootstrap) sin el resto de la página.
+  Si el BCV cambia su HTML, este fixture debe actualizarse junto con el parser.
+-->
+<!DOCTYPE html>
+<html lang="es">
+<head><title>Banco Central de Venezuela</title></head>
+<body>
+  <div class="indicadores">
+    <h3>TIPO DE CAMBIO DE REFERENCIA</h3>
+
+    <div id="euro" class="col-sm-12 col-xs-12">
+      <div class="col-sm-6 col-xs-6 centrado">
+        <span>EUR</span>
+      </div>
+      <div class="col-sm-6 col-xs-6 centrado textp">
+        <strong class="strong-tb">602,18768455</strong>
+      </div>
+    </div>
+
+    <div id="yuan" class="col-sm-12 col-xs-12">
+      <div class="col-sm-6 col-xs-6 centrado">
+        <span>CNY</span>
+      </div>
+      <div class="col-sm-6 col-xs-6 centrado textp">
+        <strong class="strong-tb">76,07353826</strong>
+      </div>
+    </div>
+
+    <div id="lira" class="col-sm-12 col-xs-12">
+      <div class="col-sm-6 col-xs-6 centrado">
+        <span>TRY</span>
+      </div>
+      <div class="col-sm-6 col-xs-6 centrado textp">
+        <strong class="strong-tb">11,37268028</strong>
+      </div>
+    </div>
+
+    <div id="rublo" class="col-sm-12 col-xs-12">
+      <div class="col-sm-6 col-xs-6 centrado">
+        <span>RUB</span>
+      </div>
+      <div class="col-sm-6 col-xs-6 centrado textp">
+        <strong class="strong-tb">7,11414789</strong>
+      </div>
+    </div>
+
+    <div id="dolar" class="col-sm-12 col-xs-12">
+      <div class="col-sm-6 col-xs-6 centrado">
+        <span>USD</span>
+      </div>
+      <div class="col-sm-6 col-xs-6 centrado textp">
+        <strong class="strong-tb">517,96190000</strong>
+      </div>
+    </div>
+
+    <h4>
+      Fecha Valor:
+      <span class="date-display-single" property="dc:date" datatype="xsd:dateTime"
+            content="2026-05-19T00:00:00-04:00">Martes, 19 Mayo 2026</span>
+    </h4>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Closes #231
Related: #213, #230 (fallback UX que este PR vuelve raro de ver en QA)

## Resumen

Cierra la causa raíz del fallback UX de #230: la tabla \`tipos_cambio\` estaba vacía en QA. Este PR implementa **scraping automático de bcv.org.ve** para mantener la tasa USD actualizada.

## Lo que verás en QA tras el merge

```
🛡️ SALDO TOTAL DISPONIBLE         [Bs] [USD]

Bs.S 271.430,50

Tasa BCV 2026-05-19: 1 USD = Bs 517.96 · Equivale a $524,01
```

(asumiendo Bs 12.450,50 + USD 500 × 517.96)

## Cambios técnicos

### Capa 1 — Parser HTML puro (testeable sin red)
**`BcvHtmlParser`** con selectores robustos:
- USD: `#dolar .centrado strong` → \`517,96190000\`
- Fecha: `.date-display-single[content]` → ISO 8601 directo del atributo
- Conversión coma → punto para BigDecimal
- Errores accionables si el selector falla (alerta clara, no fallo silencioso)

### Capa 2 — Cliente HTTP con cert SSL relajado
**`BcvScraperService`**:
- TrustManager + HostnameVerifier permisivos **solo para `bcv.org.ve`** (no global)
- Timeouts: 10s connect, 15s read
- User-Agent identificable

### Capa 3 — Orquestación
**`BcvSyncService`**:
- `@Scheduled(cron = \"0 30 8 * * *\", zone = \"America/Caracas\")` — 08:30 AM Venezuela
- Idempotente: busca por fecha valor antes de insertar
- BCV no publica spread → \`tasaCompra == tasaVenta\`
- Job captura excepciones (no rompe el scheduler de Spring)

### Capa 4 — Endpoint admin manual
**`POST /api/v1/admin/tipos-cambio/sync-bcv`** con \`@PreAuthorize(\"hasRole('ADMIN')\")\`.

### Capa 5 — Seed inicial
**`V16__seed_tipos_cambio_bcv_inicial.sql`**:
- Inserta tasa BCV del 2026-05-19 (517.96190000) capturada del sitio oficial
- `ON CONFLICT (fecha) DO NOTHING` (idempotente)
- `to_regclass` para no fallar si la tabla aún no existe

## Tests TDD (12 nuevos, fixture con HTML real del BCV)

| Test | Tipo | SIN selector correcto | CON |
|------|------|------------------------|-----|
| `parseaTasaUsd_desdeHtmlRealBcv` | **regression** | ❌ FAIL (selector no encontrado) | ✅ PASS |
| `parseaFechaValor_desdeAtributoContent` | happy | ✅ PASS | ✅ PASS |
| `parsearNumeroBcv_convierteComa` | unit | ✅ PASS | ✅ PASS |
| `parsearNumeroBcv_rechazaNoPositivos` | edge | ✅ PASS | ✅ PASS |
| `parsearTasaUsd_selectorAusente` | edge | ✅ PASS | ✅ PASS |
| `parsearFechaValor_selectorAusente` | edge | ✅ PASS | ✅ PASS |
| `parsearNumeroBcv_textoVacio` | edge | ✅ PASS | ✅ PASS |
| `parsearNumeroBcv_basura` | edge | ✅ PASS | ✅ PASS |
| `BcvSyncService.insertaCuandoNoExiste` | **regression** | N/A (sin código no compila) | ✅ PASS |
| `BcvSyncService.idempotenteCuandoYaExiste` | **regression** | N/A | ✅ PASS |
| `BcvSyncService.propagaErrorDelScraper` | edge | N/A | ✅ PASS |
| `BcvSyncService.jobDiario_capturaExcepciones` | safety | N/A | ✅ PASS |

**TDD reverso verificado**: rompí el selector `#dolar .centrado strong` a `#NOEXISTE .blabla` → el test del fixture real falla. Restaurado.

## Suite completa
```
mvn clean test
[INFO] Tests run: 351, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS  -- Total time: 5:59 min
```

## Test plan QA

### 1. Verificar seed (debe pasar automáticamente al deploy)
```sql
SELECT * FROM tipos_cambio WHERE fecha = '2026-05-19';
-- Esperado: 1 fila con tasa_venta=517.96190000, fuente='BCV'
```

### 2. Verificar dashboard del socio
- Login \`socio_prueba\` → /dashboard
- Saldo total debe mostrar agregado en Bs (Bs 12.450,50 + 500 × 517.96 = ~271k Bs)
- Toggle USD debe mostrar equivalente
- Línea inferior: \"Tasa BCV 2026-05-19: 1 USD = Bs 517.96\"

### 3. Verificar endpoint admin de sync manual
```bash
# Con token admin
curl -X POST https://qa-app.fatrans.com.ve/api/v1/admin/tipos-cambio/sync-bcv \
  -H \"Authorization: Bearer <ADMIN_TOKEN>\" -i
# Esperado: 200 OK con {\"exito\":true,\"insertada\":false,\"fecha\":\"...\",\"tasa\":517.96...}
# (insertada=false porque el seed ya está)

# Con token de socio
curl -X POST ... -H \"Authorization: Bearer <SOCIO_TOKEN>\" -i
# Esperado: 403 Forbidden
```

### 4. Verificar el job diario
- Próxima ejecución: mañana 08:30 AM hora Venezuela
- Verificar logs: \`grep \"job programado de sincronización BCV\" /var/log/...\`

## Riesgos conocidos + mitigaciones

| Riesgo | Mitigación |
|--------|-----------|
| BCV cambia HTML | Test del fixture falla con mensaje claro → alerta accionable |
| Cert SSL del BCV | TrustManager relajado **solo** para \`bcv.org.ve\` (no global) |
| BCV downtime | Job loguea error pero mantiene tasa anterior en BD |
| Rate limit | 1× al día, no es problema |

🤖 Generated with [Claude Code](https://claude.com/claude-code)