### PR TITLE
feat(notificaciones): módulo backend para notificaciones in-app (#214 PR-A)

### DIFF
--- a/backend/src/main/java/com/tufondo/notificaciones/application/dto/NotificacionListResponseDTO.java
+++ b/backend/src/main/java/com/tufondo/notificaciones/application/dto/NotificacionListResponseDTO.java
@@ -1,0 +1,19 @@
+package com.tufondo.notificaciones.application.dto;
+
+import java.util.List;
+
+/**
+ * DTO de respuesta para listado paginado de notificaciones (issue #214).
+ *
+ * <p>Estructura idéntica al patrón {@code CuentasPorSocioResponse} —
+ * envoltura con metadata de paginación. Frontend tiene
+ * {@code parse-cuentas-response.ts} y similares para manejar este wrap.</p>
+ */
+public record NotificacionListResponseDTO(
+        List<NotificacionResponseDTO> notificaciones,
+        int pagina,
+        int tamanio,
+        long totalElementos,
+        int totalPaginas,
+        long noLeidas
+) {}

--- a/backend/src/main/java/com/tufondo/notificaciones/application/dto/NotificacionResponseDTO.java
+++ b/backend/src/main/java/com/tufondo/notificaciones/application/dto/NotificacionResponseDTO.java
@@ -1,0 +1,38 @@
+package com.tufondo.notificaciones.application.dto;
+
+import com.tufondo.notificaciones.domain.model.Notificacion;
+import com.tufondo.notificaciones.domain.model.enums.PrioridadNotificacion;
+import com.tufondo.notificaciones.domain.model.enums.TipoNotificacion;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * DTO de respuesta para una notificación (issue #214).
+ * Record por simplicidad — no muta tras crearse.
+ */
+public record NotificacionResponseDTO(
+        UUID id,
+        TipoNotificacion tipo,
+        String titulo,
+        String mensaje,
+        String linkAccion,
+        boolean leida,
+        Instant fechaLectura,
+        PrioridadNotificacion prioridad,
+        Instant createdAt
+) {
+    public static NotificacionResponseDTO desde(Notificacion n) {
+        return new NotificacionResponseDTO(
+                n.getId(),
+                n.getTipo(),
+                n.getTitulo(),
+                n.getMensaje(),
+                n.getLinkAccion(),
+                n.isLeida(),
+                n.getFechaLectura(),
+                n.getPrioridad(),
+                n.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/tufondo/notificaciones/application/usecase/ListarNotificacionesUseCase.java
+++ b/backend/src/main/java/com/tufondo/notificaciones/application/usecase/ListarNotificacionesUseCase.java
@@ -1,0 +1,65 @@
+package com.tufondo.notificaciones.application.usecase;
+
+import com.tufondo.notificaciones.application.dto.NotificacionListResponseDTO;
+import com.tufondo.notificaciones.application.dto.NotificacionResponseDTO;
+import com.tufondo.notificaciones.domain.model.Notificacion;
+import com.tufondo.notificaciones.domain.repository.NotificacionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Lista notificaciones del destinatario autenticado (issue #214).
+ *
+ * <p>Filtro opcional {@code soloNoLeidas} para que el dropdown del Bell
+ * pueda pedir solo las pendientes (UX más limpia que mostrar el histórico
+ * completo en el dropdown).</p>
+ */
+@Service
+@RequiredArgsConstructor
+public class ListarNotificacionesUseCase {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final NotificacionRepository notificacionRepository;
+
+    @Transactional(readOnly = true)
+    public NotificacionListResponseDTO ejecutar(
+            UUID destinatarioId,
+            int page,
+            int size,
+            boolean soloNoLeidas
+    ) {
+        // Defensive: limitar size para prevenir abuso (mismo patrón que SocioController)
+        int safeSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+        int safePage = Math.max(page, 0);
+
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+        Page<Notificacion> pageResult = soloNoLeidas
+                ? notificacionRepository.listarNoLeidasPorDestinatario(destinatarioId, pageable)
+                : notificacionRepository.listarPorDestinatario(destinatarioId, pageable);
+
+        List<NotificacionResponseDTO> items = pageResult.getContent().stream()
+                .map(NotificacionResponseDTO::desde)
+                .toList();
+
+        // Contador de no-leídas: siempre se devuelve para el badge del Bell.
+        // No depende del filtro `soloNoLeidas` — el badge muestra el total real.
+        long noLeidas = notificacionRepository.contarNoLeidasPorDestinatario(destinatarioId);
+
+        return new NotificacionListResponseDTO(
+                items,
+                pageResult.getNumber(),
+                pageResult.getSize(),
+                pageResult.getTotalElements(),
+                pageResult.getTotalPages(),
+                noLeidas
+        );
+    }
+}

--- a/backend/src/main/java/com/tufondo/notificaciones/application/usecase/MarcarLeidaUseCase.java
+++ b/backend/src/main/java/com/tufondo/notificaciones/application/usecase/MarcarLeidaUseCase.java
@@ -1,0 +1,57 @@
+package com.tufondo.notificaciones.application.usecase;
+
+import com.tufondo.notificaciones.domain.model.Notificacion;
+import com.tufondo.notificaciones.domain.repository.NotificacionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * Marca una notificación específica como leída (issue #214).
+ *
+ * <p>Crítico: valida ownership antes de modificar — un usuario NO puede
+ * marcar leída una notificación de OTRO usuario (anti-IDOR, lección del
+ * issue #179).</p>
+ *
+ * <p>Idempotente: si la notificación ya está leída, no hace nada y retorna
+ * sin error (cliente puede marcar dos veces sin consecuencias).</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MarcarLeidaUseCase {
+
+    private final NotificacionRepository notificacionRepository;
+
+    @Transactional
+    public void ejecutar(UUID notificacionId, UUID usuarioId) {
+        Notificacion notificacion = notificacionRepository.buscarPorId(notificacionId)
+                .orElseThrow(() -> new NotificacionNoEncontradaException(notificacionId));
+
+        // Anti-IDOR: el usuario solo puede marcar SUS propias notificaciones.
+        // Sin este check, conocer un UUID válido de notificación permitía
+        // marcar como leídas las de otros.
+        if (!notificacion.perteneceA(usuarioId)) {
+            log.warn("Intento de marcar leída notificación ajena: notifId={}, usuarioActual={}",
+                    notificacionId, usuarioId);
+            throw new AccessDeniedException(
+                    "No tienes permisos para modificar esta notificación");
+        }
+
+        // Idempotente: si ya está leída, no hace nada
+        Notificacion actualizada = notificacion.marcarLeida();
+        if (actualizada != notificacion) {
+            notificacionRepository.guardar(actualizada);
+        }
+    }
+
+    public static class NotificacionNoEncontradaException extends RuntimeException {
+        public NotificacionNoEncontradaException(UUID id) {
+            super("Notificación no encontrada: " + id);
+        }
+    }
+}

--- a/backend/src/main/java/com/tufondo/notificaciones/application/usecase/MarcarTodasLeidasUseCase.java
+++ b/backend/src/main/java/com/tufondo/notificaciones/application/usecase/MarcarTodasLeidasUseCase.java
@@ -1,0 +1,31 @@
+package com.tufondo.notificaciones.application.usecase;
+
+import com.tufondo.notificaciones.domain.repository.NotificacionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * Marca todas las notificaciones no leídas del usuario como leídas (issue #214).
+ *
+ * <p>Operación atómica en BD (UPDATE con WHERE leida=false) — más eficiente
+ * que cargarlas y guardarlas una por una.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MarcarTodasLeidasUseCase {
+
+    private final NotificacionRepository notificacionRepository;
+
+    @Transactional
+    public int ejecutar(UUID destinatarioId) {
+        int actualizadas = notificacionRepository.marcarTodasLeidas(destinatarioId);
+        log.info("Marcadas {} notificaciones como leídas para usuario {}",
+                actualizadas, destinatarioId);
+        return actualizadas;
+    }
+}

--- a/backend/src/main/java/com/tufondo/notificaciones/domain/model/Notificacion.java
+++ b/backend/src/main/java/com/tufondo/notificaciones/domain/model/Notificacion.java
@@ -1,0 +1,66 @@
+package com.tufondo.notificaciones.domain.model;
+
+import com.tufondo.notificaciones.domain.model.enums.PrioridadNotificacion;
+import com.tufondo.notificaciones.domain.model.enums.TipoNotificacion;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Modelo de dominio de una notificación in-app (issue #214).
+ *
+ * <p>Immutable. Las operaciones de cambio de estado (marcar leída) crean
+ * una nueva instancia vía métodos {@code conXxx}.</p>
+ */
+@Getter
+@Builder
+public class Notificacion {
+
+    private final UUID id;
+    private final UUID destinatarioId;
+    private final TipoNotificacion tipo;
+    private final String titulo;
+    private final String mensaje;
+    /** Link relativo donde llevar al usuario si hace click. Puede ser null. */
+    private final String linkAccion;
+    private final boolean leida;
+    /** Solo presente si {@code leida == true}. Invariante validada en DB. */
+    private final Instant fechaLectura;
+    private final PrioridadNotificacion prioridad;
+    /** Metadata libre JSON (BLOB serializado). Puede ser null. */
+    private final String metadata;
+    private final Instant createdAt;
+
+    /**
+     * Retorna una nueva instancia marcada como leída, con la fecha de lectura
+     * registrada en este momento. Si ya estaba leída, retorna {@code this}
+     * sin cambios (idempotencia — evita actualizar fechaLectura por error
+     * cuando el cliente marca dos veces).
+     */
+    public Notificacion marcarLeida() {
+        if (this.leida) return this;
+        return Notificacion.builder()
+                .id(this.id)
+                .destinatarioId(this.destinatarioId)
+                .tipo(this.tipo)
+                .titulo(this.titulo)
+                .mensaje(this.mensaje)
+                .linkAccion(this.linkAccion)
+                .leida(true)
+                .fechaLectura(Instant.now())
+                .prioridad(this.prioridad)
+                .metadata(this.metadata)
+                .createdAt(this.createdAt)
+                .build();
+    }
+
+    /**
+     * Verifica que esta notificación pertenezca al destinatario indicado.
+     * Usado en use cases para protección anti-IDOR antes de mostrar/modificar.
+     */
+    public boolean perteneceA(UUID usuarioId) {
+        return this.destinatarioId != null && this.destinatarioId.equals(usuarioId);
+    }
+}

--- a/backend/src/main/java/com/tufondo/notificaciones/domain/model/enums/PrioridadNotificacion.java
+++ b/backend/src/main/java/com/tufondo/notificaciones/domain/model/enums/PrioridadNotificacion.java
@@ -1,0 +1,18 @@
+package com.tufondo.notificaciones.domain.model.enums;
+
+/**
+ * Prioridad visual de una notificación (issue #214).
+ *
+ * <p>Determina el ordenamiento y el estilo (color) en la UI:
+ * <ul>
+ *   <li>{@code URGENTE} — rojo, aparece arriba aunque sea más viejo.
+ *       Ej: fraude detectado, cuota vencida.</li>
+ *   <li>{@code NORMAL} — azul, default. Ej: KYC aprobado, depósito recibido.</li>
+ *   <li>{@code BAJA} — gris, informativa. Ej: nueva versión disponible.</li>
+ * </ul>
+ */
+public enum PrioridadNotificacion {
+    URGENTE,
+    NORMAL,
+    BAJA
+}

--- a/backend/src/main/java/com/tufondo/notificaciones/domain/model/enums/TipoNotificacion.java
+++ b/backend/src/main/java/com/tufondo/notificaciones/domain/model/enums/TipoNotificacion.java
@@ -1,0 +1,39 @@
+package com.tufondo.notificaciones.domain.model.enums;
+
+/**
+ * Tipos de notificación in-app del sistema (issue #214).
+ *
+ * <p>Cada valor representa un evento de dominio que dispara una notificación
+ * al usuario destinatario. Los disparadores reales se conectan en el PR-C;
+ * este PR (PR-A) solo define el catálogo y los endpoints.</p>
+ *
+ * <p>El nombre del valor debe coincidir EXACTAMENTE con el CHECK constraint
+ * de la migración V18 — agregar un valor aquí requiere también una
+ * migración Flyway que actualice el constraint (lección aprendida del
+ * incidente del rol fantasma, hotfix #238).</p>
+ */
+public enum TipoNotificacion {
+    // === Notificaciones para el SOCIO ===
+    KYC_APROBADO,
+    KYC_RECHAZADO,
+    KYC_REQUIERE_INFO,
+
+    CREDITO_APROBADO,
+    CREDITO_RECHAZADO,
+    CREDITO_DESEMBOLSADO,
+
+    CUOTA_PROXIMA_VENCER,
+    CUOTA_VENCIDA,
+
+    DEPOSITO_RECIBIDO,
+    RETIRO_PROCESADO,
+
+    NUEVO_DISPOSITIVO_LOGIN,
+
+    // === Notificaciones para el ADMIN ===
+    ADMIN_NUEVA_SOLICITUD,
+    ADMIN_NUEVO_KYC,
+
+    // === Genérica / fallback ===
+    GENERAL
+}

--- a/backend/src/main/java/com/tufondo/notificaciones/domain/repository/NotificacionRepository.java
+++ b/backend/src/main/java/com/tufondo/notificaciones/domain/repository/NotificacionRepository.java
@@ -1,0 +1,42 @@
+package com.tufondo.notificaciones.domain.repository;
+
+import com.tufondo.notificaciones.domain.model.Notificacion;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Port del dominio para persistencia de notificaciones (issue #214).
+ */
+public interface NotificacionRepository {
+
+    Optional<Notificacion> buscarPorId(UUID id);
+
+    /**
+     * Lista notificaciones de un destinatario paginadas, ordenadas por fecha
+     * descendente (más nuevas primero).
+     */
+    Page<Notificacion> listarPorDestinatario(UUID destinatarioId, Pageable pageable);
+
+    /**
+     * Variante con filtro: solo no-leídas.
+     */
+    Page<Notificacion> listarNoLeidasPorDestinatario(UUID destinatarioId, Pageable pageable);
+
+    /**
+     * Cuenta no-leídas. Usado por el badge del Bell (consulta más frecuente).
+     */
+    long contarNoLeidasPorDestinatario(UUID destinatarioId);
+
+    void guardar(Notificacion notificacion);
+
+    /**
+     * Marca como leídas todas las notificaciones no leídas de un destinatario
+     * en una sola operación atómica (más eficiente que iterar).
+     *
+     * @return cantidad de notificaciones actualizadas
+     */
+    int marcarTodasLeidas(UUID destinatarioId);
+}

--- a/backend/src/main/java/com/tufondo/notificaciones/infrastructure/persistence/adapter/NotificacionRepositoryImpl.java
+++ b/backend/src/main/java/com/tufondo/notificaciones/infrastructure/persistence/adapter/NotificacionRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.tufondo.notificaciones.infrastructure.persistence.adapter;
+
+import com.tufondo.notificaciones.domain.model.Notificacion;
+import com.tufondo.notificaciones.domain.repository.NotificacionRepository;
+import com.tufondo.notificaciones.infrastructure.persistence.entity.NotificacionEntity;
+import com.tufondo.notificaciones.infrastructure.persistence.jpa.NotificacionJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Adaptador JPA del port {@link NotificacionRepository} (issue #214).
+ */
+@Component
+@RequiredArgsConstructor
+public class NotificacionRepositoryImpl implements NotificacionRepository {
+
+    private final NotificacionJpaRepository jpa;
+
+    @Override
+    public Optional<Notificacion> buscarPorId(UUID id) {
+        return jpa.findById(id).map(NotificacionEntity::aDominio);
+    }
+
+    @Override
+    public Page<Notificacion> listarPorDestinatario(UUID destinatarioId, Pageable pageable) {
+        return jpa.findByDestinatarioIdOrderByCreatedAtDesc(destinatarioId, pageable)
+                .map(NotificacionEntity::aDominio);
+    }
+
+    @Override
+    public Page<Notificacion> listarNoLeidasPorDestinatario(UUID destinatarioId, Pageable pageable) {
+        return jpa.findByDestinatarioIdAndLeidaFalseOrderByCreatedAtDesc(destinatarioId, pageable)
+                .map(NotificacionEntity::aDominio);
+    }
+
+    @Override
+    public long contarNoLeidasPorDestinatario(UUID destinatarioId) {
+        return jpa.countByDestinatarioIdAndLeidaFalse(destinatarioId);
+    }
+
+    @Override
+    public void guardar(Notificacion notificacion) {
+        jpa.save(NotificacionEntity.desdeDominio(notificacion));
+    }
+
+    @Override
+    public int marcarTodasLeidas(UUID destinatarioId) {
+        return jpa.marcarTodasLeidas(destinatarioId, Instant.now());
+    }
+}

--- a/backend/src/main/java/com/tufondo/notificaciones/infrastructure/persistence/entity/NotificacionEntity.java
+++ b/backend/src/main/java/com/tufondo/notificaciones/infrastructure/persistence/entity/NotificacionEntity.java
@@ -1,0 +1,105 @@
+package com.tufondo.notificaciones.infrastructure.persistence.entity;
+
+import com.tufondo.notificaciones.domain.model.Notificacion;
+import com.tufondo.notificaciones.domain.model.enums.PrioridadNotificacion;
+import com.tufondo.notificaciones.domain.model.enums.TipoNotificacion;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "notificacion")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificacionEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "destinatario_id", nullable = false)
+    private UUID destinatarioId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo", nullable = false, length = 50)
+    private TipoNotificacion tipo;
+
+    @Column(name = "titulo", nullable = false, length = 200)
+    private String titulo;
+
+    @Column(name = "mensaje", nullable = false, columnDefinition = "TEXT")
+    private String mensaje;
+
+    @Column(name = "link_accion", length = 500)
+    private String linkAccion;
+
+    @Column(name = "leida", nullable = false)
+    private boolean leida;
+
+    @Column(name = "fecha_lectura")
+    private Instant fechaLectura;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "prioridad", nullable = false, length = 20)
+    private PrioridadNotificacion prioridad;
+
+    /**
+     * JSONB en Postgres, mapeado como String (el dominio no lo procesa,
+     * solo lo almacena/serializa el caller).
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "metadata", columnDefinition = "jsonb")
+    private String metadata;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    void onPrePersist() {
+        if (createdAt == null) createdAt = Instant.now();
+        if (prioridad == null) prioridad = PrioridadNotificacion.NORMAL;
+    }
+
+    public Notificacion aDominio() {
+        return Notificacion.builder()
+                .id(this.id)
+                .destinatarioId(this.destinatarioId)
+                .tipo(this.tipo)
+                .titulo(this.titulo)
+                .mensaje(this.mensaje)
+                .linkAccion(this.linkAccion)
+                .leida(this.leida)
+                .fechaLectura(this.fechaLectura)
+                .prioridad(this.prioridad)
+                .metadata(this.metadata)
+                .createdAt(this.createdAt)
+                .build();
+    }
+
+    public static NotificacionEntity desdeDominio(Notificacion n) {
+        return NotificacionEntity.builder()
+                .id(n.getId())
+                .destinatarioId(n.getDestinatarioId())
+                .tipo(n.getTipo())
+                .titulo(n.getTitulo())
+                .mensaje(n.getMensaje())
+                .linkAccion(n.getLinkAccion())
+                .leida(n.isLeida())
+                .fechaLectura(n.getFechaLectura())
+                .prioridad(n.getPrioridad())
+                .metadata(n.getMetadata())
+                .createdAt(n.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/tufondo/notificaciones/infrastructure/persistence/jpa/NotificacionJpaRepository.java
+++ b/backend/src/main/java/com/tufondo/notificaciones/infrastructure/persistence/jpa/NotificacionJpaRepository.java
@@ -1,0 +1,36 @@
+package com.tufondo.notificaciones.infrastructure.persistence.jpa;
+
+import com.tufondo.notificaciones.infrastructure.persistence.entity.NotificacionEntity;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public interface NotificacionJpaRepository extends JpaRepository<NotificacionEntity, UUID> {
+
+    Page<NotificacionEntity> findByDestinatarioIdOrderByCreatedAtDesc(
+            UUID destinatarioId, Pageable pageable);
+
+    Page<NotificacionEntity> findByDestinatarioIdAndLeidaFalseOrderByCreatedAtDesc(
+            UUID destinatarioId, Pageable pageable);
+
+    long countByDestinatarioIdAndLeidaFalse(UUID destinatarioId);
+
+    /**
+     * UPDATE bulk: marca como leídas TODAS las no-leídas del destinatario
+     * en una sola query. Mucho más eficiente que cargar+iterar+save.
+     */
+    @Modifying
+    @Query("UPDATE NotificacionEntity n " +
+           "SET n.leida = true, n.fechaLectura = :ahora " +
+           "WHERE n.destinatarioId = :destinatarioId AND n.leida = false")
+    int marcarTodasLeidas(@Param("destinatarioId") UUID destinatarioId,
+                          @Param("ahora") Instant ahora);
+}

--- a/backend/src/main/java/com/tufondo/notificaciones/presentation/controller/NotificacionController.java
+++ b/backend/src/main/java/com/tufondo/notificaciones/presentation/controller/NotificacionController.java
@@ -1,0 +1,115 @@
+package com.tufondo.notificaciones.presentation.controller;
+
+import com.tufondo.notificaciones.application.dto.NotificacionListResponseDTO;
+import com.tufondo.notificaciones.application.usecase.ListarNotificacionesUseCase;
+import com.tufondo.notificaciones.application.usecase.MarcarLeidaUseCase;
+import com.tufondo.notificaciones.application.usecase.MarcarTodasLeidasUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Endpoints REST de notificaciones in-app (issue #214, PR-A).
+ *
+ * <p>Todos los endpoints son del usuario autenticado — un usuario NUNCA
+ * puede leer/modificar notificaciones de otro. La autorización viene del
+ * JWT (extraerUsuarioId), no de query params (anti-IDOR).</p>
+ */
+@RestController
+@RequestMapping("/api/v1/notificaciones")
+@RequiredArgsConstructor
+@Tag(name = "Notificaciones", description = "Notificaciones in-app del usuario")
+public class NotificacionController {
+
+    private final ListarNotificacionesUseCase listarUseCase;
+    private final MarcarLeidaUseCase marcarLeidaUseCase;
+    private final MarcarTodasLeidasUseCase marcarTodasUseCase;
+
+    /**
+     * GET /notificaciones?page=0&size=20&soloNoLeidas=false
+     *
+     * Lista las notificaciones del usuario autenticado, paginadas.
+     * Incluye en el response el contador total de no-leídas (para el badge).
+     */
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Listar mis notificaciones",
+               description = "Paginado. Filtro opcional soloNoLeidas=true para el dropdown del Bell.")
+    public ResponseEntity<NotificacionListResponseDTO> listar(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "false") boolean soloNoLeidas,
+            Authentication authentication) {
+        UUID usuarioId = extraerUsuarioId(authentication);
+        return ResponseEntity.ok(listarUseCase.ejecutar(usuarioId, page, size, soloNoLeidas));
+    }
+
+    /**
+     * GET /notificaciones/count
+     *
+     * Endpoint ligero solo para el contador del badge — evita transferir
+     * la lista completa cuando solo necesitamos el número. Polling cada 30s
+     * desde el frontend lo llamará constantemente.
+     */
+    @GetMapping("/count")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Contar mis notificaciones no leídas",
+               description = "Endpoint ligero para el badge del Bell. Optimizado con índice parcial en BD.")
+    public ResponseEntity<Map<String, Long>> contarNoLeidas(Authentication authentication) {
+        UUID usuarioId = extraerUsuarioId(authentication);
+        NotificacionListResponseDTO r = listarUseCase.ejecutar(usuarioId, 0, 1, true);
+        return ResponseEntity.ok(Map.of("noLeidas", r.noLeidas()));
+    }
+
+    /**
+     * PATCH /notificaciones/{id}/leida
+     *
+     * Marca UNA notificación específica como leída. Anti-IDOR: el use case
+     * valida que la notificación pertenezca al usuario autenticado.
+     */
+    @PatchMapping("/{id}/leida")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Marcar una notificación como leída")
+    public ResponseEntity<Void> marcarLeida(
+            @PathVariable UUID id,
+            Authentication authentication) {
+        UUID usuarioId = extraerUsuarioId(authentication);
+        marcarLeidaUseCase.ejecutar(id, usuarioId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * POST /notificaciones/marcar-todas-leidas
+     *
+     * Marca como leídas TODAS las notificaciones no leídas del usuario
+     * autenticado. Útil para el botón "Marcar todas como leídas" del
+     * dropdown.
+     */
+    @PostMapping("/marcar-todas-leidas")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Marcar todas mis notificaciones como leídas")
+    public ResponseEntity<Map<String, Integer>> marcarTodasLeidas(Authentication authentication) {
+        UUID usuarioId = extraerUsuarioId(authentication);
+        int actualizadas = marcarTodasUseCase.ejecutar(usuarioId);
+        return ResponseEntity.ok(Map.of("actualizadas", actualizadas));
+    }
+
+    /**
+     * Extrae el userId del JWT, NUNCA de query params.
+     * Patrón ya usado en otros controllers (auth, ahorros).
+     */
+    private UUID extraerUsuarioId(Authentication authentication) {
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof com.tufondo.auth.infrastructure.security.AuthenticatedUser authUser) {
+            return authUser.getUserId();
+        }
+        return UUID.fromString(authentication.getName());
+    }
+}

--- a/backend/src/main/resources/db/migration/V18__crear_tabla_notificacion.sql
+++ b/backend/src/main/resources/db/migration/V18__crear_tabla_notificacion.sql
@@ -1,0 +1,93 @@
+-- =============================================================================
+-- V18: Issue #214 - Sistema de notificaciones in-app (PR-A backend base)
+-- =============================================================================
+--
+-- CONTEXTO
+-- --------
+-- Antes el frontend usaba `mockNotifications` hardcoded en `admin-shell.tsx`
+-- y el `Bell` icon estaba importado pero nunca renderizado en `socio-shell.tsx`.
+-- No había sistema real de notificaciones in-app.
+--
+-- Este PR (parte A de 3) introduce el almacenamiento + endpoints CRUD.
+-- Los disparadores desde eventos de dominio (KYC, créditos, depósitos)
+-- vienen en PR-C. El frontend (Bell + dropdown) viene en PR-B.
+--
+-- DISEÑO
+-- ------
+-- Tabla diseñada para alto volumen de lecturas (un socio puede tener cientos
+-- de notificaciones a lo largo del tiempo). El índice parcial
+-- `idx_notif_dest_unread` acelera dramáticamente el contador de no-leídas
+-- (consulta más frecuente: badge del Bell cada 30s).
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS notificacion (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Destinatario: usuario que recibe la notificación. NO usamos socio_id
+    -- porque también queremos notificar a admins (no son socios).
+    destinatario_id UUID NOT NULL,
+
+    -- Tipo: usado para iconografía/clasificación en UI y filtros del backend.
+    -- Validamos los valores conocidos vía CHECK (extensible con futuras
+    -- migraciones; el enum del lado Java valida en runtime también).
+    tipo VARCHAR(50) NOT NULL,
+
+    -- Título corto (200 chars max) — aparece en bold en la lista.
+    titulo VARCHAR(200) NOT NULL,
+
+    -- Mensaje completo. TEXT porque pueden ser largos (ej. motivo de rechazo
+    -- KYC, detalle de operación).
+    mensaje TEXT NOT NULL,
+
+    -- Link relativo donde llevar al usuario si hace click (ej. /dashboard/kyc).
+    -- NULL = notificación sin acción asociada.
+    link_accion VARCHAR(500),
+
+    -- Estado de lectura.
+    leida BOOLEAN NOT NULL DEFAULT false,
+    fecha_lectura TIMESTAMPTZ,
+
+    -- Prioridad para ordenamiento y estilos (URGENTE = rojo, NORMAL = azul, BAJA = gris).
+    prioridad VARCHAR(20) NOT NULL DEFAULT 'NORMAL',
+
+    -- Metadata libre en JSON para casos avanzados (ej. ID del crédito al que
+    -- refiere la notificación). Por ahora opcional, ayuda a no añadir
+    -- columnas para cada caso de uso.
+    metadata JSONB,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT notificacion_tipo_check CHECK (tipo IN (
+        'KYC_APROBADO', 'KYC_RECHAZADO', 'KYC_REQUIERE_INFO',
+        'CREDITO_APROBADO', 'CREDITO_RECHAZADO', 'CREDITO_DESEMBOLSADO',
+        'CUOTA_PROXIMA_VENCER', 'CUOTA_VENCIDA',
+        'DEPOSITO_RECIBIDO', 'RETIRO_PROCESADO',
+        'NUEVO_DISPOSITIVO_LOGIN',
+        'ADMIN_NUEVA_SOLICITUD', 'ADMIN_NUEVO_KYC',
+        'GENERAL'
+    )),
+
+    CONSTRAINT notificacion_prioridad_check CHECK (prioridad IN ('URGENTE', 'NORMAL', 'BAJA')),
+
+    -- Garantía de consistencia: si leida=true, debe haber fecha de lectura.
+    CONSTRAINT notificacion_fecha_lectura_check
+        CHECK ((leida = false AND fecha_lectura IS NULL)
+               OR (leida = true AND fecha_lectura IS NOT NULL))
+);
+
+-- Índice principal: las 2 queries más frecuentes son
+--   (a) listar por destinatario ordenado por fecha desc
+--   (b) contar no-leídas de un destinatario
+-- Este índice cubre ambas eficientemente.
+CREATE INDEX IF NOT EXISTS idx_notif_destinatario_fecha
+    ON notificacion(destinatario_id, created_at DESC);
+
+-- Índice parcial: solo no-leídas. Hace el COUNT del badge súper rápido
+-- incluso con miles de notificaciones leídas viejas.
+CREATE INDEX IF NOT EXISTS idx_notif_dest_unread
+    ON notificacion(destinatario_id)
+    WHERE leida = false;
+
+-- Filtro por tipo para futuras vistas (ej. "solo mis notificaciones de crédito")
+CREATE INDEX IF NOT EXISTS idx_notif_tipo
+    ON notificacion(tipo, created_at DESC);

--- a/backend/src/test/java/com/tufondo/notificaciones/application/usecase/ListarNotificacionesUseCaseTest.java
+++ b/backend/src/test/java/com/tufondo/notificaciones/application/usecase/ListarNotificacionesUseCaseTest.java
@@ -1,0 +1,138 @@
+package com.tufondo.notificaciones.application.usecase;
+
+import com.tufondo.notificaciones.application.dto.NotificacionListResponseDTO;
+import com.tufondo.notificaciones.domain.model.Notificacion;
+import com.tufondo.notificaciones.domain.model.enums.PrioridadNotificacion;
+import com.tufondo.notificaciones.domain.model.enums.TipoNotificacion;
+import com.tufondo.notificaciones.domain.repository.NotificacionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests para issue #214 PR-A: listar notificaciones con paginación y filtros.
+ */
+@ExtendWith(MockitoExtension.class)
+class ListarNotificacionesUseCaseTest {
+
+    @Mock
+    private NotificacionRepository repository;
+
+    @InjectMocks
+    private ListarNotificacionesUseCase useCase;
+
+    private UUID usuarioId;
+    private Notificacion noLeida;
+    private Notificacion leida;
+
+    @BeforeEach
+    void setUp() {
+        usuarioId = UUID.randomUUID();
+        noLeida = mockNotificacion(usuarioId, false);
+        leida = mockNotificacion(usuarioId, true);
+    }
+
+    @Test
+    @DisplayName("Sin filtro soloNoLeidas=false → lista todas las del destinatario")
+    void lista_todas_cuando_filtro_apagado() {
+        Page<Notificacion> page = new PageImpl<>(List.of(noLeida, leida));
+        when(repository.listarPorDestinatario(eq(usuarioId), any(Pageable.class)))
+                .thenReturn(page);
+        when(repository.contarNoLeidasPorDestinatario(usuarioId)).thenReturn(1L);
+
+        NotificacionListResponseDTO result = useCase.ejecutar(usuarioId, 0, 20, false);
+
+        assertThat(result.notificaciones()).hasSize(2);
+        assertThat(result.noLeidas()).isEqualTo(1L);
+        // Verificamos que NO se llamó al método con filtro de no-leídas
+        verify(repository, never()).listarNoLeidasPorDestinatario(any(), any());
+    }
+
+    @Test
+    @DisplayName("Con filtro soloNoLeidas=true → solo retorna las no leídas")
+    void lista_solo_no_leidas_cuando_filtro_activo() {
+        Page<Notificacion> page = new PageImpl<>(List.of(noLeida));
+        when(repository.listarNoLeidasPorDestinatario(eq(usuarioId), any(Pageable.class)))
+                .thenReturn(page);
+        when(repository.contarNoLeidasPorDestinatario(usuarioId)).thenReturn(1L);
+
+        NotificacionListResponseDTO result = useCase.ejecutar(usuarioId, 0, 20, true);
+
+        assertThat(result.notificaciones()).hasSize(1);
+        verify(repository).listarNoLeidasPorDestinatario(eq(usuarioId), any());
+        verify(repository, never()).listarPorDestinatario(any(), any());
+    }
+
+    @Test
+    @DisplayName("Issue #214: incluso con filtro de no-leídas, el contador siempre refleja el total real (badge)")
+    void contador_no_leidas_independiente_del_filtro() {
+        // Si el cliente pide solo no-leídas, igualmente el badge tiene que
+        // mostrar el total — sino, sería redundante (el filtro ya lo contiene).
+        // Pero también si filtra sin no-leídas, el contador debe ser válido.
+        Page<Notificacion> page = new PageImpl<>(List.of());
+        when(repository.listarPorDestinatario(any(), any())).thenReturn(page);
+        when(repository.contarNoLeidasPorDestinatario(usuarioId)).thenReturn(42L);
+
+        NotificacionListResponseDTO result = useCase.ejecutar(usuarioId, 0, 20, false);
+
+        assertThat(result.noLeidas()).isEqualTo(42L);
+    }
+
+    @Test
+    @DisplayName("Defensive: size negativo se normaliza a 1 (prevenir error de Spring Pageable)")
+    void size_negativo_normaliza() {
+        Page<Notificacion> page = new PageImpl<>(List.of());
+        when(repository.listarPorDestinatario(any(), any())).thenReturn(page);
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        useCase.ejecutar(usuarioId, 0, -10, false);
+
+        verify(repository).listarPorDestinatario(any(), captor.capture());
+        assertThat(captor.getValue().getPageSize()).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Defensive: size > MAX se clipea a 100 (prevenir abuso)")
+    void size_excesivo_se_limita() {
+        Page<Notificacion> page = new PageImpl<>(List.of());
+        when(repository.listarPorDestinatario(any(), any())).thenReturn(page);
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        useCase.ejecutar(usuarioId, 0, 999_999, false);
+
+        verify(repository).listarPorDestinatario(any(), captor.capture());
+        assertThat(captor.getValue().getPageSize()).isLessThanOrEqualTo(100);
+    }
+
+    private Notificacion mockNotificacion(UUID dest, boolean isRead) {
+        return Notificacion.builder()
+                .id(UUID.randomUUID())
+                .destinatarioId(dest)
+                .tipo(TipoNotificacion.KYC_APROBADO)
+                .titulo("Test")
+                .mensaje("Test")
+                .leida(isRead)
+                .fechaLectura(isRead ? Instant.now() : null)
+                .prioridad(PrioridadNotificacion.NORMAL)
+                .createdAt(Instant.now())
+                .build();
+    }
+}

--- a/backend/src/test/java/com/tufondo/notificaciones/application/usecase/MarcarLeidaUseCaseTest.java
+++ b/backend/src/test/java/com/tufondo/notificaciones/application/usecase/MarcarLeidaUseCaseTest.java
@@ -1,0 +1,124 @@
+package com.tufondo.notificaciones.application.usecase;
+
+import com.tufondo.notificaciones.domain.model.Notificacion;
+import com.tufondo.notificaciones.domain.model.enums.PrioridadNotificacion;
+import com.tufondo.notificaciones.domain.model.enums.TipoNotificacion;
+import com.tufondo.notificaciones.domain.repository.NotificacionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests para issue #214 PR-A: marcar leída con check de ownership.
+ *
+ * <p>Lección aprendida del issue #179 (IDOR): un usuario NUNCA debe poder
+ * modificar recursos de OTRO usuario. Estos tests blindan ese check
+ * específicamente para notificaciones.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class MarcarLeidaUseCaseTest {
+
+    @Mock
+    private NotificacionRepository repository;
+
+    @InjectMocks
+    private MarcarLeidaUseCase useCase;
+
+    private UUID usuarioDueno;
+    private UUID notificacionId;
+    private Notificacion notificacionNoLeida;
+
+    @BeforeEach
+    void setUp() {
+        usuarioDueno = UUID.randomUUID();
+        notificacionId = UUID.randomUUID();
+        notificacionNoLeida = Notificacion.builder()
+                .id(notificacionId)
+                .destinatarioId(usuarioDueno)
+                .tipo(TipoNotificacion.KYC_APROBADO)
+                .titulo("Tu KYC fue aprobado")
+                .mensaje("Felicidades, ya puedes operar.")
+                .prioridad(PrioridadNotificacion.NORMAL)
+                .leida(false)
+                .createdAt(Instant.now())
+                .build();
+    }
+
+    @Test
+    @DisplayName("Usuario marca SU PROPIA notificación → se guarda con leida=true + fechaLectura")
+    void usuario_marca_propia_notificacion_pasa() {
+        when(repository.buscarPorId(notificacionId)).thenReturn(Optional.of(notificacionNoLeida));
+
+        useCase.ejecutar(notificacionId, usuarioDueno);
+
+        ArgumentCaptor<Notificacion> captor = ArgumentCaptor.forClass(Notificacion.class);
+        verify(repository).guardar(captor.capture());
+        Notificacion guardada = captor.getValue();
+        assertThat(guardada.isLeida()).isTrue();
+        assertThat(guardada.getFechaLectura()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Issue #214 anti-IDOR: usuario intenta marcar notificación de OTRO → AccessDeniedException")
+    void usuario_marca_notificacion_ajena_falla() {
+        UUID atacante = UUID.randomUUID();
+        when(repository.buscarPorId(notificacionId)).thenReturn(Optional.of(notificacionNoLeida));
+
+        assertThatThrownBy(() -> useCase.ejecutar(notificacionId, atacante))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("No tienes permisos");
+
+        // CRÍTICO: la notificación NO debe haberse modificado
+        verify(repository, never()).guardar(any());
+    }
+
+    @Test
+    @DisplayName("Notificación inexistente → NotificacionNoEncontradaException")
+    void notificacion_inexistente_falla() {
+        when(repository.buscarPorId(notificacionId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.ejecutar(notificacionId, usuarioDueno))
+                .isInstanceOf(MarcarLeidaUseCase.NotificacionNoEncontradaException.class);
+
+        verify(repository, never()).guardar(any());
+    }
+
+    @Test
+    @DisplayName("Idempotente: marcar leída una notificación ya leída → no hace nada (no actualiza fechaLectura)")
+    void marcar_leida_dos_veces_es_idempotente() {
+        Notificacion yaLeida = Notificacion.builder()
+                .id(notificacionId)
+                .destinatarioId(usuarioDueno)
+                .tipo(TipoNotificacion.KYC_APROBADO)
+                .titulo("Test")
+                .mensaje("Test")
+                .prioridad(PrioridadNotificacion.NORMAL)
+                .leida(true)
+                .fechaLectura(Instant.parse("2026-01-01T00:00:00Z"))
+                .createdAt(Instant.now())
+                .build();
+        when(repository.buscarPorId(notificacionId)).thenReturn(Optional.of(yaLeida));
+
+        useCase.ejecutar(notificacionId, usuarioDueno);
+
+        // CRÍTICO: NO debe llamar guardar — la fechaLectura original se preserva.
+        // Sin este check, un cliente que marca dos veces "leída" sobrescribiría
+        // la fecha original (mala práctica de auditoría).
+        verify(repository, never()).guardar(any());
+    }
+}


### PR DESCRIPTION
Related: #214 (no cierra aún — quedan PR-B frontend y PR-C disparadores)

## Resumen

**PR-A de 3 del sistema de notificaciones in-app** (issue #214). Descomposición acordada con @gamijoam para mantener PRs pequeños y reducir riesgo de regresión (lección del hotfix #238).

| PR | Scope | Estado |
|----|-------|--------|
| **PR-A** (este) | Backend: tabla + entity + endpoints + tests | ⬅️ aquí |
| **PR-B** (futuro) | Frontend: NotificationBell + dropdown + página | ⏳ |
| **PR-C** (futuro) | Disparadores desde KYC/Créditos/Depósitos/Login | ⏳ |

**Sin PR-B/C**, este PR es completamente safe: el módulo es nuevo, no toca código existente, la tabla queda vacía y los endpoints devuelven listas vacías. Verificable por Swagger.

## Estructura (hexagonal, mismo patrón que otros módulos)

\`\`\`
notificaciones/
├── domain/
│   ├── model/
│   │   ├── Notificacion.java          # immutable + marcarLeida() idempotente + perteneceA() anti-IDOR
│   │   └── enums/
│   │       ├── TipoNotificacion.java   # 14 tipos
│   │       └── PrioridadNotificacion.java  # URGENTE/NORMAL/BAJA
│   └── repository/NotificacionRepository.java  # port
├── application/
│   ├── dto/{NotificacionResponseDTO, NotificacionListResponseDTO}.java
│   └── usecase/
│       ├── ListarNotificacionesUseCase.java
│       ├── MarcarLeidaUseCase.java                   # ⚠️ anti-IDOR
│       └── MarcarTodasLeidasUseCase.java             # UPDATE atómico
├── infrastructure/persistence/
│   ├── entity/NotificacionEntity.java                # JSONB metadata
│   ├── jpa/NotificacionJpaRepository.java
│   └── adapter/NotificacionRepositoryImpl.java
└── presentation/controller/NotificacionController.java
\`\`\`

## Endpoints

| Método | Path | Para qué |
|--------|------|----------|
| GET | \`/api/v1/notificaciones?page=0&size=20&soloNoLeidas=false\` | Lista paginada + contador de no-leídas |
| GET | \`/api/v1/notificaciones/count\` | Solo contador (endpoint ligero para badge, polling cada 30s) |
| PATCH | \`/api/v1/notificaciones/{id}/leida\` | Marca una específica como leída (anti-IDOR) |
| POST | \`/api/v1/notificaciones/marcar-todas-leidas\` | Marca todas las del usuario actual |

**Todos** con \`@PreAuthorize(\"isAuthenticated()\")\` + extracción de userId del JWT (NUNCA de query params).

## Decisiones de diseño relevantes

### Anti-IDOR (lección del #179)
\`MarcarLeidaUseCase\` valida que la notificación pertenezca al usuario autenticado antes de modificar. Sin este check, conocer un UUID válido permitía marcar leídas las de otros.

### Migración V18 con CHECK constraints (lección del #234/#238)
Los enums (\`tipo\`, \`prioridad\`) tienen CHECK constraints en BD para integridad. Documenté en comentarios: agregar un nuevo valor al enum requiere migración Flyway adicional para actualizar el constraint (Hibernate \`ddl-auto: update\` NO lo hace).

### Índices optimizados
- \`idx_notif_dest_unread\` (parcial, \`WHERE leida = false\`): hace que el \`COUNT\` del badge sea \`O(1)\` aunque haya miles de notificaciones leídas viejas.
- \`idx_notif_destinatario_fecha\`: acelera el listado paginado.

### Endpoint \`/count\` separado
Polling cada 30s desde el frontend para el badge necesita ser barato. Endpoint dedicado evita transferir la lista completa cuando solo necesitamos el número.

### Idempotencia en \`MarcarLeidaUseCase\`
Si una notificación ya está leída, NO se llama \`save\` (preserva la \`fechaLectura\` original). Cliente puede marcar dos veces sin sobrescribir auditoría.

### Metadata como JSONB
Campo libre para casos futuros (ej. ID del crédito al que refiere la notificación). Evita migraciones por cada caso de uso.

## Tests TDD (9 nuevos)

### \`MarcarLeidaUseCaseTest\` (4 casos)
| Test | Tipo | SIN fix | CON fix |
|------|------|---------|---------|
| Usuario marca propia notificación → guarda con leida=true | happy | ✅ | ✅ |
| **Anti-IDOR: marca ajena → AccessDeniedException, NUNCA save** | **regression crítica** | ❌ FAIL | ✅ PASS |
| Notificación inexistente → exception | edge | ✅ | ✅ |
| Marcar leída 2 veces es idempotente (no actualiza fechaLectura) | unit | ✅ | ✅ |

### \`ListarNotificacionesUseCaseTest\` (5 casos)
- Filtros soloNoLeidas=true/false llaman al método correcto del repo.
- Contador de no-leídas siempre real (independiente del filtro).
- Defensive: \`size\` negativo o excesivo se normaliza/clipea.

**TDD reverso verificado**: removí el check de ownership → BUILD FAILURE (test del IDOR detecta). Restaurado, **9/9 pasan**.

**Suite completa backend: 368/368 (\`mvn clean test\`)**, 359 previos + 9 nuevos sin regresión.

## Test plan QA

### 1. Migración Flyway corre limpio
\`\`\`bash
docker logs fatrans-qa-backend | grep \"V18\"
\`\`\`
Esperado: \`Successfully applied 1 migration\` (V18).

### 2. Tabla creada en BD
\`\`\`sql
SELECT column_name FROM information_schema.columns WHERE table_name = 'notificacion';
-- Esperado: 11 columnas (id, destinatario_id, tipo, titulo, mensaje, link_accion,
--           leida, fecha_lectura, prioridad, metadata, created_at)

SELECT conname FROM pg_constraint WHERE conrelid = 'notificacion'::regclass AND contype = 'c';
-- Esperado: 3 checks (tipo, prioridad, fecha_lectura)
\`\`\`

### 3. Endpoints responden con tabla vacía (lista vacía OK)
\`\`\`bash
curl -H \"Authorization: Bearer <TOKEN>\" https://qa-app.fatrans.com.ve/api/v1/notificaciones | jq
# {\"notificaciones\":[], \"pagina\":0, \"tamanio\":20, \"totalElementos\":0, \"totalPaginas\":0, \"noLeidas\":0}

curl -H \"Authorization: Bearer <TOKEN>\" https://qa-app.fatrans.com.ve/api/v1/notificaciones/count | jq
# {\"noLeidas\":0}
\`\`\`

### 4. Insertar manualmente una notificación de prueba
\`\`\`sql
INSERT INTO notificacion (destinatario_id, tipo, titulo, mensaje, prioridad)
VALUES (
  (SELECT id FROM usuarios WHERE nombre_usuario = 'socio_prueba'),
  'KYC_APROBADO',
  'Tu KYC fue aprobado',
  'Felicidades, ya puedes operar.',
  'NORMAL'
);
\`\`\`

Luego \`GET /notificaciones\` debe devolverla.

### 5. Marcar leída
\`\`\`bash
curl -X PATCH -H \"Authorization: Bearer <SOCIO_TOKEN>\" \
  https://qa-app.fatrans.com.ve/api/v1/notificaciones/<id>/leida -i
# Esperado: 204 No Content
\`\`\`

### 6. Anti-IDOR
\`\`\`bash
# Token de socio A intenta marcar notificación de socio B (insertada en SQL para B)
curl -X PATCH -H \"Authorization: Bearer <SOCIO_A_TOKEN>\" \
  https://qa-app.fatrans.com.ve/api/v1/notificaciones/<id_de_B>/leida -i
# Esperado: 403 Forbidden
\`\`\`

## Próximos pasos

- **PR-B**: \`NotificationBell\` + dropdown con polling al \`/count\`. Página \`/dashboard/notificaciones\` paginada.
- **PR-C**: integrar 5 disparadores en \`AprobarKycUseCase\`, \`EvaluarCreditoUseCase\`, \`RealizarDepositoUseCase\`, job de cuotas próximas a vencer, detección de nuevo dispositivo en login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)