### PR TITLE
feat(dashboard): banner KYC condicional en home del socio (#215)

### DIFF
--- a/frontend-web/src/app/(dashboard)/dashboard/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/page.tsx
@@ -18,6 +18,8 @@ import {
   sumaPorcentajes,
   type BeneficiarioApi,
 } from '@/lib/utils/parse-beneficiarios-response';
+import { decidirKycBanner, type KycBannerDecision } from '@/lib/utils/decidir-kyc-banner';
+import { AlertTriangle, Info, XOctagon, ChevronRight } from 'lucide-react';
 
 interface CuentaAhorro {
   id: string;
@@ -142,6 +144,78 @@ function QuickActionButton({
 // los que no tienen vehículo). El módulo de transporte aún no está implementado
 // (EPIC #127). Cuando llegue, se reincorpora con datos reales.
 
+/**
+ * Issue #215: banner condicional sobre el estado KYC del socio.
+ *
+ * Antes el socio no se enteraba en su home si su KYC estaba pendiente,
+ * en revisión, rechazado o nunca iniciado — descubría el problema solo
+ * cuando intentaba operar y fallaba. Ahora le mostramos el estado
+ * inmediato + CTA accionable.
+ *
+ * Si la decisión es `null` (APROBADO o estado desconocido), no renderiza
+ * nada — la ausencia de banner es señal positiva.
+ */
+function KycBanner({ decision }: { decision: KycBannerDecision | null }) {
+  if (!decision) return null;
+
+  const styles = {
+    warning: {
+      container: 'bg-amber-50 border-amber-200',
+      iconWrap: 'bg-amber-100',
+      iconColor: 'text-amber-600',
+      title: 'text-amber-900',
+      text: 'text-amber-800',
+      cta: 'bg-amber-500 hover:bg-amber-600 text-white',
+      Icon: AlertTriangle,
+    },
+    info: {
+      container: 'bg-blue-50 border-blue-200',
+      iconWrap: 'bg-blue-100',
+      iconColor: 'text-blue-600',
+      title: 'text-blue-900',
+      text: 'text-blue-800',
+      cta: 'bg-blue-500 hover:bg-blue-600 text-white',
+      Icon: Info,
+    },
+    error: {
+      container: 'bg-red-50 border-red-200',
+      iconWrap: 'bg-red-100',
+      iconColor: 'text-red-600',
+      title: 'text-red-900',
+      text: 'text-red-800',
+      cta: 'bg-red-500 hover:bg-red-600 text-white',
+      Icon: XOctagon,
+    },
+  }[decision.tipo];
+
+  const { Icon } = styles;
+
+  return (
+    <div
+      role="alert"
+      data-testid={`kyc-banner-${decision.tipo}`}
+      className={`flex items-start gap-4 p-4 lg:p-5 rounded-2xl border ${styles.container}`}
+    >
+      <div className={`w-10 h-10 rounded-xl ${styles.iconWrap} flex items-center justify-center flex-shrink-0`}>
+        <Icon className={`w-5 h-5 ${styles.iconColor}`} />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className={`text-sm font-semibold ${styles.title} mb-1`}>{decision.titulo}</p>
+        <p className={`text-xs ${styles.text}`}>{decision.mensaje}</p>
+      </div>
+      {decision.ctaTexto && decision.ctaHref && (
+        <Link
+          href={decision.ctaHref}
+          className={`flex-shrink-0 inline-flex items-center gap-1 px-3 py-2 text-xs font-semibold rounded-lg transition-colors whitespace-nowrap ${styles.cta}`}
+        >
+          {decision.ctaTexto}
+          <ChevronRight className="w-3 h-3" />
+        </Link>
+      )}
+    </div>
+  );
+}
+
 function TransactionItem({ actividad }: { actividad: MovimientoApi }) {
   const tipo = actividad.tipo?.toUpperCase() ?? '';
   const isDeposit = tipo === 'DEPOSITO' || tipo === 'INTERES' || tipo === 'TRANSFERENCIA_ENTRADA';
@@ -203,6 +277,12 @@ export default function SocioDashboardPage() {
   // con "María García 60%, Juan Pérez 30%, Ana López 10%" — ficticios)
   const [beneficiarios, setBeneficiarios] = useState<BeneficiarioApi[]>([]);
   const [loadingBeneficiarios, setLoadingBeneficiarios] = useState(true);
+
+  // Issue #215: estado KYC para decidir si mostrar banner de aviso.
+  // Mientras no haya cargado (`null`), no mostramos nada — la decisión
+  // del utility ya maneja `null` retornando `null`.
+  const [kycEstado, setKycEstado] = useState<string | null>(null);
+  const [kycMotivoRechazo, setKycMotivoRechazo] = useState<string | null>(null);
 
   const cargarCuentas = useCallback(async () => {
     if (!user?.socioId) return;
@@ -293,6 +373,33 @@ export default function SocioDashboardPage() {
     }
   }, [loadingCuentas, cargarMovimientos]);
 
+  // Issue #215: cargar estado KYC (el BFF mapea KYC no iniciado a estado SIN_KYC)
+  const cargarKycEstado = useCallback(async () => {
+    try {
+      const res = await fetch('/api/kyc/estado');
+      if (res.ok) {
+        const data = await res.json();
+        setKycEstado(data?.estado ?? null);
+        setKycMotivoRechazo(data?.motivoRechazo ?? null);
+      } else {
+        // 401/500 → no mostrar banner (no queremos ruido por fallo de red)
+        setKycEstado(null);
+      }
+    } catch (err) {
+      console.error('Error cargando estado KYC:', err);
+      setKycEstado(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isLoading && user?.socioId) {
+      cargarKycEstado();
+    }
+  }, [isLoading, user?.socioId, cargarKycEstado]);
+
+  // Decisión derivada — el utility maneja todos los casos (incluido null).
+  const kycBannerDecision = decidirKycBanner(kycEstado, kycMotivoRechazo);
+
   // Issue #213: agregación correcta de saldos multimoneda.
   // `null` cuando la tasa todavía no se cargó (mostramos fallback, no número).
   const saldoAgregado = calcularSaldoTotal(cuentas, tasaActual);
@@ -337,6 +444,10 @@ export default function SocioDashboardPage() {
           <p className="text-sm text-slate-500 mt-0.5">Aquí está el resumen de tu cuenta</p>
         </div>
       </div>
+
+      {/* Issue #215: banner KYC condicional. NO renderiza nada si APROBADO o
+          estado aún no cargado — la ausencia es señal positiva. */}
+      <KycBanner decision={kycBannerDecision} />
 
       {/* Hero Balance Card */}
       <div className="bg-gradient-to-br from-[#0F2744] via-[#0F2744] to-[#1a4a7a] rounded-3xl p-6 lg:p-8 text-white relative overflow-hidden">

--- a/frontend-web/src/lib/utils/decidir-kyc-banner.test.ts
+++ b/frontend-web/src/lib/utils/decidir-kyc-banner.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest';
+import { decidirKycBanner } from './decidir-kyc-banner';
+
+/**
+ * Tests para issue #215: decisión de UI del banner KYC según estado del backend.
+ *
+ * El backend tiene 7 estados de EstadoVerificacion + el "virtual" SIN_KYC
+ * que mapea el BFF cuando el socio no inició el proceso. Cada uno debe
+ * producir el banner correcto (o ninguno, para APROBADO).
+ */
+describe('decidirKycBanner (issue #215)', () => {
+
+  describe('Estados que SÍ muestran banner', () => {
+
+    it('SIN_KYC → banner warning con CTA para comenzar', () => {
+      const decision = decidirKycBanner('SIN_KYC');
+
+      expect(decision).not.toBeNull();
+      expect(decision!.tipo).toBe('warning');
+      expect(decision!.titulo).toContain('Completa tu verificación');
+      expect(decision!.ctaTexto).toBe('Comenzar verificación');
+      expect(decision!.ctaHref).toBe('/dashboard/kyc');
+    });
+
+    it('PENDIENTE → banner info (24-48h)', () => {
+      const decision = decidirKycBanner('PENDIENTE');
+      expect(decision).not.toBeNull();
+      expect(decision!.tipo).toBe('info');
+      expect(decision!.mensaje).toContain('24');
+    });
+
+    it('EN_REVISION → banner info', () => {
+      const decision = decidirKycBanner('EN_REVISION');
+      expect(decision).not.toBeNull();
+      expect(decision!.tipo).toBe('info');
+      expect(decision!.titulo).toContain('revisión');
+    });
+
+    it('REENVIADO → banner info', () => {
+      const decision = decidirKycBanner('REENVIADO');
+      expect(decision).not.toBeNull();
+      expect(decision!.tipo).toBe('info');
+    });
+
+    it('RECHAZADO sin motivo → banner error genérico', () => {
+      const decision = decidirKycBanner('RECHAZADO');
+      expect(decision).not.toBeNull();
+      expect(decision!.tipo).toBe('error');
+      expect(decision!.titulo).toContain('rechazada');
+      expect(decision!.ctaTexto).toBe('Corregir documentos');
+    });
+
+    it('Issue #215: RECHAZADO CON motivo → muestra el motivo al socio', () => {
+      const motivo = 'La foto de la cédula está borrosa';
+      const decision = decidirKycBanner('RECHAZADO', motivo);
+
+      expect(decision).not.toBeNull();
+      expect(decision!.tipo).toBe('error');
+      // CRÍTICO: el motivo debe aparecer en el mensaje para que el socio
+      // sepa qué corregir, no un mensaje genérico.
+      expect(decision!.mensaje).toContain(motivo);
+    });
+
+    it('EXPIRADO → banner warning para renovar', () => {
+      const decision = decidirKycBanner('EXPIRADO');
+      expect(decision).not.toBeNull();
+      expect(decision!.tipo).toBe('warning');
+      expect(decision!.ctaTexto).toBe('Renovar KYC');
+    });
+
+    it('CANCELADO → banner warning para reiniciar', () => {
+      const decision = decidirKycBanner('CANCELADO');
+      expect(decision).not.toBeNull();
+      expect(decision!.tipo).toBe('warning');
+      expect(decision!.ctaTexto).toBe('Reiniciar verificación');
+    });
+  });
+
+  describe('Estados que NO muestran banner', () => {
+
+    it('APROBADO → null (sin banner, todo OK)', () => {
+      // CRÍTICO: socio aprobado NO debe ver banner — la ausencia es el
+      // mensaje positivo. Banner permanente sería ruido visual.
+      const decision = decidirKycBanner('APROBADO');
+      expect(decision).toBeNull();
+    });
+
+    it('null (estado aún no cargado) → null (no ruido)', () => {
+      expect(decidirKycBanner(null)).toBeNull();
+    });
+
+    it('undefined (estado nunca seteado) → null', () => {
+      expect(decidirKycBanner(undefined)).toBeNull();
+    });
+
+    it('string vacío → null', () => {
+      expect(decidirKycBanner('')).toBeNull();
+    });
+  });
+
+  describe('Defensive (futuro-proof)', () => {
+
+    it('estado desconocido → null + warning en consola', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const decision = decidirKycBanner('FUTURO_NUEVO_ESTADO');
+
+      expect(decision).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Estado KYC desconocido')
+      );
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('Issue #215: todos los CTAs apuntan a /dashboard/kyc', () => {
+    const estadosConBanner = [
+      'SIN_KYC', 'PENDIENTE', 'EN_REVISION', 'REENVIADO',
+      'RECHAZADO', 'EXPIRADO', 'CANCELADO',
+    ];
+
+    estadosConBanner.forEach((estado) => {
+      it(`${estado} → ctaHref es /dashboard/kyc`, () => {
+        const decision = decidirKycBanner(estado);
+        expect(decision).not.toBeNull();
+        expect(decision!.ctaHref).toBe('/dashboard/kyc');
+      });
+    });
+  });
+});

--- a/frontend-web/src/lib/utils/decidir-kyc-banner.ts
+++ b/frontend-web/src/lib/utils/decidir-kyc-banner.ts
@@ -1,0 +1,141 @@
+/**
+ * Decide qué banner KYC mostrar en el home del socio según el estado actual
+ * (issue #215).
+ *
+ * El backend retorna {@code EstadoKYCResponse.estado} como uno de:
+ *   PENDIENTE | EN_REVISION | APROBADO | RECHAZADO | REENVIADO | EXPIRADO | CANCELADO
+ *
+ * El BFF (`/api/kyc/estado`) además mapea el caso "socio no inició KYC"
+ * (backend devuelve 500 + KYC_000) a `{estado: 'SIN_KYC', mensaje}`.
+ *
+ * Esta función traduce ese estado en una decisión de UI (tipo de banner,
+ * título, mensaje, CTA). Si retorna `null`, NO mostramos banner —
+ * típicamente porque el socio está APROBADO y no necesita ver nada.
+ */
+
+export type KycEstado =
+  | 'SIN_KYC'        // BFF: socio no inició proceso
+  | 'PENDIENTE'      // Documentos enviados, en cola
+  | 'EN_REVISION'    // Analista revisando
+  | 'APROBADO'       // OK — no mostrar banner
+  | 'RECHAZADO'      // Necesita corregir
+  | 'REENVIADO'      // Reenviado tras rechazo, esperando re-revisión
+  | 'EXPIRADO'       // KYC expiró, debe renovar
+  | 'CANCELADO';     // Socio canceló el proceso
+
+export type KycBannerTipo = 'warning' | 'info' | 'error';
+
+export interface KycBannerDecision {
+  /** Estilo visual del banner. */
+  tipo: KycBannerTipo;
+  /** Título corto y accionable. */
+  titulo: string;
+  /** Texto descriptivo bajo el título. */
+  mensaje: string;
+  /** Texto del botón CTA (null = sin botón, solo informativo). */
+  ctaTexto: string | null;
+  /** URL relativa del CTA (típicamente `/dashboard/kyc`). */
+  ctaHref: string | null;
+}
+
+/**
+ * @param estado estado actual de la verificación KYC del socio
+ * @param motivoRechazo opcional, solo aplica a estado RECHAZADO
+ * @returns decisión de UI o `null` si NO debe mostrarse banner
+ */
+export function decidirKycBanner(
+  estado: KycEstado | string | null | undefined,
+  motivoRechazo?: string | null
+): KycBannerDecision | null {
+  if (!estado) {
+    // Aún no cargó / error de red → no mostrar banner (UI no debe ruido cuando
+    // simplemente no sabemos el estado todavía).
+    return null;
+  }
+
+  switch (estado as KycEstado) {
+    case 'APROBADO':
+      // OK — el socio puede operar sin restricciones, sin banner.
+      return null;
+
+    case 'SIN_KYC':
+      return {
+        tipo: 'warning',
+        titulo: 'Completa tu verificación de identidad',
+        mensaje:
+          'Necesitas verificar tu identidad (KYC) para acceder a todas las funciones del fondo (créditos, montos altos, etc.).',
+        ctaTexto: 'Comenzar verificación',
+        ctaHref: '/dashboard/kyc',
+      };
+
+    case 'PENDIENTE':
+      return {
+        tipo: 'info',
+        titulo: 'Verificación KYC en cola',
+        mensaje:
+          'Recibimos tus documentos. Te notificaremos cuando el analista los revise (24–48h hábiles).',
+        ctaTexto: 'Ver detalle',
+        ctaHref: '/dashboard/kyc',
+      };
+
+    case 'EN_REVISION':
+      return {
+        tipo: 'info',
+        titulo: 'Verificación KYC en revisión',
+        mensaje:
+          'Un analista está revisando tus documentos. Te notificaremos en breve.',
+        ctaTexto: 'Ver detalle',
+        ctaHref: '/dashboard/kyc',
+      };
+
+    case 'REENVIADO':
+      return {
+        tipo: 'info',
+        titulo: 'Documentos reenviados',
+        mensaje:
+          'Tus correcciones fueron recibidas y están en cola para nueva revisión.',
+        ctaTexto: 'Ver detalle',
+        ctaHref: '/dashboard/kyc',
+      };
+
+    case 'RECHAZADO':
+      return {
+        tipo: 'error',
+        titulo: 'Verificación KYC rechazada',
+        mensaje: motivoRechazo
+          ? `Motivo: ${motivoRechazo}. Corrige los documentos para continuar.`
+          : 'Hubo un problema con tus documentos. Revisa el detalle para corregir.',
+        ctaTexto: 'Corregir documentos',
+        ctaHref: '/dashboard/kyc',
+      };
+
+    case 'EXPIRADO':
+      return {
+        tipo: 'warning',
+        titulo: 'Tu verificación KYC expiró',
+        mensaje:
+          'Por seguridad y regulación bancaria, debes renovar tu verificación de identidad.',
+        ctaTexto: 'Renovar KYC',
+        ctaHref: '/dashboard/kyc',
+      };
+
+    case 'CANCELADO':
+      return {
+        tipo: 'warning',
+        titulo: 'Verificación KYC cancelada',
+        mensaje:
+          'Cancelaste tu proceso de verificación. Puedes reiniciarlo cuando quieras.',
+        ctaTexto: 'Reiniciar verificación',
+        ctaHref: '/dashboard/kyc',
+      };
+
+    default:
+      // Estado desconocido (futuro, typo, etc.) — no rompemos la UI, no
+      // mostramos banner ruido. El log queda en consola para detectar.
+      if (typeof window !== 'undefined') {
+        // eslint-disable-next-line no-console
+        console.warn(`[KycBanner] Estado KYC desconocido: ${estado}`);
+      }
+      return null;
+  }
+}


### PR DESCRIPTION
Closes #215

## Resumen

Antes el socio entraba al home y **no se enteraba** si su KYC estaba pendiente, en revisión, rechazado o nunca iniciado. Descubría el problema solo cuando intentaba operar y fallaba. Si su KYC era rechazado con un motivo concreto, el motivo solo aparecía dentro del menú KYC → muchos socios abandonaban.

Ahora: banner condicional en el home (entre el saludo y el saldo) con el estado actual + CTA directo a corregir/iniciar.

## Estados cubiertos

| Estado backend | Banner | Color | CTA |
|---|---|---|---|
| **APROBADO** | ❌ Sin banner (señal positiva) | — | — |
| **SIN_KYC** (BFF inyecta) | ✅ \"Completa tu verificación...\" | 🟡 Warning | Comenzar verificación |
| **PENDIENTE** | ✅ \"En cola, 24-48h\" | 🔵 Info | Ver detalle |
| **EN_REVISION** | ✅ \"Analista revisando\" | 🔵 Info | Ver detalle |
| **REENVIADO** | ✅ \"Reenviados\" | 🔵 Info | Ver detalle |
| **RECHAZADO** | ✅ \"Motivo: {motivoRechazo}\" | 🔴 Error | Corregir documentos |
| **EXPIRADO** | ✅ \"Tu KYC expiró\" | 🟡 Warning | Renovar KYC |
| **CANCELADO** | ✅ \"Cancelaste el proceso\" | 🟡 Warning | Reiniciar verificación |

## Cambios técnicos

### Utility puro testeable
\`decidir-kyc-banner.ts\`:
- Función pura \`decidirKycBanner(estado, motivoRechazo) → KycBannerDecision | null\`.
- Switch exhaustivo sobre los 7 estados del backend + SIN_KYC.
- \`null\` para APROBADO (la ausencia es la señal) y para estados desconocidos (defensive futuro-proof).
- RECHAZADO con motivo lo propaga al socio.

### Componente \`KycBanner\`
Estilos por tipo (warning/info/error) con ícono propio (\`AlertTriangle\`/\`Info\`/\`XOctagon\`). \`role=\"alert\"\` + \`data-testid\` por tipo para tests E2E futuros.

### Integración en \`dashboard/page.tsx\`
- Nuevo \`useEffect\` para fetch a \`/api/kyc/estado\` (no bloquea otros fetches).
- Banner renderizado **entre Welcome y Hero Balance** — posición más visible para mensajes accionables.
- Si la API falla (401/500), no se muestra banner (no ruido por red).

## Tests TDD (20 nuevos)

| Test | Tipo | SIN fix | CON fix |
|------|------|---------|---------|
| Cada estado (7) produce el tipo + CTA esperado | unit | N/A | ✅ |
| APROBADO → null (la ausencia es la señal) | **crítico** | N/A | ✅ |
| **RECHAZADO CON motivo → muestra el motivo** | **regression** | ❌ FAIL | ✅ PASS |
| null/undefined/string vacío → null (no ruido) | defensive | N/A | ✅ |
| Estado desconocido → null + warning consola | defensive | N/A | ✅ |
| Todos los 7 CTAs apuntan a /dashboard/kyc | parametrized x7 | N/A | ✅ |

**Verificación TDD reverso**: rompí el case RECHAZADO para ignorar \`motivoRechazo\` → el test \"RECHAZADO CON motivo\" falla. Restaurado, **20/20 pasan**.

## Test plan QA

### Caso 1 — Socio APROBADO (\`socio_prueba\` por defecto)
- Login y home → **NO debe ver banner KYC**.
- Es la señal positiva: el socio aprobado tiene un home limpio.

### Caso 2 — Socio SIN KYC (banner amarillo)
\`\`\`sql
DELETE FROM kyc_verificacion WHERE socio_id = (
    SELECT id FROM socios WHERE numero_documento = 'V-20123456'
);
\`\`\`
Refrescar home → banner amarillo \"Completa tu verificación\" + CTA verde.

### Caso 3 — Socio RECHAZADO con motivo (banner rojo)
\`\`\`sql
UPDATE kyc_verificacion
   SET estado = 'RECHAZADO',
       motivo_rechazo = 'La foto de la cédula está borrosa'
 WHERE socio_id = (SELECT id FROM socios WHERE numero_documento = 'V-20123456');
\`\`\`
Refrescar home → banner rojo \"Motivo: La foto de la cédula está borrosa. Corrige los documentos...\"

### Caso 4 — Click CTA
Cualquier banner → click CTA → navega a \`/dashboard/kyc\` sin 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)