### PR TITLE
feat(socio): idle timeout watcher con warning modal + auto-logout (#221)

### DIFF
--- a/frontend-web/src/components/features/auth/login-form-neobank.tsx
+++ b/frontend-web/src/components/features/auth/login-form-neobank.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { loginSchema } from '@/lib/utils/validators';
 import { useAuthStore } from '@/stores/auth-store';
 import { Button } from '@/components/ui/button';
@@ -45,8 +45,20 @@ export function LoginFormNeobank() {
   const [lockoutRemaining, setLockoutRemaining] = useState(0);
   const [rememberMe, setRememberMe] = useState(false);
   const router = useRouter();
+  const searchParams = useSearchParams();
   const setUser = useAuthStore((state) => state.setUser);
   const setLoading = useAuthStore((state) => state.setLoading);
+
+  // Issue #221: si llegamos al login por idle timeout, avisar al usuario
+  useEffect(() => {
+    const reason = searchParams?.get('reason');
+    if (reason === 'inactivity') {
+      toast.info('Sesión cerrada por inactividad', {
+        description: 'Por tu seguridad, cerramos tu sesión tras varios minutos sin actividad.',
+        duration: 6000,
+      });
+    }
+  }, [searchParams]);
 
   const {
     register,

--- a/frontend-web/src/components/layouts/socio/socio-shell.tsx
+++ b/frontend-web/src/components/layouts/socio/socio-shell.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 import { useAuthStore } from '@/stores/auth-store';
 import { ProtectedRoute } from '@/components/shared/protected-route';
 import { LogoutButton } from '@/components/shared/logout-button';
+import { IdleTimeoutWatcher } from '@/components/shared/idle-timeout-watcher';
 import {
   LayoutDashboard,
   Wallet,
@@ -71,6 +72,8 @@ export function SocioShell({ children }: { children: React.ReactNode }) {
 
   return (
     <ProtectedRoute allowedRoles={['SOCIO', 'ADMIN', 'SUPER_ADMIN']}>
+      {/* Issue #221: auto-logout por inactividad (banking standard) */}
+      <IdleTimeoutWatcher idleMinutes={10} warningSeconds={60} />
       <div className="flex min-h-screen bg-slate-100">
         {/* Desktop Sidebar - Minimal & Clean */}
         <aside className="hidden lg:flex w-64 bg-white flex-col fixed h-full z-40 border-r border-slate-200">

--- a/frontend-web/src/components/shared/idle-timeout-watcher.tsx
+++ b/frontend-web/src/components/shared/idle-timeout-watcher.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/stores/auth-store';
+import { useIdleTimeout } from '@/hooks/useIdleTimeout';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Clock } from 'lucide-react';
+
+/**
+ * Vigilante de inactividad para sesiones de socio (issue #221).
+ *
+ * Tras `idleMinutes` minutos sin actividad → modal con countdown de
+ * `warningSeconds` segundos. Si no responde → logout + redirect a
+ * `/login?reason=inactivity`.
+ *
+ * Banking standard: si dejas el teléfono sin bloqueo, cualquiera operaría
+ * con tu cuenta. Auto-logout previene esto.
+ *
+ * Defaults sensatos para socio (10 min idle + 60s countdown). Admin
+ * podría usar valores más estrictos vía props si se reusa.
+ */
+interface IdleTimeoutWatcherProps {
+  /** Minutos de inactividad antes del warning. Default 10. */
+  idleMinutes?: number;
+  /** Segundos del countdown del warning. Default 60. */
+  warningSeconds?: number;
+}
+
+export function IdleTimeoutWatcher({
+  idleMinutes = 10,
+  warningSeconds = 60,
+}: IdleTimeoutWatcherProps) {
+  const router = useRouter();
+  const logout = useAuthStore((state) => state.logout);
+  const user = useAuthStore((state) => state.user);
+
+  const handleTimeout = useCallback(async () => {
+    try {
+      await logout();
+    } catch {
+      // logout puede fallar si el token ya expiró; igual continuamos
+    }
+    router.push('/login?reason=inactivity');
+  }, [logout, router]);
+
+  const { showWarning, secondsRemaining, dismissWarning } = useIdleTimeout({
+    idleMs: idleMinutes * 60 * 1000,
+    warningCountdownMs: warningSeconds * 1000,
+    onTimeout: handleTimeout,
+    enabled: !!user, // solo activo si hay sesión
+  });
+
+  return (
+    <AlertDialog open={showWarning} onOpenChange={(open) => !open && dismissWarning()}>
+      <AlertDialogContent
+        data-testid="idle-timeout-warning"
+        className="border-amber-200"
+      >
+        <AlertDialogHeader>
+          <div className="flex items-center gap-3 mb-1">
+            <div className="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center">
+              <Clock className="w-5 h-5 text-amber-600" />
+            </div>
+            <AlertDialogTitle className="text-[#0F2744]">
+              ¿Sigues conectado?
+            </AlertDialogTitle>
+          </div>
+          <AlertDialogDescription>
+            Por tu seguridad, cerraremos tu sesión automáticamente en{' '}
+            <span className="font-bold text-amber-700 tabular-nums">
+              {secondsRemaining}s
+            </span>{' '}
+            debido a inactividad. Presiona el botón si deseas continuar.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogAction
+            onClick={dismissWarning}
+            className="bg-[#16A34A] hover:bg-[#15803D]"
+          >
+            Seguir conectado
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend-web/src/hooks/useIdleTimeout.test.ts
+++ b/frontend-web/src/hooks/useIdleTimeout.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useIdleTimeout } from './useIdleTimeout';
+
+/**
+ * Tests para issue #221: idle timeout watcher.
+ *
+ * Usa fake timers para no esperar segundos/minutos reales. Simulamos
+ * actividad disparando eventos del DOM en `document` (jsdom).
+ */
+describe('useIdleTimeout (issue #221)', () => {
+  let onTimeout: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    onTimeout = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('Después de `idleMs` sin actividad → muestra warning', () => {
+    const { result } = renderHook(() =>
+      useIdleTimeout({
+        idleMs: 9000,
+        warningCountdownMs: 1000,
+        onTimeout,
+      })
+    );
+
+    expect(result.current.showWarning).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(9000);
+    });
+
+    expect(result.current.showWarning).toBe(true);
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('Issue #221: si nadie responde al warning → onTimeout se llama tras warningCountdownMs', () => {
+    renderHook(() =>
+      useIdleTimeout({
+        idleMs: 9000,
+        warningCountdownMs: 1000,
+        onTimeout,
+      })
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(9000); // entra en warning
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000); // expira el countdown
+    });
+
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('Actividad antes del warning → resetea el timer (NO triggea warning)', () => {
+    const { result } = renderHook(() =>
+      useIdleTimeout({
+        idleMs: 9000,
+        warningCountdownMs: 1000,
+        onTimeout,
+      })
+    );
+
+    // Pasamos 5s (menos que idleMs)
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    // Actividad: reset
+    act(() => {
+      document.dispatchEvent(new Event('mousedown'));
+    });
+
+    // Otros 5s → todavía no debería haber warning (porque se reseteó)
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(result.current.showWarning).toBe(false);
+
+    // Si pasan 4s más → ahora sí (total desde el reset: 9s)
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+
+    expect(result.current.showWarning).toBe(true);
+  });
+
+  it('Issue #221: actividad DURANTE el warning NO debe cancelarlo (anti-mousemove fantasma)', () => {
+    const { result } = renderHook(() =>
+      useIdleTimeout({
+        idleMs: 1000,
+        warningCountdownMs: 5000,
+        onTimeout,
+      })
+    );
+
+    // Entrar al warning
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.showWarning).toBe(true);
+
+    // Simular actividad accidental durante el countdown
+    act(() => {
+      document.dispatchEvent(new Event('mousemove'));
+    });
+
+    // El warning DEBE seguir activo (usuario debe presionar "Seguir conectado")
+    expect(result.current.showWarning).toBe(true);
+
+    // Si nadie hace nada, expira normalmente
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismissWarning() cierra el warning y reinicia el ciclo idle', () => {
+    const { result } = renderHook(() =>
+      useIdleTimeout({
+        idleMs: 1000,
+        warningCountdownMs: 5000,
+        onTimeout,
+      })
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1000); // entra al warning
+    });
+    expect(result.current.showWarning).toBe(true);
+
+    act(() => {
+      result.current.dismissWarning();
+    });
+    expect(result.current.showWarning).toBe(false);
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    // Tras dismiss, el ciclo reinicia: 1s más sin actividad debería volver al warning
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.showWarning).toBe(true);
+  });
+
+  it('secondsRemaining cuenta hacia abajo desde warningCountdownMs/1000', () => {
+    const { result } = renderHook(() =>
+      useIdleTimeout({
+        idleMs: 1000,
+        warningCountdownMs: 5000, // 5 seg
+        onTimeout,
+      })
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1000); // entra al warning
+    });
+    expect(result.current.secondsRemaining).toBe(5);
+
+    act(() => {
+      vi.advanceTimersByTime(1000); // 1 seg después
+    });
+    expect(result.current.secondsRemaining).toBe(4);
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(result.current.secondsRemaining).toBe(1);
+  });
+
+  it('enabled=false → no se registran timers ni listeners', () => {
+    renderHook(() =>
+      useIdleTimeout({
+        idleMs: 1000,
+        warningCountdownMs: 1000,
+        onTimeout,
+        enabled: false,
+      })
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('Cleanup: desmontar el hook cancela todos los timers', () => {
+    const { unmount } = renderHook(() =>
+      useIdleTimeout({
+        idleMs: 1000,
+        warningCountdownMs: 1000,
+        onTimeout,
+      })
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    unmount();
+
+    // Aunque pasen 10s, onTimeout NO debe llamarse (timer cancelado)
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/frontend-web/src/hooks/useIdleTimeout.ts
+++ b/frontend-web/src/hooks/useIdleTimeout.ts
@@ -1,0 +1,155 @@
+'use client';
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+
+/**
+ * Hook puro de idle timeout para sesiones de banca (issue #221).
+ *
+ * Reproduce el patrón estándar de apps bancarias:
+ *  - Tras `idleMs` de inactividad → muestra warning con countdown.
+ *  - Si tras `warningCountdownMs` el usuario sigue sin responder → `onTimeout()`.
+ *  - Cualquier actividad detectada en `events` resetea el contador a 0.
+ *
+ * Diseñado puro: sin importar react-idle-timer ni librerías externas. Usa
+ * únicamente `setTimeout` y `addEventListener`. ~50 líneas testeables.
+ *
+ * @example
+ *   const { showWarning, secondsRemaining, dismissWarning } = useIdleTimeout({
+ *     idleMs: 9 * 60 * 1000,        // 9 min inactivo → warning
+ *     warningCountdownMs: 60 * 1000, // 60s para responder
+ *     onTimeout: () => logout(),
+ *     enabled: !!user,
+ *   });
+ */
+
+export interface UseIdleTimeoutOptions {
+  /** Tiempo de inactividad antes de mostrar el warning (ms). */
+  idleMs: number;
+  /** Tiempo del countdown del warning antes del timeout (ms). */
+  warningCountdownMs: number;
+  /** Callback al expirar el countdown (típicamente: logout + redirect). */
+  onTimeout: () => void;
+  /** Si el watcher está activo. Útil para deshabilitar mientras no hay usuario. */
+  enabled?: boolean;
+  /** Eventos del DOM que resetean el timer (default: estándar de actividad). */
+  events?: ReadonlyArray<keyof DocumentEventMap>;
+}
+
+export interface UseIdleTimeoutReturn {
+  /** True cuando se está mostrando el warning. */
+  showWarning: boolean;
+  /** Segundos restantes en el countdown (0 cuando expira). */
+  secondsRemaining: number;
+  /** Cerrar el warning y reiniciar el idle timer (botón "Seguir conectado"). */
+  dismissWarning: () => void;
+}
+
+const DEFAULT_EVENTS: ReadonlyArray<keyof DocumentEventMap> = [
+  'mousedown', 'mousemove', 'keydown', 'scroll', 'touchstart', 'click',
+];
+
+export function useIdleTimeout({
+  idleMs,
+  warningCountdownMs,
+  onTimeout,
+  enabled = true,
+  events = DEFAULT_EVENTS,
+}: UseIdleTimeoutOptions): UseIdleTimeoutReturn {
+  const [showWarning, setShowWarning] = useState(false);
+  const [secondsRemaining, setSecondsRemaining] = useState(
+    Math.ceil(warningCountdownMs / 1000)
+  );
+
+  // Refs para los timers (no triggean re-renders)
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const countdownTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const timeoutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Refs para callbacks/valores volátiles: las funciones registradas en
+  // setTimeout/listeners NO deben recrearse cuando cambia el state, sino
+  // el useEffect de setup re-ejecuta y cancela los timers recién creados
+  // (bug detectado en TDD).
+  const onTimeoutRef = useRef(onTimeout);
+  const showWarningRef = useRef(showWarning);
+  const idleMsRef = useRef(idleMs);
+  const warningCountdownMsRef = useRef(warningCountdownMs);
+
+  useEffect(() => { onTimeoutRef.current = onTimeout; }, [onTimeout]);
+  useEffect(() => { showWarningRef.current = showWarning; }, [showWarning]);
+  useEffect(() => { idleMsRef.current = idleMs; }, [idleMs]);
+  useEffect(() => { warningCountdownMsRef.current = warningCountdownMs; }, [warningCountdownMs]);
+
+  const clearAllTimers = useCallback(() => {
+    if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+    if (countdownTimerRef.current) clearInterval(countdownTimerRef.current);
+    if (timeoutTimerRef.current) clearTimeout(timeoutTimerRef.current);
+    idleTimerRef.current = null;
+    countdownTimerRef.current = null;
+    timeoutTimerRef.current = null;
+  }, []);
+
+  const dismissWarning = useCallback(() => {
+    clearAllTimers();
+    setShowWarning(false);
+    setSecondsRemaining(Math.ceil(warningCountdownMsRef.current / 1000));
+    // Reiniciar el ciclo idle
+    idleTimerRef.current = setTimeout(() => startCountdownRef.current(),
+                                       idleMsRef.current);
+  }, [clearAllTimers]);
+
+  // Ref para startCountdown (porque dismissWarning lo llama por ref para
+  // evitar dep cycle: startCountdown necesita startCountdown vía setTimeout).
+  const startCountdownRef = useRef<() => void>(() => {});
+
+  // useEffect de setup: SIN deps que cambien con el state. Solo deps que
+  // razonablemente requieren re-registrar listeners (enabled, events array).
+  useEffect(() => {
+    if (!enabled || typeof document === 'undefined') return;
+
+    const startCountdown = () => {
+      setShowWarning(true);
+      const totalSeconds = Math.ceil(warningCountdownMsRef.current / 1000);
+      setSecondsRemaining(totalSeconds);
+
+      // Tick cada segundo para refrescar el display
+      countdownTimerRef.current = setInterval(() => {
+        setSecondsRemaining((prev) => (prev > 0 ? prev - 1 : 0));
+      }, 1000);
+
+      // Timeout duro que dispara onTimeout al expirar
+      timeoutTimerRef.current = setTimeout(() => {
+        if (countdownTimerRef.current) clearInterval(countdownTimerRef.current);
+        countdownTimerRef.current = null;
+        timeoutTimerRef.current = null;
+        setShowWarning(false);
+        onTimeoutRef.current();
+      }, warningCountdownMsRef.current);
+    };
+
+    // Exponer por ref para que dismissWarning pueda llamarlo
+    startCountdownRef.current = startCountdown;
+
+    const handleActivity = () => {
+      // Si ya estamos mostrando warning, una actividad NO debe ocultarlo
+      // automáticamente — el usuario debe presionar "Seguir conectado"
+      // explícitamente. Esto previene que un mousemove accidental mantenga
+      // viva una sesión que el usuario abandonó.
+      if (showWarningRef.current) return;
+      // Reset idle timer
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = setTimeout(startCountdown, idleMsRef.current);
+    };
+
+    events.forEach((ev) => document.addEventListener(ev, handleActivity, { passive: true }));
+    idleTimerRef.current = setTimeout(startCountdown, idleMsRef.current);
+
+    return () => {
+      events.forEach((ev) => document.removeEventListener(ev, handleActivity));
+      clearAllTimers();
+    };
+    // CRÍTICO: NO incluir state ni callbacks aquí, solo deps estables.
+    // El comportamiento dinámico se logra vía refs.
+  }, [enabled, events, clearAllTimers]);
+
+  return { showWarning, secondsRemaining, dismissWarning };
+}


### PR DESCRIPTION
Closes #221

## Resumen

Antes el socio dejaba el teléfono sin bloqueo y su sesión vivía **7 días** (refresh token TTL del fix #178). Cualquiera con el dispositivo en mano operaba con su cuenta.

Implementé **banking standard de idle timeout**:
- **10 min** sin actividad → AlertDialog con countdown 60s
- **\"Seguir conectado\"** → resetea timer
- **No responde** → logout + redirect \`/login?reason=inactivity\` → toast \"Sesión cerrada por inactividad\"

> 📝 Nota: el issue mencionaba que admin ya tenía esto, pero verifiqué — el \`session-manager\` del admin es un **panel para gestionar sesiones de OTROS** usuarios, no auto-logout. No había nada en admin tampoco. Este PR hace solo el socio (alcance del issue); el admin se puede agregar después reusando el mismo componente.

## Cambios técnicos

### Hook puro `useIdleTimeout`
Sin librerías externas (\`react-idle-timer\` NO está en package.json). Implementación con \`setTimeout\` + \`setInterval\` + \`addEventListener\`. ~140 líneas.

**Decisión crítica anti-bug**: actividad **DURANTE** el warning **NO lo cancela automáticamente** (anti-mousemove fantasma). El socio debe presionar \"Seguir conectado\" explícitamente. Si no, un mousemove accidental mantendría viva una sesión abandonada.

**Bug encontrado en TDD reverso**: cuando puse el state como dep del \`useEffect\` principal, el cleanup cancelaba los timers del warning recién creados (se re-ejecutaba al cambiar \`showWarning\`). Fix: usar refs para state volátil + useEffect estable.

### Componente `IdleTimeoutWatcher`
\`AlertDialog\` con countdown visible (\`tabular-nums\` para evitar jitter). Botón verde \"Seguir conectado\". Sin botón \"Cerrar\" (el dismiss del backdrop también resetea el timer).

### Integración
- \`socio-shell.tsx\`: monta el watcher dentro de \`ProtectedRoute\` (solo si hay sesión).
- \`login-form-neobank.tsx\`: lee \`?reason=inactivity\` → toast info al cargar.

## Tests TDD (8 nuevos, fake timers)

| Test | SIN fix | CON fix |
|------|---------|---------|
| Muestra warning tras idleMs | ✅ | ✅ |
| **\`onTimeout\` se llama tras warningCountdownMs sin responder** | ❌ (timers cancelados) | ✅ |
| Actividad antes del warning resetea timer | ✅ | ✅ |
| **Actividad DURANTE warning NO lo cancela (anti-fantasma)** | ❌ (timers cancelados) | ✅ |
| **secondsRemaining cuenta hacia abajo** | ❌ (interval cancelado) | ✅ |
| dismissWarning cierra y reinicia ciclo | ✅ | ✅ |
| enabled=false desactiva todo | ✅ | ✅ |
| Cleanup en unmount cancela timers | ✅ | ✅ |

**Verificación TDD reverso**: con el bug original (state como dep del useEffect), 3 tests críticos fallaron exactamente como debe ser. Fix con refs → 8/8 pasan.

**Suite utility/hooks frontend completa: 153/153** (145 previos + 8 nuevos).

## Test plan QA

### 1. Caso normal (timer reset por actividad)
- Login socio → home → mover el mouse → no debe aparecer warning.

### 2. Warning aparece tras 10 min
- Login → dejar la página tab activo pero sin tocar nada.
- A los 10 min: aparece dialog amarillo \"¿Sigues conectado?\" con countdown 60→0.

### 3. \"Seguir conectado\" funciona
- Cuando aparezca el warning, click \"Seguir conectado\".
- Dialog se cierra, sesión continúa, el ciclo reinicia (otros 10 min).

### 4. Auto-logout
- Dejar el warning sin responder 60s completos.
- Al expirar: redirect a \`/login?reason=inactivity\` + toast azul \"Sesión cerrada por inactividad\".

### 5. Para QA rápido sin esperar 10 min
Editar temporalmente \`socio-shell.tsx\`:
\`\`\`tsx
<IdleTimeoutWatcher idleMinutes={0.1} warningSeconds={5} />
\`\`\`
→ Warning aparece en 6 segundos, expira en 11.

## Bonus para futuro

- Reusar \`<IdleTimeoutWatcher>\` en \`admin-shell.tsx\` con \`idleMinutes={5}\` (más estricto). Issue separado si se prioriza.
- Settings: hacer \`idleMinutes\` configurable vía admin panel (otro issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)