### PR TITLE
fix(auth): resolver rol fantasma ANALISTA_CREDITO (#207)

### DIFF
--- a/backend/src/main/java/com/tufondo/auth/application/service/PermisoService.java
+++ b/backend/src/main/java/com/tufondo/auth/application/service/PermisoService.java
@@ -87,6 +87,14 @@ public class PermisoService {
         return tieneRol(authentication, Rol.ANALISTA_KYC);
     }
 
+    /**
+     * Issue #207: rol dedicado a evaluar y aprobar créditos.
+     * Separation of Duties: este rol NO puede desembolsar, solo evaluar/aprobar.
+     */
+    public boolean esAnalistaCredito(Authentication authentication) {
+        return tieneRol(authentication, Rol.ANALISTA_CREDITO);
+    }
+
     public boolean esSistema(Authentication authentication) {
         return tieneRol(authentication, Rol.SISTEMA);
     }

--- a/backend/src/main/java/com/tufondo/auth/domain/model/enums/Rol.java
+++ b/backend/src/main/java/com/tufondo/auth/domain/model/enums/Rol.java
@@ -6,5 +6,17 @@ public enum Rol {
     SUPER_ADMIN,
     CAJERO,
     ANALISTA_KYC,
+    /**
+     * Issue #207: rol dedicado a evaluar y aprobar (NO desembolsar) créditos.
+     * La jerarquía en {@code SecurityConfig} ya lo declaraba bajo ADMIN
+     * pero no existía aquí — era un "rol fantasma" que nunca podía emitirse
+     * en el JWT.
+     *
+     * <p>Separation of Duties: este rol puede evaluar y aprobar/rechazar,
+     * pero NO desembolsar (esa acción queda solo en ADMIN/SISTEMA para
+     * mantener separación entre quien autoriza y quien ejecuta el movimiento
+     * de fondos).</p>
+     */
+    ANALISTA_CREDITO,
     SISTEMA
 }

--- a/backend/src/main/java/com/tufondo/auth/infrastructure/persistence/adapter/RolPermisoRepositoryImpl.java
+++ b/backend/src/main/java/com/tufondo/auth/infrastructure/persistence/adapter/RolPermisoRepositoryImpl.java
@@ -59,6 +59,29 @@ public class RolPermisoRepositoryImpl implements RolPermisoRepository {
             Permiso.VER_KYC_ESTADISTICAS, Permiso.VER_AUDITORIA
     );
 
+    /**
+     * Issue #207: ANALISTA_CREDITO — evalúa y aprueba/rechaza créditos.
+     *
+     * <p>Separation of Duties: NO incluye {@link Permiso#DESEMBOLSAR_CREDITO}.
+     * El desembolso (movimiento de fondos) queda separado del análisis
+     * crediticio para que la misma persona no pueda aprobar y ejecutar el
+     * pago. ADMIN/SISTEMA conservan el desembolso.</p>
+     *
+     * <p>Tiene visibilidad de cuentas/movimientos/documentos del socio
+     * para poder evaluar capacidad de pago.</p>
+     */
+    private static final List<Permiso> PERMISOS_ANALISTA_CREDITO = List.of(
+            Permiso.VER_DASHBOARD,
+            Permiso.GESTIONAR_CREDITOS,
+            Permiso.EVALUAR_CREDITO,
+            Permiso.APROBAR_CREDITO,
+            Permiso.RECHAZAR_CREDITO,
+            // NO: Permiso.DESEMBOLSAR_CREDITO (separation of duties)
+            Permiso.VER_AUDITORIA,
+            Permiso.VER_CUENTAS, Permiso.VER_MOVIMIENTOS, Permiso.VER_RENDIMIENTOS,
+            Permiso.VER_DOCUMENTOS, Permiso.DESCARGAR_DOCUMENTOS
+    );
+
     private static final List<Permiso> PERMISOS_SISTEMA = List.of(
             Permiso.GESTIONAR_CREDITOS, Permiso.EVALUAR_CREDITO, Permiso.APROBAR_CREDITO,
             Permiso.RECHAZAR_CREDITO, Permiso.DESEMBOLSAR_CREDITO,
@@ -154,6 +177,7 @@ public class RolPermisoRepositoryImpl implements RolPermisoRepository {
         inicializarRol(Rol.ADMIN, PERMISOS_ADMIN);
         inicializarRol(Rol.CAJERO, PERMISOS_CAJERO);
         inicializarRol(Rol.ANALISTA_KYC, PERMISOS_ANALISTA_KYC);
+        inicializarRol(Rol.ANALISTA_CREDITO, PERMISOS_ANALISTA_CREDITO);  // Issue #207
         inicializarRol(Rol.SISTEMA, PERMISOS_SISTEMA);
         inicializarRol(Rol.SUPER_ADMIN, PERMISOS_SUPER_ADMIN);
         log.info("Permisos default inicializados para todos los roles");
@@ -173,6 +197,7 @@ public class RolPermisoRepositoryImpl implements RolPermisoRepository {
             case ADMIN -> PERMISOS_ADMIN;
             case CAJERO -> PERMISOS_CAJERO;
             case ANALISTA_KYC -> PERMISOS_ANALISTA_KYC;
+            case ANALISTA_CREDITO -> PERMISOS_ANALISTA_CREDITO;  // Issue #207
             case SISTEMA -> PERMISOS_SISTEMA;
             case SUPER_ADMIN -> PERMISOS_SUPER_ADMIN;
         };

--- a/backend/src/test/java/com/tufondo/auth/application/service/PermisoServiceTest.java
+++ b/backend/src/test/java/com/tufondo/auth/application/service/PermisoServiceTest.java
@@ -186,6 +186,28 @@ class PermisoServiceTest {
         }
 
         @Test
+        @DisplayName("Issue #207: esAnalistaCredito retorna true para ANALISTA_CREDITO")
+        void es_analista_credito_retorna_true() {
+            doReturn(true).when(authentication).isAuthenticated();
+            doReturn(authorities("ANALISTA_CREDITO")).when(authentication).getAuthorities();
+
+            assertThat(permisoService.esAnalistaCredito(authentication)).isTrue();
+        }
+
+        @Test
+        @DisplayName("Issue #207: esAnalistaCredito retorna false para otros roles")
+        void es_analista_credito_retorna_false_para_otros() {
+            doReturn(true).when(authentication).isAuthenticated();
+            doReturn(authorities("ADMIN")).when(authentication).getAuthorities();
+
+            // Aunque ADMIN > ANALISTA_CREDITO en la jerarquía de Spring (para
+            // @PreAuthorize), `esAnalistaCredito()` chequea el rol exacto, no la
+            // jerarquía. Esto es deliberado: si quieres saber si es admin, usa
+            // esAdmin(); este helper es para identificar al analista específicamente.
+            assertThat(permisoService.esAnalistaCredito(authentication)).isFalse();
+        }
+
+        @Test
         @DisplayName("Retorna lista vacía cuando auth null")
         void retorna_lista_vacia_cuando_auth_null() {
             List<Permiso> result = permisoService.obtenerPermisosDelUsuario(null);

--- a/backend/src/test/java/com/tufondo/auth/infrastructure/persistence/adapter/RolPermisoRepositoryImplTest.java
+++ b/backend/src/test/java/com/tufondo/auth/infrastructure/persistence/adapter/RolPermisoRepositoryImplTest.java
@@ -224,4 +224,101 @@ class RolPermisoRepositoryImplTest {
             assertThat(result).contains(Permiso.GESTIONAR_USUARIOS);
         }
     }
+
+    @Nested
+    @DisplayName("Issue #207 — Rol ANALISTA_CREDITO real (ya no fantasma)")
+    class AnalistaCreditoTests {
+
+        @Test
+        @DisplayName("ANALISTA_CREDITO existe en el enum Rol")
+        void analistaCreditoExisteEnEnum() {
+            // Test de compilación + runtime: si alguien borra el valor del
+            // enum, este test falla con `IllegalArgumentException`.
+            Rol rol = Rol.valueOf("ANALISTA_CREDITO");
+            assertThat(rol).isNotNull();
+            assertThat(rol.name()).isEqualTo("ANALISTA_CREDITO");
+        }
+
+        @Test
+        @DisplayName("ANALISTA_CREDITO tiene permisos default (no es un rol fantasma)")
+        void analistaCreditoTienePermisosDefault() {
+            when(jpaRepository.findByRol(Rol.ANALISTA_CREDITO)).thenReturn(List.of());
+
+            List<Permiso> permisos = repository.obtenerPermisosPorRol(Rol.ANALISTA_CREDITO);
+
+            assertThat(permisos).isNotEmpty();
+            assertThat(permisos).contains(
+                    Permiso.EVALUAR_CREDITO,
+                    Permiso.APROBAR_CREDITO,
+                    Permiso.RECHAZAR_CREDITO,
+                    Permiso.VER_DASHBOARD
+            );
+        }
+
+        @Test
+        @DisplayName("Separation of Duties: ANALISTA_CREDITO NO puede desembolsar")
+        void analistaCreditoNoPuedeDesembolsar() {
+            when(jpaRepository.findByRol(Rol.ANALISTA_CREDITO)).thenReturn(List.of());
+
+            boolean puede = repository.tienePermiso(Rol.ANALISTA_CREDITO,
+                    Permiso.DESEMBOLSAR_CREDITO);
+
+            assertThat(puede)
+                    .as("ANALISTA_CREDITO NO debe poder desembolsar — separation of duties " +
+                        "entre quien aprueba y quien ejecuta el movimiento de fondos.")
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("ANALISTA_CREDITO tiene visibilidad de cuentas/movimientos para evaluar capacidad")
+        void analistaCreditoVeCuentas() {
+            when(jpaRepository.findByRol(Rol.ANALISTA_CREDITO)).thenReturn(List.of());
+
+            List<Permiso> permisos = repository.obtenerPermisosPorRol(Rol.ANALISTA_CREDITO);
+
+            assertThat(permisos).contains(
+                    Permiso.VER_CUENTAS,
+                    Permiso.VER_MOVIMIENTOS,
+                    Permiso.VER_RENDIMIENTOS,
+                    Permiso.VER_DOCUMENTOS
+            );
+        }
+
+        @Test
+        @DisplayName("ANALISTA_CREDITO NO debe tener permisos administrativos sensibles")
+        void analistaCreditoNoTienePermisosAdmin() {
+            when(jpaRepository.findByRol(Rol.ANALISTA_CREDITO)).thenReturn(List.of());
+
+            List<Permiso> permisos = repository.obtenerPermisosPorRol(Rol.ANALISTA_CREDITO);
+
+            // No debe poder crear usuarios, gestionar socios, gestionar tipos de
+            // crédito/cambio, etc.
+            assertThat(permisos)
+                    .doesNotContain(
+                            Permiso.CREAR_USUARIOS,
+                            Permiso.GESTIONAR_USUARIOS,
+                            Permiso.GESTIONAR_SOCIOS,
+                            Permiso.GESTIONAR_TIPOS_CREDITO,
+                            Permiso.GESTIONAR_TIPOS_CAMBIO,
+                            Permiso.REGISTRAR_DEPOSITOS,
+                            Permiso.REGISTRAR_RETIROS
+                    );
+        }
+
+        @Test
+        @DisplayName("inicializarPermisosDefault cubre TODOS los valores del enum (incluido ANALISTA_CREDITO)")
+        void inicializarCubreCadaRol() {
+            when(jpaRepository.existsByRolAndPermiso(any(), any())).thenReturn(false);
+
+            // No debe lanzar (significaría que getPermisosDefault olvidó un case del switch).
+            repository.inicializarPermisosDefault();
+
+            // Verifica explícitamente que cada rol del enum tiene al menos un save.
+            for (Rol rol : Rol.values()) {
+                verify(jpaRepository, atLeastOnce()).save(argThat(
+                        e -> e.getRol() == rol
+                ));
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes #207

## Resumen

\`SecurityConfig.java:40\` declaraba la jerarquía:
\`\`\`java
roleHierarchy.setHierarchy(\"ROLE_ADMIN > ROLE_ANALISTA_CREDITO\");
\`\`\`

Pero el enum \`Rol.java\` NO contenía \`ANALISTA_CREDITO\` — era un **rol fantasma**: el JWT nunca podía emitirlo, ningún usuario lo tenía, las cláusulas \`@PreAuthorize(\"hasRole('ANALISTA_CREDITO')\")\` eran no-op.

## Decisión de diseño (Opción A acotada)

Elegí la **Opción A del issue (crear el rol real)** pero **acotada al núcleo**:
- ✅ Crear el rol + permisos + ayudante en \`PermisoService\`
- ✅ Mantener la jerarquía actual (ahora ya no es fantasma)
- ❌ **NO migrar controllers de crédito** — eso es un cambio mayor que requiere
   coordinación con QA, operaciones (\"¿quién aprobará créditos en QA?\"), y
   probablemente cambio de proceso humano. Lo dejo para issue separado.

Resultado: el rol existe, los permisos están definidos, los \`@PreAuthorize\` futuros pueden referenciarlo. Pero los flujos actuales que usan ADMIN siguen funcionando hasta que se mergee el siguiente PR.

## Permisos para ANALISTA_CREDITO

Subset del ADMIN respetando **Separation of Duties**:

| Permiso | Tiene | Razón |
|---------|:-----:|-------|
| \`EVALUAR_CREDITO\` | ✅ | Trabajo principal del rol |
| \`APROBAR_CREDITO\` | ✅ | Decisión crediticia |
| \`RECHAZAR_CREDITO\` | ✅ | Decisión crediticia |
| \`GESTIONAR_CREDITOS\` | ✅ | Permite usar endpoints del módulo |
| \`VER_DASHBOARD\` | ✅ | Panel admin para trabajar |
| \`VER_AUDITORIA\` | ✅ | Revisar historial del socio |
| \`VER_CUENTAS\`, \`VER_MOVIMIENTOS\`, \`VER_RENDIMIENTOS\` | ✅ | Evaluar capacidad de pago |
| \`VER_DOCUMENTOS\`, \`DESCARGAR_DOCUMENTOS\` | ✅ | Estados de cuenta, KYC |
| **\`DESEMBOLSAR_CREDITO\`** | ❌ | **Separation of Duties — quien aprueba ≠ quien ejecuta el movimiento de fondos** |
| \`CREAR_USUARIOS\`, \`GESTIONAR_SOCIOS\` | ❌ | Fuera de scope del rol |
| \`GESTIONAR_TIPOS_CREDITO\`, \`GESTIONAR_TIPOS_CAMBIO\` | ❌ | Configuración del sistema, no operación |
| \`REGISTRAR_DEPOSITOS\`, \`REGISTRAR_RETIROS\` | ❌ | Operación de caja, no análisis |

## Tests TDD (8 nuevos, todos detectan regresión real)

| Test | SIN fix | CON fix |
|------|---------|---------|
| \`analistaCreditoExisteEnEnum\` | ❌ (Rol.valueOf lanza) | ✅ |
| \`analistaCreditoTienePermisosDefault\` | ❌ (switch no maneja → no compila) | ✅ |
| \`analistaCreditoNoPuedeDesembolsar\` | N/A | ✅ |
| \`analistaCreditoVeCuentas\` | N/A | ✅ |
| \`analistaCreditoNoTienePermisosAdmin\` | N/A | ✅ |
| **\`inicializarCubreCadaRol\`** | ❌ (falla si falta el inicializarRol) | ✅ |
| \`esAnalistaCredito retorna true para ANALISTA_CREDITO\` | N/A | ✅ |
| \`esAnalistaCredito retorna false para ADMIN\` | N/A | ✅ |

**Verificación TDD reverso documentada**: removí la línea \`inicializarRol(Rol.ANALISTA_CREDITO, ...)\` → \`Tests run: 19, Failures: 1\` (exactamente \`inicializarCubreCadaRol\`). Restaurado, 359/359 pasan.

## Resultado del build

\`\`\`
mvn clean test
[INFO] Tests run: 359, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS  -- Total time: 5:28 min
\`\`\`

## Test plan QA

1. **Smoke**: tras el deploy, el log de arranque debe mostrar:
   \`\`\`
   Permisos default inicializados para todos los roles
   \`\`\`
   sin errores de switch incompleto.

2. **Verificar permisos en BD**:
   \`\`\`sql
   SELECT permiso FROM rol_permiso WHERE rol = 'ANALISTA_CREDITO' ORDER BY permiso;
   \`\`\`
   Debe retornar 11 filas con la lista de permisos del PR.

3. **No regresión**: login con \`admin\` y \`socio_prueba\` debe seguir funcionando idéntico (este PR no toca flujos existentes).

## Próximos issues a abrir (no incluidos aquí)

- **Issue X**: migrar \`CreditoController\` para que evaluación/aprobación requieran \`ANALISTA_CREDITO\` en lugar de \`ADMIN\`. Requiere crear usuario de prueba con este rol en QA.
- **Issue Y**: documentar jerarquía de roles en \`docs/operations/roles.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)