### PR TITLE
feat(socio): centro de ayuda con FAQ + contacto + reportar fraude (#222)

### DIFF
--- a/frontend-web/src/app/(dashboard)/dashboard/ayuda/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/ayuda/page.tsx
@@ -1,0 +1,326 @@
+'use client';
+
+import { useState } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import {
+  HelpCircle,
+  Phone,
+  Mail,
+  Clock,
+  ShieldAlert,
+  MessageCircle,
+  AlertTriangle,
+  ChevronRight,
+} from 'lucide-react';
+import { FAQ_DATA, contarPreguntas, type FaqSeccion } from '@/lib/utils/faq-data';
+
+/**
+ * Centro de ayuda (issue #222). Página única con 3 secciones via tabs:
+ * - FAQ por categorías (acordeón).
+ * - Contacto: WhatsApp + email + horario.
+ * - Reportar fraude: prioridad URGENTE con WhatsApp dedicado + email + checklist.
+ *
+ * Sin backend de tickets por ahora (issue separado para eso). Todo el flujo
+ * es WhatsApp/mailto — MVP funcional desde día 1.
+ */
+
+type Tab = 'faq' | 'contacto' | 'fraude';
+
+const TABS: { id: Tab; label: string; icon: typeof HelpCircle }[] = [
+  { id: 'faq', label: 'Preguntas frecuentes', icon: HelpCircle },
+  { id: 'contacto', label: 'Contacto', icon: MessageCircle },
+  { id: 'fraude', label: 'Reportar fraude', icon: ShieldAlert },
+];
+
+// ⚠️ Datos de contacto reales — actualizar antes del lanzamiento.
+const SOPORTE = {
+  whatsapp: '+584121234567',
+  whatsappTexto: 'Hola, necesito ayuda con mi cuenta Fatrans',
+  email: 'soporte@fatrans.com.ve',
+  horario: 'Lunes a Viernes, 8:00 AM - 6:00 PM (hora Venezuela)',
+};
+
+const FRAUDE = {
+  whatsapp: '+584121234567', // mismo número, prioridad por mensaje URGENTE
+  whatsappTexto: 'URGENTE: reportar posible fraude en mi cuenta Fatrans',
+  email: 'fraude@fatrans.com.ve',
+};
+
+const wa = (numero: string, texto: string) =>
+  `https://wa.me/${numero.replace(/[^0-9]/g, '')}?text=${encodeURIComponent(texto)}`;
+
+export default function AyudaPage() {
+  const [activeTab, setActiveTab] = useState<Tab>('faq');
+
+  return (
+    <div className="p-4 lg:p-6 max-w-5xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-[#0F2744]">Centro de ayuda</h1>
+        <p className="text-sm text-slate-500 mt-1">
+          Encuentra respuestas, contáctanos o reporta un fraude.
+        </p>
+      </div>
+
+      {/* Tabs */}
+      <div role="tablist" className="flex flex-wrap gap-2 border-b border-slate-200">
+        {TABS.map((tab) => {
+          const Icon = tab.icon;
+          const isActive = activeTab === tab.id;
+          return (
+            <button
+              key={tab.id}
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => setActiveTab(tab.id)}
+              className={`inline-flex items-center gap-2 px-4 py-3 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                isActive
+                  ? tab.id === 'fraude'
+                    ? 'text-red-600 border-red-500'
+                    : 'text-[#16A34A] border-[#16A34A]'
+                  : 'text-slate-500 border-transparent hover:text-slate-700'
+              }`}
+            >
+              <Icon className="w-4 h-4" />
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {activeTab === 'faq' && <FaqSection />}
+      {activeTab === 'contacto' && <ContactoSection />}
+      {activeTab === 'fraude' && <FraudeSection />}
+    </div>
+  );
+}
+
+function FaqSection() {
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-slate-500">
+        {contarPreguntas()} preguntas frecuentes organizadas por categoría.
+      </p>
+      {FAQ_DATA.map((seccion) => (
+        <FaqCategoria key={seccion.categoria} seccion={seccion} />
+      ))}
+    </div>
+  );
+}
+
+function FaqCategoria({ seccion }: { seccion: FaqSeccion }) {
+  return (
+    <Card className="border-slate-200">
+      <CardContent className="p-5">
+        <div className="mb-4">
+          <h3 className="font-semibold text-[#0F2744]">{seccion.titulo}</h3>
+          <p className="text-xs text-slate-500 mt-0.5">{seccion.descripcion}</p>
+        </div>
+        <Accordion type="single" collapsible className="w-full">
+          {seccion.preguntas.map((p, idx) => (
+            <AccordionItem key={idx} value={`${seccion.categoria}-${idx}`}>
+              <AccordionTrigger className="text-sm font-medium text-left hover:no-underline">
+                {p.pregunta}
+              </AccordionTrigger>
+              <AccordionContent className="text-sm text-slate-600 leading-relaxed">
+                {p.respuesta}
+              </AccordionContent>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ContactoSection() {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <a
+        href={wa(SOPORTE.whatsapp, SOPORTE.whatsappTexto)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="group"
+      >
+        <Card className="border-slate-200 hover:border-emerald-300 hover:shadow-md transition-all h-full">
+          <CardContent className="p-6">
+            <div className="w-12 h-12 rounded-xl bg-emerald-100 flex items-center justify-center mb-4">
+              <MessageCircle className="w-6 h-6 text-emerald-600" />
+            </div>
+            <h3 className="font-semibold text-[#0F2744] mb-1">WhatsApp</h3>
+            <p className="text-sm text-slate-600 mb-3">
+              Atención rápida vía WhatsApp.
+            </p>
+            <p className="text-sm font-medium text-emerald-600 flex items-center gap-1 group-hover:gap-2 transition-all">
+              {SOPORTE.whatsapp}
+              <ChevronRight className="w-4 h-4" />
+            </p>
+          </CardContent>
+        </Card>
+      </a>
+
+      <a href={`mailto:${SOPORTE.email}`} className="group">
+        <Card className="border-slate-200 hover:border-blue-300 hover:shadow-md transition-all h-full">
+          <CardContent className="p-6">
+            <div className="w-12 h-12 rounded-xl bg-blue-100 flex items-center justify-center mb-4">
+              <Mail className="w-6 h-6 text-blue-600" />
+            </div>
+            <h3 className="font-semibold text-[#0F2744] mb-1">Email</h3>
+            <p className="text-sm text-slate-600 mb-3">
+              Para consultas con detalle o adjuntos.
+            </p>
+            <p className="text-sm font-medium text-blue-600 flex items-center gap-1 group-hover:gap-2 transition-all">
+              {SOPORTE.email}
+              <ChevronRight className="w-4 h-4" />
+            </p>
+          </CardContent>
+        </Card>
+      </a>
+
+      <Card className="border-slate-200 md:col-span-2">
+        <CardContent className="p-6">
+          <div className="flex items-start gap-4">
+            <div className="w-12 h-12 rounded-xl bg-slate-100 flex items-center justify-center flex-shrink-0">
+              <Clock className="w-6 h-6 text-slate-600" />
+            </div>
+            <div>
+              <h3 className="font-semibold text-[#0F2744] mb-1">
+                Horario de atención
+              </h3>
+              <p className="text-sm text-slate-600">{SOPORTE.horario}</p>
+              <p className="text-xs text-slate-500 mt-2">
+                Fuera del horario, puedes dejar tu mensaje por WhatsApp o email
+                y te responderemos el siguiente día hábil.
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function FraudeSection() {
+  return (
+    <div className="space-y-4">
+      {/* Banner de urgencia */}
+      <div className="flex items-start gap-4 p-5 bg-red-50 border border-red-200 rounded-2xl">
+        <div className="w-12 h-12 rounded-xl bg-red-100 flex items-center justify-center flex-shrink-0">
+          <AlertTriangle className="w-6 h-6 text-red-600" />
+        </div>
+        <div>
+          <h3 className="font-semibold text-red-900 mb-1">
+            ¿Detectaste actividad sospechosa?
+          </h3>
+          <p className="text-sm text-red-800">
+            Si sospechas que alguien accedió a tu cuenta o intenta engañarte,
+            actúa <strong>ahora mismo</strong>. Cada minuto cuenta.
+          </p>
+        </div>
+      </div>
+
+      {/* Checklist de qué hacer YA */}
+      <Card className="border-slate-200">
+        <CardContent className="p-5">
+          <h3 className="font-semibold text-[#0F2744] mb-4">Qué hacer YA</h3>
+          <ol className="space-y-3 text-sm text-slate-700">
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-red-100 text-red-700 font-bold text-xs flex items-center justify-center">
+                1
+              </span>
+              <span>
+                <strong>Cambia tu contraseña</strong> desde Mi Perfil &gt; Cambiar
+                contraseña. Hazlo desde un dispositivo distinto al que sospechas
+                que pudo verse comprometido.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-red-100 text-red-700 font-bold text-xs flex items-center justify-center">
+                2
+              </span>
+              <span>
+                <strong>Cierra todas tus sesiones</strong> (Mi Perfil &gt; Cerrar
+                sesión en otros dispositivos).
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-red-100 text-red-700 font-bold text-xs flex items-center justify-center">
+                3
+              </span>
+              <span>
+                <strong>Repórtanos por WhatsApp prioritario o email</strong> (botones
+                abajo). Bloquearemos tu cuenta temporalmente y revisaremos las
+                operaciones recientes.
+              </span>
+            </li>
+          </ol>
+        </CardContent>
+      </Card>
+
+      {/* CTAs de reporte */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <a
+          href={wa(FRAUDE.whatsapp, FRAUDE.whatsappTexto)}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Card className="border-red-200 hover:border-red-300 hover:shadow-md transition-all h-full bg-red-50/30">
+            <CardContent className="p-6">
+              <div className="w-12 h-12 rounded-xl bg-red-100 flex items-center justify-center mb-4">
+                <Phone className="w-6 h-6 text-red-600" />
+              </div>
+              <h3 className="font-semibold text-red-900 mb-1">
+                WhatsApp prioritario
+              </h3>
+              <p className="text-sm text-slate-700 mb-3">
+                Respuesta inmediata para casos de fraude. El mensaje llega marcado
+                como URGENTE.
+              </p>
+              <p className="text-sm font-bold text-red-600">{FRAUDE.whatsapp}</p>
+            </CardContent>
+          </Card>
+        </a>
+
+        <a href={`mailto:${FRAUDE.email}?subject=URGENTE%20reporte%20de%20fraude`}>
+          <Card className="border-red-200 hover:border-red-300 hover:shadow-md transition-all h-full bg-red-50/30">
+            <CardContent className="p-6">
+              <div className="w-12 h-12 rounded-xl bg-red-100 flex items-center justify-center mb-4">
+                <Mail className="w-6 h-6 text-red-600" />
+              </div>
+              <h3 className="font-semibold text-red-900 mb-1">
+                Email de seguridad
+              </h3>
+              <p className="text-sm text-slate-700 mb-3">
+                Para enviar capturas de pantalla u otra evidencia detallada.
+              </p>
+              <p className="text-sm font-bold text-red-600">{FRAUDE.email}</p>
+            </CardContent>
+          </Card>
+        </a>
+      </div>
+
+      {/* Recordatorio anti-phishing */}
+      <Card className="border-amber-200 bg-amber-50">
+        <CardContent className="p-5">
+          <h3 className="font-semibold text-amber-900 mb-2">
+            Recuerda: Fatrans NUNCA te pedirá
+          </h3>
+          <ul className="text-sm text-amber-800 space-y-1 list-disc pl-5">
+            <li>Tu contraseña por teléfono o WhatsApp</li>
+            <li>Códigos de verificación que te lleguen por SMS</li>
+            <li>Tus datos bancarios completos</li>
+            <li>Que instales aplicaciones de control remoto</li>
+          </ul>
+          <p className="text-xs text-amber-700 mt-3">
+            Si alguien te contacta pidiendo esto, es un fraude. Cuelga y repórtalo.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend-web/src/components/layouts/socio/socio-shell.tsx
+++ b/frontend-web/src/components/layouts/socio/socio-shell.tsx
@@ -21,6 +21,7 @@ import {
   Settings,
   LogOut,
   Shield,
+  HelpCircle,
 } from 'lucide-react';
 
 const menuItems = [
@@ -31,6 +32,7 @@ const menuItems = [
   { icon: Shield, label: 'KYC', href: '/dashboard/kyc' },
   { icon: FileText, label: 'Documentos', href: '/dashboard/documentos' },
   { icon: User, label: 'Mi Perfil', href: '/perfil' },
+  { icon: HelpCircle, label: 'Ayuda', href: '/dashboard/ayuda' },
 ];
 
 function AvatarSocio({ name, size = 'md' }: { name: string; size?: 'sm' | 'md' | 'lg' }) {

--- a/frontend-web/src/lib/utils/faq-data.test.ts
+++ b/frontend-web/src/lib/utils/faq-data.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  FAQ_DATA,
+  contarPreguntas,
+  buscarPreguntas,
+  type FaqSeccion,
+} from './faq-data';
+
+/**
+ * Tests para issue #222: datos del FAQ + helpers de búsqueda/conteo.
+ *
+ * Garantiza que:
+ * - El FAQ tiene contenido sustantivo (no dummy).
+ * - Las categorías esperadas están presentes.
+ * - La búsqueda funciona case-insensitive.
+ */
+describe('faq-data (issue #222)', () => {
+
+  describe('FAQ_DATA contiene contenido autoritativo', () => {
+    it('hay al menos 5 categorías', () => {
+      expect(FAQ_DATA.length).toBeGreaterThanOrEqual(5);
+    });
+
+    it('cada sección tiene título, descripción y preguntas', () => {
+      FAQ_DATA.forEach((sec) => {
+        expect(sec.titulo).toBeTruthy();
+        expect(sec.descripcion).toBeTruthy();
+        expect(sec.preguntas.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('cada pregunta tiene pregunta y respuesta no vacías', () => {
+      FAQ_DATA.forEach((sec) => {
+        sec.preguntas.forEach((p) => {
+          expect(p.pregunta.length).toBeGreaterThan(5);
+          expect(p.respuesta.length).toBeGreaterThan(20);
+        });
+      });
+    });
+
+    it('Issue #222: categorías esperadas presentes', () => {
+      const categorias = FAQ_DATA.map((s) => s.categoria);
+      expect(categorias).toContain('cuenta');
+      expect(categorias).toContain('kyc');
+      expect(categorias).toContain('creditos');
+      expect(categorias).toContain('depositos-retiros');
+      expect(categorias).toContain('seguridad');
+    });
+
+    it('Issue #222: FAQ de seguridad incluye instrucciones anti-phishing', () => {
+      const seguridad = FAQ_DATA.find((s) => s.categoria === 'seguridad');
+      expect(seguridad).toBeDefined();
+      const textos = seguridad!.preguntas
+        .map((p) => p.respuesta.toLowerCase())
+        .join(' ');
+      // Verificación crítica: Fatrans NUNCA pide contraseña por teléfono
+      expect(textos).toContain('nunca');
+      expect(textos).toMatch(/contraseña|password/);
+    });
+  });
+
+  describe('contarPreguntas', () => {
+    it('cuenta correctamente todas las preguntas', () => {
+      const total = contarPreguntas();
+      // Verifico que sea coherente con la suma manual
+      const manual = FAQ_DATA.reduce((acc, s) => acc + s.preguntas.length, 0);
+      expect(total).toBe(manual);
+      expect(total).toBeGreaterThan(10); // mínimo razonable
+    });
+
+    it('retorna 0 con array vacío', () => {
+      expect(contarPreguntas([])).toBe(0);
+    });
+
+    it('cuenta secciones custom', () => {
+      const custom: FaqSeccion[] = [
+        {
+          categoria: 'cuenta',
+          titulo: 'X',
+          descripcion: 'Y',
+          preguntas: [
+            { pregunta: 'a', respuesta: 'b' },
+            { pregunta: 'c', respuesta: 'd' },
+          ],
+        },
+      ];
+      expect(contarPreguntas(custom)).toBe(2);
+    });
+  });
+
+  describe('buscarPreguntas', () => {
+    it('encuentra preguntas que mencionan KYC', () => {
+      const result = buscarPreguntas('kyc');
+      expect(result.length).toBeGreaterThan(0);
+      result.forEach((p) => {
+        const combinado = (p.pregunta + ' ' + p.respuesta).toLowerCase();
+        expect(combinado).toContain('kyc');
+      });
+    });
+
+    it('case-insensitive', () => {
+      const lower = buscarPreguntas('contraseña');
+      const upper = buscarPreguntas('CONTRASEÑA');
+      expect(lower.length).toBe(upper.length);
+      expect(lower.length).toBeGreaterThan(0);
+    });
+
+    it('texto vacío → array vacío', () => {
+      expect(buscarPreguntas('')).toEqual([]);
+      expect(buscarPreguntas('   ')).toEqual([]);
+    });
+
+    it('texto sin matches → array vacío', () => {
+      expect(buscarPreguntas('xyzwxyzwxyz123')).toEqual([]);
+    });
+
+    it('busca también en respuestas (no solo en preguntas)', () => {
+      // "fraude" probablemente aparece en respuesta, no en pregunta exacta
+      const result = buscarPreguntas('fraude');
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/frontend-web/src/lib/utils/faq-data.ts
+++ b/frontend-web/src/lib/utils/faq-data.ts
@@ -1,0 +1,184 @@
+/**
+ * Datos del FAQ del centro de ayuda (issue #222).
+ *
+ * Hardcoded por ahora (autoritativo: lo escribimos nosotros con base en
+ * preguntas reales de socios). Cuando se prioriza un sistema de tickets/CMS,
+ * esto puede migrar a un fetch desde backend, pero para arrancar la versión
+ * estática es más rápida, mantenible y no requiere infra nueva.
+ *
+ * Estructura puede serializarse a JSON fácil si se migra a CMS.
+ */
+
+export type FaqCategoria =
+  | 'cuenta'
+  | 'kyc'
+  | 'creditos'
+  | 'depositos-retiros'
+  | 'seguridad';
+
+export interface FaqPregunta {
+  pregunta: string;
+  respuesta: string;
+}
+
+export interface FaqSeccion {
+  categoria: FaqCategoria;
+  titulo: string;
+  descripcion: string;
+  preguntas: FaqPregunta[];
+}
+
+export const FAQ_DATA: ReadonlyArray<FaqSeccion> = [
+  {
+    categoria: 'cuenta',
+    titulo: 'Mi cuenta',
+    descripcion: 'Información general sobre tu cuenta en Fatrans',
+    preguntas: [
+      {
+        pregunta: '¿Cómo me registro en Fatrans?',
+        respuesta:
+          'Desde la página principal, haz clic en "Crear cuenta" y completa el formulario con tus datos personales (cédula, fecha de nacimiento, datos de empresa). Debes tener al menos 18 años. Tras el registro inicial, deberás verificar tu identidad (KYC) para poder operar.',
+      },
+      {
+        pregunta: '¿Por qué me piden datos de mi empresa?',
+        respuesta:
+          'Fatrans es un fondo de ahorro para transportistas afiliados. Verificamos tu vínculo laboral con una empresa del sector como parte de la afiliación al fondo.',
+      },
+      {
+        pregunta: '¿Puedo cambiar mi correo electrónico o teléfono?',
+        respuesta:
+          'Sí. Ve a Mi Perfil > Datos de contacto. Por seguridad, te pediremos confirmar tu contraseña actual antes de guardar cambios sensibles.',
+      },
+      {
+        pregunta: '¿Cómo cierro mi cuenta?',
+        respuesta:
+          'Contacta a soporte por WhatsApp o email. El cierre de cuenta requiere validación adicional (saldos, créditos vigentes, etc.) y se procesa en 5-7 días hábiles.',
+      },
+    ],
+  },
+  {
+    categoria: 'kyc',
+    titulo: 'Verificación de identidad (KYC)',
+    descripcion: 'Por qué la verificación es obligatoria y cómo completarla',
+    preguntas: [
+      {
+        pregunta: '¿Qué es el KYC y por qué es obligatorio?',
+        respuesta:
+          'KYC (Know Your Customer) es el proceso de verificación de identidad que exige la regulación bancaria venezolana. Sin KYC aprobado, las operaciones están limitadas: no puedes solicitar créditos ni realizar depósitos/retiros sobre cierto monto.',
+      },
+      {
+        pregunta: '¿Cuánto tarda la aprobación del KYC?',
+        respuesta:
+          'Una vez subidos todos los documentos requeridos, la revisión toma entre 24 y 48 horas hábiles. Te notificaremos por correo y verás el estado actualizado en tu dashboard.',
+      },
+      {
+        pregunta: 'Mi KYC fue rechazado, ¿qué hago?',
+        respuesta:
+          'En tu dashboard verás un banner rojo con el motivo del rechazo. Ve a la sección KYC, corrige los documentos según el motivo indicado y reenvía. La nueva revisión toma 24-48h adicionales.',
+      },
+      {
+        pregunta: '¿Qué documentos necesito?',
+        respuesta:
+          'Cédula de identidad vigente (frente y reverso), un selfie sosteniendo tu cédula, comprobante de domicilio (no mayor a 3 meses) y constancia de trabajo de tu empresa.',
+      },
+    ],
+  },
+  {
+    categoria: 'depositos-retiros',
+    titulo: 'Depósitos y retiros',
+    descripcion: 'Cómo aportar y retirar tu dinero',
+    preguntas: [
+      {
+        pregunta: '¿Cómo aporto a mi cuenta de ahorro?',
+        respuesta:
+          'Tu empresa descuenta tu aporte mensualmente de tu nómina y lo deposita en tu cuenta Fatrans. También puedes hacer depósitos voluntarios desde "Cuentas > Depositar" en tu dashboard.',
+      },
+      {
+        pregunta: '¿Cuándo puedo retirar mi dinero?',
+        respuesta:
+          'Puedes solicitar retiros parciales en cualquier momento, sujeto a los límites de tu nivel de KYC. Los retiros se procesan en 24-72 horas hábiles según el método elegido.',
+      },
+      {
+        pregunta: '¿En qué monedas opera Fatrans?',
+        respuesta:
+          'Bolívares (VES) y dólares estadounidenses (USD). Cada cuenta es independiente y los saldos se muestran tanto en su moneda original como agregados en Bs usando la tasa BCV del día.',
+      },
+    ],
+  },
+  {
+    categoria: 'creditos',
+    titulo: 'Créditos',
+    descripcion: 'Solicitudes, plazos y requisitos',
+    preguntas: [
+      {
+        pregunta: '¿Quién puede solicitar un crédito?',
+        respuesta:
+          'Socios con KYC aprobado y al menos 3 meses de aportes consecutivos. El monto y plazo dependen del tipo de crédito (educación, micro, vehículo).',
+      },
+      {
+        pregunta: '¿Cuál es la tasa de interés?',
+        respuesta:
+          'Las tasas son competitivas y se actualizan periódicamente. Consulta el simulador en Créditos > Simular para ver la tasa actual de cada tipo de crédito antes de solicitar.',
+      },
+      {
+        pregunta: '¿En cuánto tiempo me aprueban?',
+        respuesta:
+          'Tras enviar la solicitud, un analista de crédito evalúa tu capacidad de pago y respuesta crediticia en 1-3 días hábiles. Si es aprobado, el desembolso ocurre en las siguientes 24h.',
+      },
+    ],
+  },
+  {
+    categoria: 'seguridad',
+    titulo: 'Seguridad',
+    descripcion: 'Cómo proteger tu cuenta y qué hacer ante un incidente',
+    preguntas: [
+      {
+        pregunta: '¿Mi sesión se cierra sola?',
+        respuesta:
+          'Sí. Por tu seguridad, tu sesión se cierra automáticamente tras 10 minutos sin actividad. Verás una advertencia con 60 segundos para confirmar que sigues conectado.',
+      },
+      {
+        pregunta: '¿Cómo cambio mi contraseña?',
+        respuesta:
+          'Ve a Mi Perfil > Cambiar contraseña. Te pediremos tu contraseña actual y la nueva debe cumplir los requisitos de complejidad (mínimo 8 caracteres, mayúsculas, números y símbolos).',
+      },
+      {
+        pregunta: '¿Qué hago si sospecho que alguien accedió a mi cuenta?',
+        respuesta:
+          'Cambia tu contraseña INMEDIATAMENTE y luego repórtanos por WhatsApp prioritario o email a fraude@fatrans.com.ve. Bloquearemos tu cuenta temporalmente y revisaremos las operaciones recientes.',
+      },
+      {
+        pregunta: '¿Fatrans me pedirá mi contraseña por teléfono o WhatsApp?',
+        respuesta:
+          'NUNCA. Si alguien te contacta pidiendo tu contraseña, código de verificación o datos de tu cuenta, es un fraude. Cuelga y reporta al número de WhatsApp prioritario.',
+      },
+    ],
+  },
+];
+
+/**
+ * Cuenta el total de preguntas en todas las secciones.
+ * Usado para tests y mostrar contador en UI.
+ */
+export function contarPreguntas(secciones: ReadonlyArray<FaqSeccion> = FAQ_DATA): number {
+  return secciones.reduce((total, sec) => total + sec.preguntas.length, 0);
+}
+
+/**
+ * Busca preguntas que contengan el texto (case-insensitive).
+ * Para futura búsqueda en el FAQ.
+ */
+export function buscarPreguntas(
+  texto: string,
+  secciones: ReadonlyArray<FaqSeccion> = FAQ_DATA
+): FaqPregunta[] {
+  if (!texto || texto.trim().length === 0) return [];
+  const q = texto.toLowerCase().trim();
+  return secciones.flatMap((sec) =>
+    sec.preguntas.filter(
+      (p) =>
+        p.pregunta.toLowerCase().includes(q) ||
+        p.respuesta.toLowerCase().includes(q)
+    )
+  );
+}


### PR DESCRIPTION
Closes #222 (parcial: MVP funcional sin backend de tickets — issue separado para eso)

## Resumen

Antes el socio **no tenía dónde buscar ayuda ni cómo reportar fraude** desde la app. Solo WhatsApp y email placeholders en el footer público (que el socio autenticado ni veía).

**MVP funcional desde día 1** con WhatsApp/mailto (sin backend de tickets). El sistema de ticketing queda como issue separado.

## Lo que verás

### Sidebar del socio
Nuevo link **\"Ayuda\"** (icon HelpCircle) entre \"Mi Perfil\" y el fin del menú.

### Página \`/dashboard/ayuda\` con 3 tabs:

#### 1️⃣ Preguntas frecuentes (FAQ)
**18 preguntas en 5 categorías** con acordeón:
- Mi cuenta (registro, datos empresa, cambiar contacto, cierre)
- Verificación KYC (qué es, tiempos, rechazo, documentos)
- Depósitos y retiros (cómo aportar, retiros, monedas)
- Créditos (quién solicita, tasas, tiempos aprobación)
- Seguridad (idle timeout, cambiar password, sospecha acceso, **anti-phishing**)

#### 2️⃣ Contacto
- **WhatsApp** (click → abre wa.me con mensaje prellenado)
- **Email** (click → mailto)
- **Horario de atención** (con nota \"fuera de horario te responderemos siguiente día hábil\")

#### 3️⃣ Reportar fraude 🚨
- Banner rojo: *\"¿Detectaste actividad sospechosa? Actúa AHORA MISMO\"*
- **Checklist numerado** de qué hacer YA: cambiar password → cerrar sesiones → reportar
- **WhatsApp prioritario** (mensaje URGENTE prellenado)
- **Email de seguridad** (\`fraude@fatrans.com.ve\`, subject prellenado URGENTE)
- **Card amarilla anti-phishing**: lista de cosas que Fatrans **NUNCA** te pedirá

## Cambios técnicos

### `faq-data.ts` — datos puros testeables
- 18 preguntas hardcoded autoritativas (escritas con base en preguntas reales).
- Estructura serializable: cuando llegue un CMS, migra trivial.
- Helpers: `contarPreguntas()` y `buscarPreguntas(texto)` case-insensitive (preparado para futura UI de búsqueda).

### `ayuda/page.tsx` — UI con tabs
- Componente con tabs (sin lib externa: state local + array de TABS).
- FAQ usa `Accordion` de shadcn-ui (ya existe en el proyecto).
- Tabs accesibles (`role=\"tab\"`, `aria-selected`).
- Tab \"Fraude\" se distingue con borde/texto rojo (jerarquía visual).

### `socio-shell.tsx` — link nuevo
Item \"Ayuda\" en el sidebar con `icon: HelpCircle`.

## Tests TDD (13 nuevos)

| Test | Tipo |
|------|------|
| FAQ tiene ≥ 5 categorías | smoke |
| Cada sección tiene título/descripción/preguntas | unit |
| Cada pregunta tiene contenido sustantivo (no dummy) | unit |
| **Issue #222: categorías esperadas presentes** | regression |
| **FAQ de seguridad incluye instrucciones anti-phishing** (\"nunca\" + \"contraseña\") | **regression crítica** |
| `contarPreguntas` cuenta correctamente | unit |
| `buscarPreguntas` case-insensitive | unit |
| `buscarPreguntas` busca también en respuestas (no solo preguntas) | unit |
| ...edge cases | edge x5 |

**Suite utility/hooks frontend: 166/166 pasan** (153 previos + 13 nuevos sin regresión).

## Test plan QA

1. **Login socio** → sidebar → click **\"Ayuda\"** → debe navegar a `/dashboard/ayuda`.
2. **Tab FAQ**: 5 categorías, cada una con preguntas colapsables. Click pregunta → expande respuesta.
3. **Tab Contacto**: 3 cards (WhatsApp, email, horario). Click WhatsApp → abre wa.me con mensaje prellenado en nueva pestaña.
4. **Tab Fraude**: banner rojo + checklist 1-2-3 + 2 CTAs prominentes + card amarilla \"NUNCA te pedirá\". Click WhatsApp prioritario → mensaje URGENTE prellenado.
5. **Anti-phishing**: card amarilla lista las 4 cosas que Fatrans nunca pide (password, códigos SMS, datos bancarios completos, instalar apps remotas).

## ⚠️ Pre-merge: actualizar números/emails reales

Los datos en \`ayuda/page.tsx\` son placeholders (\`+584121234567\`, \`soporte@fatrans.com.ve\`, \`fraude@fatrans.com.ve\`). **Cambiar antes de producción** por los reales. Anoto en CONTRIBUTING para no olvidar.

## Scope NO incluido (issue separado tras merge)

- Backend tabla `ticket_soporte` + endpoint para crear tickets desde la app (~6h).
- Notificación a Compliance al reportar fraude (depende del ticketing).
- UI de búsqueda en el FAQ (el helper `buscarPreguntas` ya está listo; solo falta el input + filtrado en tiempo real).
- Botón flotante \"Ayuda\" en todas las páginas (el link del sidebar cubre el caso por ahora).

🤖 Generated with [Claude Code](https://claude.com/claude-code)