### PR TITLE
feat(socio): NotificationBell + dropdown + página completa (#214 PR-B)

### DIFF
--- a/frontend-web/src/app/(dashboard)/dashboard/notificaciones/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/notificaciones/page.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { Bell, CheckCheck, Check, Loader2, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  parseNotificacionesResponse,
+  estiloPorPrioridad,
+  formatearTiempoRelativo,
+  type NotificacionApi,
+} from '@/lib/utils/parse-notificaciones-response';
+
+/**
+ * Página dedicada con histórico paginado de notificaciones (issue #214 PR-B).
+ *
+ * Diferencias con el dropdown del Bell:
+ * - Paginación completa (20 por página, navegación con prev/next).
+ * - Filtro: todas / solo no leídas.
+ * - Click en notificación con link la marca leída y navega.
+ */
+
+const PAGE_SIZE = 20;
+
+export default function NotificacionesPage() {
+  const [items, setItems] = useState<NotificacionApi[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(0);
+  const [totalPaginas, setTotalPaginas] = useState(1);
+  const [noLeidas, setNoLeidas] = useState(0);
+  const [filtro, setFiltro] = useState<'todas' | 'no-leidas'>('todas');
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    try {
+      const qs = new URLSearchParams({
+        page: String(page),
+        size: String(PAGE_SIZE),
+        soloNoLeidas: filtro === 'no-leidas' ? 'true' : 'false',
+      });
+      const res = await fetch(`/api/notificaciones?${qs}`);
+      if (res.ok) {
+        const data = parseNotificacionesResponse(await res.json());
+        setItems(data.notificaciones);
+        setTotalPaginas(Math.max(1, data.totalPaginas));
+        setNoLeidas(data.noLeidas);
+      } else {
+        setItems([]);
+      }
+    } catch {
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, filtro]);
+
+  useEffect(() => {
+    cargar();
+  }, [cargar]);
+
+  const marcarLeida = async (id: string) => {
+    try {
+      await fetch(`/api/notificaciones/${id}/leida`, { method: 'PATCH' });
+      setItems((prev) =>
+        prev.map((n) => (n.id === id ? { ...n, leida: true } : n))
+      );
+      setNoLeidas((prev) => Math.max(0, prev - 1));
+    } catch {
+      cargar();
+    }
+  };
+
+  const marcarTodas = async () => {
+    try {
+      await fetch('/api/notificaciones/marcar-todas-leidas', { method: 'POST' });
+      cargar();
+    } catch {
+      cargar();
+    }
+  };
+
+  return (
+    <div className="p-4 lg:p-6 max-w-4xl mx-auto space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-[#0F2744]">Notificaciones</h1>
+          <p className="text-sm text-slate-500 mt-1">
+            {noLeidas > 0
+              ? `Tienes ${noLeidas} ${noLeidas === 1 ? 'notificación' : 'notificaciones'} sin leer`
+              : 'Estás al día — sin notificaciones pendientes'}
+          </p>
+        </div>
+        {noLeidas > 0 && (
+          <button
+            onClick={marcarTodas}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-[#16A34A] bg-emerald-50 hover:bg-emerald-100 rounded-lg transition-colors"
+          >
+            <CheckCheck className="w-4 h-4" />
+            Marcar todas como leídas
+          </button>
+        )}
+      </div>
+
+      {/* Filtros */}
+      <div role="tablist" className="inline-flex bg-slate-100 rounded-lg p-1 text-sm">
+        <FiltroTab
+          activo={filtro === 'todas'}
+          onClick={() => {
+            setPage(0);
+            setFiltro('todas');
+          }}
+          label="Todas"
+        />
+        <FiltroTab
+          activo={filtro === 'no-leidas'}
+          onClick={() => {
+            setPage(0);
+            setFiltro('no-leidas');
+          }}
+          label="No leídas"
+          badge={noLeidas > 0 ? String(noLeidas) : undefined}
+        />
+      </div>
+
+      {/* Lista */}
+      <Card className="border-slate-200">
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="p-12 text-center">
+              <Loader2 className="w-6 h-6 animate-spin text-[#16A34A] mx-auto" />
+            </div>
+          ) : items.length === 0 ? (
+            <div className="p-12 text-center">
+              <Bell className="w-12 h-12 text-slate-300 mx-auto mb-3" />
+              <p className="text-sm text-slate-500">
+                {filtro === 'no-leidas'
+                  ? 'No tienes notificaciones sin leer'
+                  : 'Aún no tienes notificaciones'}
+              </p>
+            </div>
+          ) : (
+            items.map((n) => (
+              <NotificacionRow key={n.id} notif={n} onMarcarLeida={() => marcarLeida(n.id)} />
+            ))
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Paginación */}
+      {totalPaginas > 1 && (
+        <div className="flex items-center justify-between">
+          <button
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            disabled={page === 0}
+            className="inline-flex items-center gap-1 px-3 py-2 text-sm text-slate-600 hover:text-slate-900 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <ChevronLeft className="w-4 h-4" /> Anterior
+          </button>
+          <span className="text-sm text-slate-500">
+            Página {page + 1} de {totalPaginas}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPaginas - 1, p + 1))}
+            disabled={page >= totalPaginas - 1}
+            className="inline-flex items-center gap-1 px-3 py-2 text-sm text-slate-600 hover:text-slate-900 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Siguiente <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FiltroTab({
+  activo,
+  onClick,
+  label,
+  badge,
+}: {
+  activo: boolean;
+  onClick: () => void;
+  label: string;
+  badge?: string;
+}) {
+  return (
+    <button
+      role="tab"
+      aria-selected={activo}
+      onClick={onClick}
+      className={`inline-flex items-center gap-2 px-4 py-1.5 rounded-md transition-colors ${
+        activo ? 'bg-white text-[#0F2744] shadow-sm font-medium' : 'text-slate-600 hover:text-slate-900'
+      }`}
+    >
+      {label}
+      {badge && (
+        <span className="bg-red-500 text-white text-[10px] font-bold rounded-full min-w-[1rem] h-4 px-1 flex items-center justify-center">
+          {badge}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function NotificacionRow({
+  notif,
+  onMarcarLeida,
+}: {
+  notif: NotificacionApi;
+  onMarcarLeida: () => void;
+}) {
+  const estilo = estiloPorPrioridad(notif.prioridad as string);
+  const dotColor = {
+    urgent: 'bg-red-500',
+    normal: 'bg-blue-500',
+    low: 'bg-slate-400',
+  }[estilo];
+
+  const wrapperClass = `block px-5 py-4 border-b border-slate-100 last:border-0 ${
+    notif.leida ? 'opacity-60' : 'bg-blue-50/30'
+  } hover:bg-slate-50 transition-colors`;
+
+  const contenido = (
+    <div className="flex items-start gap-3">
+      <span
+        className={`flex-shrink-0 w-2 h-2 mt-2 rounded-full ${
+          notif.leida ? 'bg-slate-300' : dotColor
+        }`}
+      />
+      <div className="flex-1 min-w-0">
+        <p
+          className={`text-sm ${notif.leida ? 'text-slate-700' : 'font-semibold text-[#0F2744]'}`}
+        >
+          {notif.titulo}
+        </p>
+        <p className="text-sm text-slate-600 mt-1">{notif.mensaje}</p>
+        <p className="text-xs text-slate-400 mt-2">
+          {formatearTiempoRelativo(notif.createdAt)}
+        </p>
+      </div>
+      {!notif.leida && (
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onMarcarLeida();
+          }}
+          aria-label="Marcar como leída"
+          title="Marcar como leída"
+          className="flex-shrink-0 text-slate-400 hover:text-emerald-600 transition-colors p-2"
+        >
+          <Check className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  );
+
+  if (notif.linkAccion) {
+    return (
+      <Link href={notif.linkAccion} className={wrapperClass}>
+        {contenido}
+      </Link>
+    );
+  }
+  return <div className={wrapperClass}>{contenido}</div>;
+}

--- a/frontend-web/src/app/api/notificaciones/[id]/leida/route.ts
+++ b/frontend-web/src/app/api/notificaciones/[id]/leida/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+/**
+ * BFF para PATCH /api/v1/notificaciones/{id}/leida (issue #214 PR-B).
+ *
+ * El backend valida ownership (anti-IDOR). Aquí solo proxy.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const accessToken = request.cookies.get('access_token')?.value;
+    if (!accessToken) {
+      return NextResponse.json({ message: 'No autenticado' }, { status: 401 });
+    }
+
+    const backendResponse = await fetch(
+      `${BACKEND_URL}/api/v1/notificaciones/${params.id}/leida`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      }
+    );
+
+    if (!backendResponse.ok) {
+      const errorData = await backendResponse.json().catch(() => ({}));
+      return NextResponse.json(
+        { message: errorData.message || 'Error al marcar como leída' },
+        { status: backendResponse.status }
+      );
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    console.error('Marcar leída error:', error);
+    return NextResponse.json({ message: 'Error interno' }, { status: 500 });
+  }
+}

--- a/frontend-web/src/app/api/notificaciones/count/route.ts
+++ b/frontend-web/src/app/api/notificaciones/count/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+/**
+ * BFF para /api/v1/notificaciones/count (issue #214 PR-B).
+ *
+ * Endpoint ligero para el badge del NotificationBell. El frontend hace
+ * polling cada 30s sobre esto — debe ser barato y rápido.
+ *
+ * No cacheable: el badge debe reflejar cambios casi-realtime.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const accessToken = request.cookies.get('access_token')?.value;
+    if (!accessToken) {
+      // Para el polling, devolvemos 0 sin auth en vez de 401 — evita ruido
+      // en consola del browser cuando expira la sesión. El Bell se ocultará
+      // de todas formas (no hay usuario en el store).
+      return NextResponse.json({ noLeidas: 0 }, { status: 200 });
+    }
+
+    const backendResponse = await fetch(
+      `${BACKEND_URL}/api/v1/notificaciones/count`,
+      {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      }
+    );
+
+    if (!backendResponse.ok) {
+      // Fallar abierto: devolver 0 en vez de error — el badge se oculta
+      // pero no rompe la UI.
+      return NextResponse.json({ noLeidas: 0 }, { status: 200 });
+    }
+
+    const data = await backendResponse.json();
+    return NextResponse.json(data, {
+      status: 200,
+      headers: { 'Cache-Control': 'no-store' },
+    });
+  } catch (error) {
+    console.error('Notificaciones count error:', error);
+    return NextResponse.json({ noLeidas: 0 }, { status: 200 });
+  }
+}

--- a/frontend-web/src/app/api/notificaciones/marcar-todas-leidas/route.ts
+++ b/frontend-web/src/app/api/notificaciones/marcar-todas-leidas/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+/**
+ * BFF para POST /api/v1/notificaciones/marcar-todas-leidas (issue #214 PR-B).
+ *
+ * Marca todas las notificaciones no-leídas del usuario actual.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const accessToken = request.cookies.get('access_token')?.value;
+    if (!accessToken) {
+      return NextResponse.json({ message: 'No autenticado' }, { status: 401 });
+    }
+
+    const backendResponse = await fetch(
+      `${BACKEND_URL}/api/v1/notificaciones/marcar-todas-leidas`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      }
+    );
+
+    if (!backendResponse.ok) {
+      const errorData = await backendResponse.json().catch(() => ({}));
+      return NextResponse.json(
+        { message: errorData.message || 'Error al marcar todas como leídas' },
+        { status: backendResponse.status }
+      );
+    }
+
+    const data = await backendResponse.json();
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    console.error('Marcar todas leídas error:', error);
+    return NextResponse.json({ message: 'Error interno' }, { status: 500 });
+  }
+}

--- a/frontend-web/src/app/api/notificaciones/route.ts
+++ b/frontend-web/src/app/api/notificaciones/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+/**
+ * BFF para /api/v1/notificaciones del backend (issue #214 PR-B).
+ *
+ * GET con query params:
+ *  - page (default 0)
+ *  - size (default 20)
+ *  - soloNoLeidas (default false) — para el dropdown del Bell
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const accessToken = request.cookies.get('access_token')?.value;
+    if (!accessToken) {
+      return NextResponse.json({ message: 'No autenticado' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const page = searchParams.get('page') || '0';
+    const size = searchParams.get('size') || '20';
+    const soloNoLeidas = searchParams.get('soloNoLeidas') || 'false';
+
+    const qs = new URLSearchParams({ page, size, soloNoLeidas });
+
+    const backendResponse = await fetch(
+      `${BACKEND_URL}/api/v1/notificaciones?${qs}`,
+      {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      }
+    );
+
+    if (!backendResponse.ok) {
+      const errorData = await backendResponse.json().catch(() => ({}));
+      return NextResponse.json(
+        { message: errorData.message || 'Error al obtener notificaciones' },
+        { status: backendResponse.status }
+      );
+    }
+
+    const data = await backendResponse.json();
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    console.error('Notificaciones GET error:', error);
+    return NextResponse.json({ message: 'Error interno' }, { status: 500 });
+  }
+}

--- a/frontend-web/src/components/layouts/socio/socio-shell.tsx
+++ b/frontend-web/src/components/layouts/socio/socio-shell.tsx
@@ -7,6 +7,7 @@ import { useAuthStore } from '@/stores/auth-store';
 import { ProtectedRoute } from '@/components/shared/protected-route';
 import { LogoutButton } from '@/components/shared/logout-button';
 import { IdleTimeoutWatcher } from '@/components/shared/idle-timeout-watcher';
+import { NotificationBell } from '@/components/shared/notification-bell';
 import {
   LayoutDashboard,
   Wallet,
@@ -17,7 +18,6 @@ import {
   Menu,
   X,
   ChevronRight,
-  Bell,
   Settings,
   LogOut,
   Shield,
@@ -224,15 +224,18 @@ export function SocioShell({ children }: { children: React.ReactNode }) {
                 </div>
               </div>
 
-              {/* Right: Profile */}
-              <div ref={profileRef} className="relative">
-                <button
-                  onClick={() => setProfileOpen(!profileOpen)}
-                  className="flex items-center gap-3 p-1.5 hover:bg-slate-100 rounded-xl transition-colors"
-                >
-                  <AvatarSocio name={user?.nombreCompleto || 'U'} size="sm" />
-                  <ChevronRight className={`w-4 h-4 text-slate-400 hidden sm:block transition-transform ${profileOpen ? 'rotate-90' : ''}`} />
-                </button>
+              {/* Right: Bell + Profile (issue #214 — Bell ya no es un dead import) */}
+              <div className="flex items-center gap-2">
+                <NotificationBell />
+
+                <div ref={profileRef} className="relative">
+                  <button
+                    onClick={() => setProfileOpen(!profileOpen)}
+                    className="flex items-center gap-3 p-1.5 hover:bg-slate-100 rounded-xl transition-colors"
+                  >
+                    <AvatarSocio name={user?.nombreCompleto || 'U'} size="sm" />
+                    <ChevronRight className={`w-4 h-4 text-slate-400 hidden sm:block transition-transform ${profileOpen ? 'rotate-90' : ''}`} />
+                  </button>
 
                 {profileOpen && (
                   <div className="absolute right-0 mt-2 w-64 bg-white rounded-2xl shadow-xl border border-slate-200 overflow-hidden">
@@ -262,6 +265,7 @@ export function SocioShell({ children }: { children: React.ReactNode }) {
                     </div>
                   </div>
                 )}
+                </div>
               </div>
             </div>
           </header>

--- a/frontend-web/src/components/shared/notification-bell.tsx
+++ b/frontend-web/src/components/shared/notification-bell.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+import Link from 'next/link';
+import { Bell, Check, CheckCheck } from 'lucide-react';
+import { useAuthStore } from '@/stores/auth-store';
+import {
+  parseNotificacionesResponse,
+  formatearBadgeCount,
+  estiloPorPrioridad,
+  formatearTiempoRelativo,
+  type NotificacionApi,
+} from '@/lib/utils/parse-notificaciones-response';
+
+/**
+ * Campana de notificaciones con badge + dropdown (issue #214 PR-B).
+ *
+ * <p>Polling cada 30s al endpoint ligero `/api/notificaciones/count` para
+ * el badge. El dropdown completo (lista de últimas 5) solo se carga al
+ * abrir, para no transferir datos innecesarios.</p>
+ *
+ * <p>Diseño "anti-mock": antes del PR-A había `<Bell />` importado pero
+ * nunca renderizado, y `mockNotifications` hardcoded en admin-shell.
+ * Este componente reemplaza ambos.</p>
+ */
+
+const POLLING_INTERVAL_MS = 30_000;
+const NOTIFICACIONES_EN_DROPDOWN = 5;
+
+export function NotificationBell() {
+  const user = useAuthStore((state) => state.user);
+  const [count, setCount] = useState(0);
+  const [open, setOpen] = useState(false);
+  const [notificaciones, setNotificaciones] = useState<NotificacionApi[]>([]);
+  const [loadingList, setLoadingList] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // === Polling del badge ===
+  const fetchCount = useCallback(async () => {
+    if (!user) return;
+    try {
+      const res = await fetch('/api/notificaciones/count', { cache: 'no-store' });
+      if (res.ok) {
+        const data = await res.json();
+        setCount(Number(data?.noLeidas) || 0);
+      }
+    } catch {
+      // Silent — el polling no debe ensuciar consola con errores transitorios
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (!user) return;
+    fetchCount();
+    const interval = setInterval(fetchCount, POLLING_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [user, fetchCount]);
+
+  // === Cargar lista al abrir el dropdown ===
+  const cargarLista = useCallback(async () => {
+    setLoadingList(true);
+    try {
+      const res = await fetch(
+        `/api/notificaciones?page=0&size=${NOTIFICACIONES_EN_DROPDOWN}`
+      );
+      if (res.ok) {
+        const data = parseNotificacionesResponse(await res.json());
+        setNotificaciones(data.notificaciones);
+        setCount(data.noLeidas);
+      }
+    } catch {
+      // Empty state se ve igual al de "sin notificaciones"
+    } finally {
+      setLoadingList(false);
+    }
+  }, []);
+
+  // Cerrar al click fuera
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const toggleDropdown = () => {
+    const willOpen = !open;
+    setOpen(willOpen);
+    if (willOpen) cargarLista();
+  };
+
+  // === Acciones ===
+  const marcarLeida = async (id: string) => {
+    try {
+      await fetch(`/api/notificaciones/${id}/leida`, { method: 'PATCH' });
+      // Optimistic update local
+      setNotificaciones((prev) =>
+        prev.map((n) => (n.id === id ? { ...n, leida: true } : n))
+      );
+      // Refrescar contador con el real
+      fetchCount();
+    } catch {
+      // Si falla, recargar para recuperar estado real
+      cargarLista();
+    }
+  };
+
+  const marcarTodas = async () => {
+    try {
+      await fetch('/api/notificaciones/marcar-todas-leidas', { method: 'POST' });
+      setNotificaciones((prev) => prev.map((n) => ({ ...n, leida: true })));
+      setCount(0);
+    } catch {
+      cargarLista();
+    }
+  };
+
+  if (!user) return null;
+
+  const badge = formatearBadgeCount(count);
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        onClick={toggleDropdown}
+        aria-label={
+          badge
+            ? `Notificaciones (${count} no leídas)`
+            : 'Notificaciones'
+        }
+        data-testid="notification-bell-trigger"
+        className="relative p-2 text-slate-600 hover:text-slate-900 hover:bg-slate-100 rounded-lg transition-colors"
+      >
+        <Bell className="w-5 h-5" />
+        {badge && (
+          <span
+            data-testid="notification-badge"
+            className="absolute -top-0.5 -right-0.5 min-w-[1.25rem] h-5 px-1 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center"
+          >
+            {badge}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          data-testid="notification-dropdown"
+          className="absolute right-0 mt-2 w-80 sm:w-96 bg-white rounded-2xl shadow-xl border border-slate-200 z-50 overflow-hidden"
+        >
+          <div className="flex items-center justify-between px-4 py-3 border-b border-slate-100">
+            <h3 className="text-sm font-semibold text-[#0F2744]">Notificaciones</h3>
+            {count > 0 && (
+              <button
+                onClick={marcarTodas}
+                className="text-xs text-[#16A34A] font-medium hover:underline flex items-center gap-1"
+              >
+                <CheckCheck className="w-3 h-3" />
+                Marcar todas
+              </button>
+            )}
+          </div>
+
+          <div className="max-h-96 overflow-y-auto">
+            {loadingList ? (
+              <div className="p-8 text-center text-sm text-slate-500">
+                Cargando...
+              </div>
+            ) : notificaciones.length === 0 ? (
+              <div className="p-8 text-center">
+                <Bell className="w-10 h-10 text-slate-300 mx-auto mb-2" />
+                <p className="text-sm text-slate-500">Sin notificaciones</p>
+              </div>
+            ) : (
+              notificaciones.map((n) => (
+                <NotificationItem
+                  key={n.id}
+                  notif={n}
+                  onMarcarLeida={() => marcarLeida(n.id)}
+                />
+              ))
+            )}
+          </div>
+
+          <div className="border-t border-slate-100 p-2">
+            <Link
+              href="/dashboard/notificaciones"
+              onClick={() => setOpen(false)}
+              className="block w-full text-center text-xs font-medium text-[#16A34A] hover:bg-slate-50 py-2 rounded-lg transition-colors"
+            >
+              Ver todas las notificaciones
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NotificationItem({
+  notif,
+  onMarcarLeida,
+}: {
+  notif: NotificacionApi;
+  onMarcarLeida: () => void;
+}) {
+  const estilo = estiloPorPrioridad(notif.prioridad as string);
+  const tiempo = formatearTiempoRelativo(notif.createdAt);
+
+  const dotColor = {
+    urgent: 'bg-red-500',
+    normal: 'bg-blue-500',
+    low: 'bg-slate-400',
+  }[estilo];
+
+  const wrapperClass = `block px-4 py-3 border-b border-slate-50 last:border-0 ${
+    notif.leida ? 'opacity-60' : 'bg-blue-50/40'
+  } hover:bg-slate-50 transition-colors`;
+
+  const contenido = (
+    <div className="flex items-start gap-3">
+      <span
+        className={`flex-shrink-0 w-2 h-2 mt-2 rounded-full ${
+          notif.leida ? 'bg-slate-300' : dotColor
+        }`}
+      />
+      <div className="flex-1 min-w-0">
+        <p
+          className={`text-sm ${
+            notif.leida ? 'text-slate-600' : 'font-semibold text-[#0F2744]'
+          } truncate`}
+        >
+          {notif.titulo}
+        </p>
+        <p className="text-xs text-slate-500 line-clamp-2 mt-0.5">
+          {notif.mensaje}
+        </p>
+        <p className="text-[11px] text-slate-400 mt-1">{tiempo}</p>
+      </div>
+      {!notif.leida && (
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onMarcarLeida();
+          }}
+          aria-label="Marcar como leída"
+          title="Marcar como leída"
+          className="flex-shrink-0 text-slate-400 hover:text-emerald-600 transition-colors p-1"
+        >
+          <Check className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  );
+
+  if (notif.linkAccion) {
+    return (
+      <Link href={notif.linkAccion} className={wrapperClass}>
+        {contenido}
+      </Link>
+    );
+  }
+  return <div className={wrapperClass}>{contenido}</div>;
+}

--- a/frontend-web/src/lib/utils/parse-notificaciones-response.test.ts
+++ b/frontend-web/src/lib/utils/parse-notificaciones-response.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseNotificacionesResponse,
+  formatearBadgeCount,
+  estiloPorPrioridad,
+  formatearTiempoRelativo,
+  type NotificacionApi,
+} from './parse-notificaciones-response';
+
+/**
+ * Tests para issue #214 PR-B: helpers de parsing y formato.
+ */
+describe('parse-notificaciones-response (issue #214 PR-B)', () => {
+  const notif: NotificacionApi = {
+    id: 'n1',
+    tipo: 'KYC_APROBADO',
+    titulo: 'Tu KYC fue aprobado',
+    mensaje: 'Felicidades.',
+    leida: false,
+    prioridad: 'NORMAL',
+    createdAt: '2026-05-17T10:00:00Z',
+  };
+
+  describe('parseNotificacionesResponse', () => {
+    it('Formato real del backend → extrae fields correctos', () => {
+      const respuesta = {
+        notificaciones: [notif],
+        pagina: 0,
+        tamanio: 20,
+        totalElementos: 1,
+        totalPaginas: 1,
+        noLeidas: 1,
+      };
+
+      const r = parseNotificacionesResponse(respuesta);
+      expect(r.notificaciones).toHaveLength(1);
+      expect(r.notificaciones[0].id).toBe('n1');
+      expect(r.noLeidas).toBe(1);
+    });
+
+    it('Wrap con campos faltantes → completa con defaults razonables', () => {
+      const r = parseNotificacionesResponse({ notificaciones: [notif] });
+      expect(r.notificaciones).toHaveLength(1);
+      expect(r.pagina).toBe(0);
+      expect(r.totalElementos).toBe(1);
+      expect(r.noLeidas).toBe(0);
+    });
+
+    it('Array directo (futuro-proof) → lo envuelve', () => {
+      const r = parseNotificacionesResponse([notif]);
+      expect(r.notificaciones).toHaveLength(1);
+      expect(r.totalElementos).toBe(1);
+    });
+
+    it('null/undefined/string → payload vacío (UI muestra empty state)', () => {
+      expect(parseNotificacionesResponse(null).notificaciones).toEqual([]);
+      expect(parseNotificacionesResponse(undefined).notificaciones).toEqual([]);
+      expect(parseNotificacionesResponse('error').notificaciones).toEqual([]);
+    });
+
+    it('Objeto con `notificaciones` no-array → vacío', () => {
+      const r = parseNotificacionesResponse({ notificaciones: 'broken' });
+      expect(r.notificaciones).toEqual([]);
+    });
+  });
+
+  describe('formatearBadgeCount', () => {
+    it('0 o negativo → null (no mostrar badge)', () => {
+      expect(formatearBadgeCount(0)).toBeNull();
+      expect(formatearBadgeCount(-5)).toBeNull();
+    });
+
+    it('1-99 → string del número', () => {
+      expect(formatearBadgeCount(1)).toBe('1');
+      expect(formatearBadgeCount(42)).toBe('42');
+      expect(formatearBadgeCount(99)).toBe('99');
+    });
+
+    it('Issue #214: 100+ → "99+" (visual compacto)', () => {
+      expect(formatearBadgeCount(100)).toBe('99+');
+      expect(formatearBadgeCount(9999)).toBe('99+');
+    });
+
+    it('NaN o Infinity → null (defensive)', () => {
+      expect(formatearBadgeCount(NaN)).toBeNull();
+      expect(formatearBadgeCount(Infinity)).toBeNull();
+    });
+  });
+
+  describe('estiloPorPrioridad', () => {
+    it('URGENTE → "urgent" (rojo)', () => {
+      expect(estiloPorPrioridad('URGENTE')).toBe('urgent');
+    });
+
+    it('NORMAL → "normal" (azul, default)', () => {
+      expect(estiloPorPrioridad('NORMAL')).toBe('normal');
+    });
+
+    it('BAJA → "low" (gris)', () => {
+      expect(estiloPorPrioridad('BAJA')).toBe('low');
+    });
+
+    it('Valor desconocido → "normal" (default seguro)', () => {
+      expect(estiloPorPrioridad('FUTURO_VALOR')).toBe('normal');
+    });
+  });
+
+  describe('formatearTiempoRelativo', () => {
+    const ahora = new Date('2026-05-17T12:00:00Z');
+
+    it('Hace menos de 1 minuto → "ahora mismo"', () => {
+      const hace30s = new Date('2026-05-17T11:59:30Z').toISOString();
+      expect(formatearTiempoRelativo(hace30s, ahora)).toBe('ahora mismo');
+    });
+
+    it('Hace 5 minutos → "hace 5 minutos"', () => {
+      const hace5m = new Date('2026-05-17T11:55:00Z').toISOString();
+      expect(formatearTiempoRelativo(hace5m, ahora)).toBe('hace 5 minutos');
+    });
+
+    it('Singular "1 minuto" (no "1 minutos")', () => {
+      const hace1m = new Date('2026-05-17T11:59:00Z').toISOString();
+      expect(formatearTiempoRelativo(hace1m, ahora)).toBe('hace 1 minuto');
+    });
+
+    it('Hace 3 horas → "hace 3 horas"', () => {
+      const hace3h = new Date('2026-05-17T09:00:00Z').toISOString();
+      expect(formatearTiempoRelativo(hace3h, ahora)).toBe('hace 3 horas');
+    });
+
+    it('Hace 3 días → "hace 3 días"', () => {
+      const hace3d = new Date('2026-05-14T12:00:00Z').toISOString();
+      expect(formatearTiempoRelativo(hace3d, ahora)).toBe('hace 3 días');
+    });
+
+    it('Más de 7 días → fecha localizada', () => {
+      const hace15d = new Date('2026-05-01T12:00:00Z').toISOString();
+      const r = formatearTiempoRelativo(hace15d, ahora);
+      expect(r).toMatch(/\d{2}/);  // contiene día
+    });
+
+    it('Inputs inválidos → string vacío (defensive)', () => {
+      expect(formatearTiempoRelativo('', ahora)).toBe('');
+      expect(formatearTiempoRelativo('no-iso', ahora)).toBe('');
+    });
+  });
+});

--- a/frontend-web/src/lib/utils/parse-notificaciones-response.ts
+++ b/frontend-web/src/lib/utils/parse-notificaciones-response.ts
@@ -1,0 +1,129 @@
+/**
+ * Parsea y formatea respuestas de notificaciones del backend (issue #214 PR-B).
+ *
+ * Wrap del backend: `{notificaciones, pagina, tamanio, totalElementos,
+ * totalPaginas, noLeidas}`.
+ *
+ * Defensive: acepta también array directo o formas inesperadas (lección de
+ * los parsers previos de cuentas/movimientos/beneficiarios).
+ */
+
+export type TipoNotificacion =
+  | 'KYC_APROBADO' | 'KYC_RECHAZADO' | 'KYC_REQUIERE_INFO'
+  | 'CREDITO_APROBADO' | 'CREDITO_RECHAZADO' | 'CREDITO_DESEMBOLSADO'
+  | 'CUOTA_PROXIMA_VENCER' | 'CUOTA_VENCIDA'
+  | 'DEPOSITO_RECIBIDO' | 'RETIRO_PROCESADO'
+  | 'NUEVO_DISPOSITIVO_LOGIN'
+  | 'ADMIN_NUEVA_SOLICITUD' | 'ADMIN_NUEVO_KYC'
+  | 'GENERAL';
+
+export type PrioridadNotificacion = 'URGENTE' | 'NORMAL' | 'BAJA';
+
+export interface NotificacionApi {
+  id: string;
+  tipo: TipoNotificacion | string;
+  titulo: string;
+  mensaje: string;
+  linkAccion?: string | null;
+  leida: boolean;
+  fechaLectura?: string | null;
+  prioridad: PrioridadNotificacion | string;
+  createdAt: string;
+}
+
+export interface NotificacionListPayload {
+  notificaciones: NotificacionApi[];
+  pagina: number;
+  tamanio: number;
+  totalElementos: number;
+  totalPaginas: number;
+  noLeidas: number;
+}
+
+const EMPTY: NotificacionListPayload = {
+  notificaciones: [],
+  pagina: 0,
+  tamanio: 0,
+  totalElementos: 0,
+  totalPaginas: 0,
+  noLeidas: 0,
+};
+
+/**
+ * Parsea el response JSON del backend en una estructura tipada.
+ * Cuando el formato no se reconoce, retorna el payload vacío para que la UI
+ * pueda renderizar empty state sin romper.
+ */
+export function parseNotificacionesResponse(data: unknown): NotificacionListPayload {
+  if (!data) return EMPTY;
+
+  // Caso normal: objeto del backend
+  if (typeof data === 'object' && 'notificaciones' in (data as object)) {
+    const d = data as Partial<NotificacionListPayload>;
+    const list = Array.isArray(d.notificaciones) ? d.notificaciones : [];
+    return {
+      notificaciones: list,
+      pagina: typeof d.pagina === 'number' ? d.pagina : 0,
+      tamanio: typeof d.tamanio === 'number' ? d.tamanio : list.length,
+      totalElementos:
+        typeof d.totalElementos === 'number' ? d.totalElementos : list.length,
+      totalPaginas: typeof d.totalPaginas === 'number' ? d.totalPaginas : 1,
+      noLeidas: typeof d.noLeidas === 'number' ? d.noLeidas : 0,
+    };
+  }
+
+  // Caso defensive: array directo (futuro-proof)
+  if (Array.isArray(data)) {
+    return { ...EMPTY, notificaciones: data as NotificacionApi[], totalElementos: data.length };
+  }
+
+  return EMPTY;
+}
+
+/**
+ * Formatea el contador del badge: si es 0 retorna `null` (no mostrar badge),
+ * si es > 99 retorna `'99+'` (apto para visual).
+ */
+export function formatearBadgeCount(noLeidas: number): string | null {
+  if (!Number.isFinite(noLeidas) || noLeidas <= 0) return null;
+  if (noLeidas > 99) return '99+';
+  return String(Math.floor(noLeidas));
+}
+
+/**
+ * Devuelve el tipo CSS de prioridad (warning/info/error) para colorear
+ * el item en la UI. Mismo patrón que `decidir-kyc-banner`.
+ */
+export function estiloPorPrioridad(
+  prioridad: string
+): 'urgent' | 'normal' | 'low' {
+  if (prioridad === 'URGENTE') return 'urgent';
+  if (prioridad === 'BAJA') return 'low';
+  return 'normal';
+}
+
+/**
+ * Formatea timestamp ISO a "hace X minutos / hace X horas / DD MMM".
+ * Localizado a es-VE.
+ */
+export function formatearTiempoRelativo(isoString: string, ahora: Date = new Date()): string {
+  if (!isoString) return '';
+  try {
+    const fecha = new Date(isoString);
+    if (Number.isNaN(fecha.getTime())) return '';
+
+    const diffMs = ahora.getTime() - fecha.getTime();
+    const diffMin = Math.floor(diffMs / 60_000);
+    const diffH = Math.floor(diffMs / 3_600_000);
+    const diffDays = Math.floor(diffMs / 86_400_000);
+
+    if (diffMin < 1) return 'ahora mismo';
+    if (diffMin < 60) return `hace ${diffMin} ${diffMin === 1 ? 'minuto' : 'minutos'}`;
+    if (diffH < 24) return `hace ${diffH} ${diffH === 1 ? 'hora' : 'horas'}`;
+    if (diffDays < 7) return `hace ${diffDays} ${diffDays === 1 ? 'día' : 'días'}`;
+
+    return fecha.toLocaleDateString('es-VE', { day: '2-digit', month: 'short' });
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
Related: #214 (no cierra aún — falta PR-C disparadores)
Depends on: #241 (PR-A backend, ya mergeado)

## Resumen

**PR-B de 3 del sistema de notificaciones in-app.** Completa el frontend sobre los endpoints del PR-A (#241).

Sin PR-C (disparadores), la tabla queda vacía y la UI muestra **empty states** correctamente (\"Sin notificaciones\"). NO afecta el flujo existente.

## Lo que verás en QA

| Lugar | Lo que aparece |
|-------|----------------|
| Header del socio | **Icono 🔔** (Bell) — antes era \`<Bell />\` importado pero no renderizado |
| Click en el Bell | Dropdown con últimas 5 + \"Marcar todas\" + \"Ver todas las notificaciones\" |
| Badge rojo | Solo si hay no-leídas. \"99+\" si >99 |
| \`/dashboard/notificaciones\` | Página completa paginada (20/página) con filtros |
| Polling | Cada 30s al \`/count\` actualiza el badge silenciosamente |

## Cambios técnicos

### BFF routes (4 nuevos archivos)
\`/api/notificaciones/{,count,[id]/leida,marcar-todas-leidas}\` — proxies al backend con manejo defensivo. \`/count\` falla abierto (devuelve 0 en vez de 401/500) para que el polling no rompa la UI cuando expira la sesión.

### Utility puro \`parse-notificaciones-response.ts\` (testeable sin React)
- \`parseNotificacionesResponse\` defensive ante 5 formatos.
- \`formatearBadgeCount\` 0→null, 100+→\"99+\".
- \`estiloPorPrioridad\` 3 niveles + default seguro.
- \`formatearTiempoRelativo\` con singular/plural correctos en español.

### Componente \`NotificationBell\`
- Polling 30s al \`/count\` (barato).
- Lista solo al abrir dropdown (lazy).
- Optimistic update al marcar leída.
- Click fuera cierra.
- Soporte para notificaciones con/sin \`linkAccion\` (Link vs div, conditional rendering TS-safe).
- Accesible: \`aria-label\` dinámico, \`data-testid\` para tests E2E.

### Página \`/dashboard/notificaciones\`
- Paginada (20/página, prev/next con \`disabled\`).
- Filtros: todas / no-leídas (con badge del count).
- \"Marcar todas\" prominente cuando hay no-leídas.

### Integración \`socio-shell.tsx\`
- Renderiza \`<NotificationBell />\` en el header.
- Removido el import dead-code de \`Bell\` (que el issue ya había detectado).

## Tests TDD (20 nuevos)

| Test | Tipo | SIN fix | CON fix |
|------|------|---------|---------|
| Formato real del backend → extrae correctamente | regression | N/A | ✅ |
| Defensive: null/undefined/string/sin notificaciones/no-array → vacío | edge x5 | N/A | ✅ |
| \`formatearBadgeCount(100+)\` → \"99+\" (no \"100\") | unit | N/A | ✅ |
| \`formatearBadgeCount(0)\` → null (badge oculto) | unit | N/A | ✅ |
| \`estiloPorPrioridad\` con 3 niveles + valor desconocido seguro | unit x4 | N/A | ✅ |
| \`formatearTiempoRelativo\` singular/plural correctos | unit x6 | N/A | ✅ |
| Defensive en formateadores (NaN/Infinity/no-iso) | edge x3 | N/A | ✅ |

**Suite utility/hooks frontend: 202/202** (sin regresión).

## Test plan QA

### 1. Bell aparece en el header del socio
- Login → debe verse el icono 🔔 entre el título y el avatar.
- Sin notificaciones: ningún badge rojo.

### 2. Insertar notificación de prueba en BD
\`\`\`sql
INSERT INTO notificacion (destinatario_id, tipo, titulo, mensaje, prioridad, link_accion)
VALUES (
  (SELECT id FROM usuarios WHERE nombre_usuario = 'socio_prueba'),
  'KYC_APROBADO',
  'Tu KYC fue aprobado',
  'Felicidades, ya puedes operar.',
  'NORMAL',
  '/dashboard/kyc'
);
\`\`\`
- Esperar ≤30s → badge rojo \"1\" aparece automáticamente (polling).

### 3. Click en Bell → dropdown
- Muestra la notificación con punto azul (no leída) + título en bold + tiempo \"hace X segundos\".
- Click en el ✓ → marca leída (punto gris, texto opacado, badge desaparece).
- Click en la notificación misma (tiene linkAccion) → navega a \`/dashboard/kyc\`.

### 4. \"Marcar todas como leídas\"
- Insertar 3-5 notificaciones más.
- Click en el botón verde del dropdown → todas pasan a leídas, badge desaparece.

### 5. Página completa
- Click \"Ver todas las notificaciones\" → navega a \`/dashboard/notificaciones\`.
- Tabs \"Todas\" / \"No leídas\" filtran correctamente.
- Paginación funcional si hay >20.

### 6. Polling silencioso
- DevTools → Network → filtrar \`count\`.
- Debe verse una request cada 30s aproximadamente.
- Si cierras sesión, \`/count\` devuelve 0 (no 401 — fallar abierto).

## Pendiente para PR-C

- Integrar disparadores en \`AprobarKYCUseCase\`, \`RechazarKycUseCase\`, \`EvaluarCreditoUseCase\`, \`RealizarDepositoUseCase\`, job de cuotas próximas, login desde nuevo dispositivo.
- Hasta entonces, la única forma de crear notificaciones es vía SQL manual.
- Admin shell todavía tiene \`mockNotifications\` — se puede limpiar en PR-C también, o en uno separado de menor scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)