### PR TITLE
hotfix(auth): CHECK constraint rol_permiso.rol debe incluir ANALISTA_CREDITO (regresión #207)

### DIFF
--- a/backend/src/main/resources/db/migration/V17__rol_permiso_check_incluir_analista_credito.sql
+++ b/backend/src/main/resources/db/migration/V17__rol_permiso_check_incluir_analista_credito.sql
@@ -1,0 +1,59 @@
+-- =============================================================================
+-- V17: HOTFIX - Actualizar CHECK constraint de `rol_permiso.rol` para incluir
+--      ANALISTA_CREDITO (regresión introducida por PR #234, issue #207).
+-- =============================================================================
+--
+-- PROBLEMA
+-- --------
+-- El PR #234 agregó el valor `ANALISTA_CREDITO` al enum `Rol.java` y al
+-- `inicializarPermisosDefault()`. Asumió (erróneamente) que Hibernate
+-- `ddl-auto: update` actualizaría el CHECK constraint generado para la
+-- columna `rol_permiso.rol`. Hibernate NO actualiza CHECK constraints
+-- existentes — solo agrega columnas/tablas nuevas.
+--
+-- Al arrancar el backend en QA tras el merge de #234:
+--   PermisoInicializador.run() → inicializarPermisosDefault()
+--     → inicializarRol(Rol.ANALISTA_CREDITO, ...)
+--       → INSERT INTO rol_permiso (..., rol='ANALISTA_CREDITO')
+--         → ERROR: rol_permiso_rol_check rejects the value
+--
+-- Resultado: backend muere al arrancar → todos los requests dan 500
+-- (incluido /api/v1/auth/login que el usuario reportó).
+--
+-- ACCIÓN
+-- ------
+-- 1. Drop el constraint viejo (idempotente con IF EXISTS).
+-- 2. Recrear con la lista completa actual del enum Rol (7 valores).
+--
+-- Usamos `to_regclass` para skip silencioso si la tabla aún no existe
+-- (caso entorno limpio nuevo, donde Hibernate la creará después).
+--
+-- NOTA: este patrón se repetirá cada vez que se agregue un valor al enum
+-- `Rol`. Considerar (otro issue) migrar a una tabla `roles` real para
+-- desacoplar del enum, o usar `TEXT` + validación en aplicación.
+-- =============================================================================
+
+DO $$
+BEGIN
+    IF to_regclass('public.rol_permiso') IS NOT NULL THEN
+        -- Drop si existe (Hibernate puede haber autogenerado un nombre
+        -- estable o aleatorio; el más común es `rol_permiso_rol_check`).
+        ALTER TABLE rol_permiso DROP CONSTRAINT IF EXISTS rol_permiso_rol_check;
+
+        -- Recrear con todos los valores del enum actual.
+        ALTER TABLE rol_permiso ADD CONSTRAINT rol_permiso_rol_check
+            CHECK (rol IN (
+                'SOCIO',
+                'ADMIN',
+                'SUPER_ADMIN',
+                'CAJERO',
+                'ANALISTA_KYC',
+                'ANALISTA_CREDITO',   -- Issue #207 / hotfix
+                'SISTEMA'
+            ));
+
+        RAISE NOTICE 'V17: rol_permiso_rol_check actualizado para incluir ANALISTA_CREDITO.';
+    ELSE
+        RAISE NOTICE 'V17: tabla rol_permiso no existe aún (entorno limpio), skip.';
+    END IF;
+END $$;


### PR DESCRIPTION
🚨 **HOTFIX urgente** — el PR #234 (issue #207) rompió el arranque del backend en QA esta tarde. Resucitado en caliente con SQL manual a las 14:11 UTC; este PR deja la migración en repo para entornos futuros.

## Síntoma reportado por usuario

> \"cuando en qa intento logearme da error de servidor\"

\`POST /api/auth/login\` → 500 \"Error interno del servidor\".

## Causa raíz

PR #234 (issue #207) agregó \`ANALISTA_CREDITO\` al enum \`Rol\` y al \`inicializarPermisosDefault()\`. **Asumió que Hibernate \`ddl-auto: update\` actualizaría el CHECK constraint** que Hibernate había generado originalmente para \`rol_permiso.rol\`. **Hibernate NO actualiza CHECK constraints existentes** — solo agrega columnas/tablas nuevas.

Logs del backend QA:
\`\`\`
ERROR: new row for relation \"rol_permiso\" violates check constraint \"rol_permiso_rol_check\"
Detail: Failing row contains (..., VER_DASHBOARD, ANALISTA_CREDITO).
[insert into rol_permiso (permiso,rol,id) values (?,?,?)]
at RolPermisoRepositoryImpl.inicializarRol(RolPermisoRepositoryImpl.java:188)
at PermisoInicializador.run(PermisoInicializador.java:20)
...
Application run failed
\`\`\`

El backend **muere al arrancar** → todos los requests (login incluido) responden 500.

## Acción inmediata ya aplicada en QA

\`\`\`sql
ALTER TABLE rol_permiso DROP CONSTRAINT IF EXISTS rol_permiso_rol_check;
ALTER TABLE rol_permiso ADD CONSTRAINT rol_permiso_rol_check
    CHECK (rol IN ('SOCIO','ADMIN','SUPER_ADMIN','CAJERO',
                   'ANALISTA_KYC','ANALISTA_CREDITO','SISTEMA'));
\`\`\`
\`docker restart fatrans-qa-backend\` → backend healthy en 20s.

**Verificación**:
\`\`\`
curl -X POST .../api/auth/login -d '{...socio_prueba...}'
→ HTTP 200 {\"success\":true,\"user\":{...}}
\`\`\`

## Fix permanente (este PR)

**Migración Flyway V17** que aplica el mismo ALTER. Idempotente:
- \`DROP CONSTRAINT IF EXISTS\` (no falla si ya fue eliminado por el SQL manual).
- \`to_regclass\` para skip si la tabla aún no existe (entorno limpio).
- Re-ejecutar en QA: no-op seguro (el constraint ya tiene la lista correcta).
- Ejecutar en prod (cuando llegue): aplica el fix real.

## Tests

\`mvn test -Dtest=RolPermisoRepositoryImplTest,PermisoServiceTest\` → **38/38 pasan** (los del PR #234 ya verificaban que ANALISTA_CREDITO existe y tiene permisos; ahora el constraint también lo permite a nivel DB).

## Lección aprendida — agregar al CONTRIBUTING

> ⚠️ Cualquier cambio futuro al enum \`Rol\` (o a cualquier enum mapeado a una columna con CHECK constraint autogenerado por Hibernate) DEBE acompañarse de una migración Flyway que actualice el constraint. \`ddl-auto: update\` no lo hace.

Sugerencia: considerar migrar de enum-en-Java a tabla \`roles\` real (issue futuro) para desacoplar el schema de cambios al código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)