### PR TITLE
feat(notificaciones): disparadores desde eventos KYC y Crédito (#214 PR-C)

### DIFF
--- a/backend/src/main/java/com/tufondo/creditos/application/usecase/AprobarSolicitudCreditoUseCase.java
+++ b/backend/src/main/java/com/tufondo/creditos/application/usecase/AprobarSolicitudCreditoUseCase.java
@@ -12,6 +12,7 @@ import com.tufondo.creditos.domain.model.enums.EstadoSolicitud;
 import com.tufondo.creditos.domain.repository.CuentaGarantiaRepository;
 import com.tufondo.creditos.domain.repository.SolicitudCreditoRepository;
 import com.tufondo.creditos.domain.repository.TipoCreditoRepository;
+import com.tufondo.notificaciones.application.service.NotificacionPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,6 +36,8 @@ public class AprobarSolicitudCreditoUseCase {
     private final TipoCreditoRepository tipoCreditoRepository;
     private final CuentaGarantiaRepository cuentaGarantiaRepository;
     private final CreditosDTOMapper mapper;
+    // Issue #214 PR-C
+    private final NotificacionPublisher notificacionPublisher;
 
     @Transactional
     public Map<String, Object> ejecutar(String numeroSolicitud, AprobarRechazarRequest request) {
@@ -92,8 +95,16 @@ public class AprobarSolicitudCreditoUseCase {
         solicitud.setUpdatedAt(LocalDateTime.now());
         solicitudRepository.guardar(solicitud);
 
-        log.info("Solicitud {} aprobada - Colateral: {} - Tasa: {}", 
+        log.info("Solicitud {} aprobada - Colateral: {} - Tasa: {}",
             numeroSolicitud, colateralRequerido, tasaInteres);
+
+        // Issue #214 PR-C: notificar al socio. La SolicitudCredito no tiene
+        // moneda (asume VES); si el dominio agrega multi-moneda, actualizar aquí.
+        notificacionPublisher.notificarSocioCreditoAprobado(
+                solicitud.getSocioId(),
+                solicitud.getMontoSolicitado(),
+                "Bs",
+                numeroSolicitud);
 
         Map<String, Object> response = new HashMap<>();
         response.put("id", solicitud.getId().toString());

--- a/backend/src/main/java/com/tufondo/creditos/application/usecase/DesembolsaCreditoUseCase.java
+++ b/backend/src/main/java/com/tufondo/creditos/application/usecase/DesembolsaCreditoUseCase.java
@@ -12,6 +12,7 @@ import com.tufondo.creditos.domain.model.enums.EstadoSolicitud;
 import com.tufondo.creditos.domain.repository.PlanAmortizacionRepository;
 import com.tufondo.creditos.domain.repository.SolicitudCreditoRepository;
 import com.tufondo.creditos.domain.repository.TipoCreditoRepository;
+import com.tufondo.notificaciones.application.service.NotificacionPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -36,6 +37,8 @@ public class DesembolsaCreditoUseCase {
     private final TipoCreditoRepository tipoCreditoRepository;
     private final PlanAmortizacionRepository planRepository;
     private final CreditosDTOMapper mapper;
+    // Issue #214 PR-C
+    private final NotificacionPublisher notificacionPublisher;
 
     @Transactional
     public Map<String, Object> ejecutar(String numeroSolicitud, DesembolsaRequest request, String ipOrigen) {
@@ -82,8 +85,12 @@ public class DesembolsaCreditoUseCase {
         solicitud.setUpdatedAt(LocalDateTime.now());
         solicitudRepository.guardar(solicitud);
 
-        log.info("Crédito desembolsado: {} - Monto: {} - Comision: {} - IP: {}", 
+        log.info("Crédito desembolsado: {} - Monto: {} - Comision: {} - IP: {}",
             numeroSolicitud, montoNeto, comisionApertura, ipOrigen);
+
+        // Issue #214 PR-C: notificar al socio del desembolso
+        notificacionPublisher.notificarSocioCreditoDesembolsado(
+                solicitud.getSocioId(), montoNeto, "Bs", numeroSolicitud);
 
         Map<String, Object> response = new HashMap<>();
         response.put("id", solicitud.getId().toString());

--- a/backend/src/main/java/com/tufondo/creditos/application/usecase/RechazarSolicitudCreditoUseCase.java
+++ b/backend/src/main/java/com/tufondo/creditos/application/usecase/RechazarSolicitudCreditoUseCase.java
@@ -7,6 +7,7 @@ import com.tufondo.creditos.domain.exception.EstadoCreditoInvalidoException;
 import com.tufondo.creditos.domain.model.SolicitudCredito;
 import com.tufondo.creditos.domain.model.enums.EstadoSolicitud;
 import com.tufondo.creditos.domain.repository.SolicitudCreditoRepository;
+import com.tufondo.notificaciones.application.service.NotificacionPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,8 @@ import java.util.Map;
 public class RechazarSolicitudCreditoUseCase {
 
     private final SolicitudCreditoRepository solicitudRepository;
+    // Issue #214 PR-C
+    private final NotificacionPublisher notificacionPublisher;
 
     @Transactional
     public Map<String, Object> ejecutar(String numeroSolicitud, AprobarRechazarRequest request) {
@@ -44,6 +47,10 @@ public class RechazarSolicitudCreditoUseCase {
         solicitudRepository.guardar(solicitud);
 
         log.info("Solicitud {} rechazada - Motivo: {}", numeroSolicitud, motivo);
+
+        // Issue #214 PR-C: notificar al socio con el motivo
+        notificacionPublisher.notificarSocioCreditoRechazado(
+                solicitud.getSocioId(), numeroSolicitud, motivo);
 
         Map<String, Object> response = new HashMap<>();
         response.put("id", solicitud.getId().toString());

--- a/backend/src/main/java/com/tufondo/kyc/application/usecase/RevisarDocumentosUseCase.java
+++ b/backend/src/main/java/com/tufondo/kyc/application/usecase/RevisarDocumentosUseCase.java
@@ -15,6 +15,7 @@ import com.tufondo.kyc.domain.model.port.StoragePort;
 import com.tufondo.kyc.domain.repository.ConsentimientoKYCRepository;
 import com.tufondo.kyc.domain.repository.DocumentoIdentidadRepository;
 import com.tufondo.kyc.domain.repository.VerificacionKYCRepository;
+import com.tufondo.notificaciones.application.service.NotificacionPublisher;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,10 @@ public class RevisarDocumentosUseCase {
     private final DocumentoIdentidadRepository documentoRepository;
     private final ConsentimientoKYCRepository consentimientoRepository;
     private final StoragePort storagePort;
+    // Issue #214 PR-C: notificar al socio del resultado de la revisión KYC.
+    // El publisher es defensivo: si falla la persistencia de la notificación,
+    // el flujo de aprobar/rechazar NO se ve afectado.
+    private final NotificacionPublisher notificacionPublisher;
 
     public RevisionResponse obtenerDetalle(UUID verificacionId) {
         VerificacionKYC verificacion = verificacionRepository.findById(verificacionId)
@@ -136,6 +141,9 @@ public class RevisarDocumentosUseCase {
             documentoRepository.save(doc);
         }
 
+        // Issue #214 PR-C: notificar al socio
+        notificacionPublisher.notificarSocioKycAprobado(verificacion.getSocioId());
+
         return RevisionDecisionResponse.builder()
             .verificacionId(verificacion.getId())
             .estadoAnterior(estadoAnterior)
@@ -174,6 +182,10 @@ public class RevisarDocumentosUseCase {
             }
         }
 
+        // Issue #214 PR-C: notificar al socio del rechazo con el motivo
+        notificacionPublisher.notificarSocioKycRechazado(
+                verificacion.getSocioId(), request.getComentario());
+
         return RevisionDecisionResponse.builder()
             .verificacionId(verificacion.getId())
             .estadoAnterior(estadoAnterior)
@@ -199,6 +211,10 @@ public class RevisarDocumentosUseCase {
         verificacion.setFechaRevision(LocalDateTime.now());
         verificacion.setComentariosRevision(request.getComentario());
         verificacionRepository.save(verificacion);
+
+        // Issue #214 PR-C: notificar al socio que necesita enviar más info
+        notificacionPublisher.notificarSocioKycRequiereInfo(
+                verificacion.getSocioId(), request.getComentario());
 
         return RevisionDecisionResponse.builder()
             .verificacionId(verificacion.getId())

--- a/backend/src/main/java/com/tufondo/notificaciones/application/service/NotificacionPublisher.java
+++ b/backend/src/main/java/com/tufondo/notificaciones/application/service/NotificacionPublisher.java
@@ -1,0 +1,187 @@
+package com.tufondo.notificaciones.application.service;
+
+import com.tufondo.auth.domain.repository.UsuarioRepository;
+import com.tufondo.notificaciones.domain.model.Notificacion;
+import com.tufondo.notificaciones.domain.model.enums.PrioridadNotificacion;
+import com.tufondo.notificaciones.domain.model.enums.TipoNotificacion;
+import com.tufondo.notificaciones.domain.repository.NotificacionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Servicio "publicador" de notificaciones — fachada con métodos semánticos
+ * del dominio (issue #214 PR-C).
+ *
+ * <p>Los use cases de KYC, créditos, depósitos, etc. inyectan este servicio
+ * y llaman métodos como {@code notificarSocioKycAprobado(socioId)} sin
+ * preocuparse por la resolución socioId→usuarioId, ni por construir el
+ * mensaje, ni por elegir la prioridad. Eso queda centralizado aquí.</p>
+ *
+ * <p><strong>Resiliencia</strong>: si la inserción de la notificación falla
+ * (BD caída, contraint violation, etc.), el caller NO debe abortar su
+ * operación principal. Por eso usamos {@code REQUIRES_NEW} y atrapamos
+ * Throwable — un fallo de notificación nunca debe romper aprobar un KYC
+ * o desembolsar un crédito.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificacionPublisher {
+
+    private final NotificacionRepository notificacionRepository;
+    private final UsuarioRepository usuarioRepository;
+
+    // === Notificaciones a SOCIO (resuelven socioId → usuarioId) ===
+
+    public void notificarSocioKycAprobado(UUID socioId) {
+        publicarASocio(socioId, Notificacion.builder()
+                .tipo(TipoNotificacion.KYC_APROBADO)
+                .titulo("Tu verificación KYC fue aprobada")
+                .mensaje("¡Felicidades! Ya puedes acceder a todas las funciones del fondo: solicitar créditos, depósitos y retiros sin límites adicionales.")
+                .linkAccion("/dashboard/kyc")
+                .prioridad(PrioridadNotificacion.NORMAL)
+                .build());
+    }
+
+    public void notificarSocioKycRechazado(UUID socioId, String motivo) {
+        String texto = motivo != null && !motivo.isBlank()
+                ? "Motivo: " + motivo + ". Revisa los documentos y vuelve a enviar."
+                : "Revisa el detalle, corrige los documentos y vuelve a enviar.";
+        publicarASocio(socioId, Notificacion.builder()
+                .tipo(TipoNotificacion.KYC_RECHAZADO)
+                .titulo("Tu verificación KYC fue rechazada")
+                .mensaje(texto)
+                .linkAccion("/dashboard/kyc")
+                .prioridad(PrioridadNotificacion.URGENTE)
+                .build());
+    }
+
+    public void notificarSocioKycRequiereInfo(UUID socioId, String detalle) {
+        String texto = detalle != null && !detalle.isBlank()
+                ? "El analista necesita: " + detalle
+                : "El analista necesita información adicional para continuar.";
+        publicarASocio(socioId, Notificacion.builder()
+                .tipo(TipoNotificacion.KYC_REQUIERE_INFO)
+                .titulo("Tu KYC requiere información adicional")
+                .mensaje(texto)
+                .linkAccion("/dashboard/kyc")
+                .prioridad(PrioridadNotificacion.NORMAL)
+                .build());
+    }
+
+    public void notificarSocioCreditoAprobado(UUID socioId, BigDecimal monto, String moneda, String numeroSolicitud) {
+        publicarASocio(socioId, Notificacion.builder()
+                .tipo(TipoNotificacion.CREDITO_APROBADO)
+                .titulo("Tu crédito fue aprobado")
+                .mensaje(String.format("Solicitud %s aprobada por %s %s. Pronto recibirás el desembolso.",
+                        safe(numeroSolicitud), safe(moneda), monto != null ? monto.toPlainString() : "—"))
+                .linkAccion("/dashboard/creditos")
+                .prioridad(PrioridadNotificacion.NORMAL)
+                .build());
+    }
+
+    public void notificarSocioCreditoRechazado(UUID socioId, String numeroSolicitud, String motivo) {
+        String texto = motivo != null && !motivo.isBlank()
+                ? "Motivo: " + motivo
+                : "Revisa el detalle desde tu panel de créditos.";
+        publicarASocio(socioId, Notificacion.builder()
+                .tipo(TipoNotificacion.CREDITO_RECHAZADO)
+                .titulo("Tu solicitud de crédito fue rechazada")
+                .mensaje(String.format("Solicitud %s. %s", safe(numeroSolicitud), texto))
+                .linkAccion("/dashboard/creditos")
+                .prioridad(PrioridadNotificacion.NORMAL)
+                .build());
+    }
+
+    public void notificarSocioCreditoDesembolsado(UUID socioId, BigDecimal monto, String moneda, String numeroSolicitud) {
+        publicarASocio(socioId, Notificacion.builder()
+                .tipo(TipoNotificacion.CREDITO_DESEMBOLSADO)
+                .titulo("Tu crédito fue desembolsado")
+                .mensaje(String.format("Recibiste %s %s en tu cuenta (solicitud %s). Revisa el plan de amortización.",
+                        safe(moneda), monto != null ? monto.toPlainString() : "—", safe(numeroSolicitud)))
+                .linkAccion("/dashboard/creditos")
+                .prioridad(PrioridadNotificacion.NORMAL)
+                .build());
+    }
+
+    // === Helper interno: resolver socioId → usuarioId y persistir ===
+
+    /**
+     * Resuelve el {@code socioId} al {@code usuarioId} (destinatario real) y
+     * persiste la notificación en una transacción separada con manejo de
+     * errores defensivo: una falla aquí NUNCA propaga al caller.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void publicarASocio(UUID socioId, Notificacion plantilla) {
+        try {
+            if (socioId == null) {
+                log.warn("notificación skip: socioId es null (tipo={})", plantilla.getTipo());
+                return;
+            }
+            Optional<UUID> usuarioId = usuarioRepository.buscarPorSocioId(socioId)
+                    .map(u -> u.id());
+            if (usuarioId.isEmpty()) {
+                // Sin usuario asociado al socio (caso raro pero posible en
+                // datos legacy): logueamos y skipeamos en vez de romper el
+                // flujo del caller.
+                log.warn("notificación skip: socio {} no tiene usuario asociado (tipo={})",
+                        socioId, plantilla.getTipo());
+                return;
+            }
+            persistir(usuarioId.get(), plantilla);
+        } catch (Throwable t) {
+            // Defensivo extra: ninguna excepción debe propagar.
+            log.error("Falló al publicar notificación tipo={} a socioId={}: {}",
+                    plantilla.getTipo(), socioId, t.getMessage(), t);
+        }
+    }
+
+    /**
+     * Variante para notificar directamente al usuarioId (admin, sistema)
+     * sin pasar por la resolución socio → usuario.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void publicarAUsuario(UUID usuarioId, Notificacion plantilla) {
+        try {
+            if (usuarioId == null) {
+                log.warn("notificación skip: usuarioId es null (tipo={})", plantilla.getTipo());
+                return;
+            }
+            persistir(usuarioId, plantilla);
+        } catch (Throwable t) {
+            log.error("Falló al publicar notificación tipo={} a usuarioId={}: {}",
+                    plantilla.getTipo(), usuarioId, t.getMessage(), t);
+        }
+    }
+
+    private void persistir(UUID destinatarioId, Notificacion plantilla) {
+        Notificacion completa = Notificacion.builder()
+                .id(UUID.randomUUID())
+                .destinatarioId(destinatarioId)
+                .tipo(plantilla.getTipo())
+                .titulo(plantilla.getTitulo())
+                .mensaje(plantilla.getMensaje())
+                .linkAccion(plantilla.getLinkAccion())
+                .prioridad(plantilla.getPrioridad() != null
+                        ? plantilla.getPrioridad()
+                        : PrioridadNotificacion.NORMAL)
+                .metadata(plantilla.getMetadata())
+                .leida(false)
+                .createdAt(Instant.now())
+                .build();
+        notificacionRepository.guardar(completa);
+        log.debug("Notificación creada: destinatario={}, tipo={}", destinatarioId, plantilla.getTipo());
+    }
+
+    private static String safe(String s) {
+        return s != null ? s : "";
+    }
+}

--- a/backend/src/test/java/com/tufondo/notificaciones/application/service/NotificacionPublisherTest.java
+++ b/backend/src/test/java/com/tufondo/notificaciones/application/service/NotificacionPublisherTest.java
@@ -1,0 +1,195 @@
+package com.tufondo.notificaciones.application.service;
+
+import com.tufondo.auth.domain.model.Usuario;
+import com.tufondo.auth.domain.model.enums.Rol;
+import com.tufondo.auth.domain.repository.UsuarioRepository;
+import com.tufondo.notificaciones.domain.model.Notificacion;
+import com.tufondo.notificaciones.domain.model.enums.PrioridadNotificacion;
+import com.tufondo.notificaciones.domain.model.enums.TipoNotificacion;
+import com.tufondo.notificaciones.domain.repository.NotificacionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests para issue #214 PR-C: publicador semántico de notificaciones.
+ *
+ * <p>Verifica que (a) las notificaciones se persisten con los campos correctos,
+ * (b) la resolución socioId→usuarioId funciona, (c) los fallos NO se propagan
+ * al caller (defensa en profundidad — un fallo de notificación nunca debe
+ * romper aprobar un KYC o desembolsar un crédito).</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class NotificacionPublisherTest {
+
+    @Mock
+    private NotificacionRepository notificacionRepository;
+
+    @Mock
+    private UsuarioRepository usuarioRepository;
+
+    @InjectMocks
+    private NotificacionPublisher publisher;
+
+    private UUID socioId;
+    private UUID usuarioId;
+
+    @BeforeEach
+    void setUp() {
+        socioId = UUID.randomUUID();
+        usuarioId = UUID.randomUUID();
+        // Nota: el stub `buscarPorSocioId` se hace por test (no en setUp) porque
+        // algunos tests prueban explícitamente la ausencia de usuario o IDs
+        // diferentes. Mockito strict mode marca como error los stubs no usados.
+    }
+
+    /** Helper: stub que devuelve usuario válido para el socio del setUp. */
+    private void stubUsuarioParaSocio() {
+        Usuario usuario = Usuario.desdeParametros(
+                usuarioId, "socio_test", "socio@test.com", "hash",
+                "Test", Rol.SOCIO, socioId, true,
+                Instant.now(), Instant.now(), 0, null, false);
+        when(usuarioRepository.buscarPorSocioId(socioId))
+                .thenReturn(Optional.of(usuario));
+    }
+
+    @Test
+    @DisplayName("notificarSocioKycAprobado: persiste notificación con tipo KYC_APROBADO + linkAccion correcto")
+    void kyc_aprobado_persiste_correctamente() {
+        stubUsuarioParaSocio();
+        publisher.notificarSocioKycAprobado(socioId);
+
+        ArgumentCaptor<Notificacion> captor = ArgumentCaptor.forClass(Notificacion.class);
+        verify(notificacionRepository).guardar(captor.capture());
+        Notificacion n = captor.getValue();
+
+        assertThat(n.getDestinatarioId()).isEqualTo(usuarioId);
+        assertThat(n.getTipo()).isEqualTo(TipoNotificacion.KYC_APROBADO);
+        assertThat(n.getLinkAccion()).isEqualTo("/dashboard/kyc");
+        assertThat(n.isLeida()).isFalse();
+        assertThat(n.getPrioridad()).isEqualTo(PrioridadNotificacion.NORMAL);
+        assertThat(n.getTitulo()).isNotBlank();
+        assertThat(n.getMensaje()).isNotBlank();
+        assertThat(n.getId()).isNotNull();
+        assertThat(n.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Issue #214: notificarSocioKycRechazado CON motivo → el motivo aparece en el mensaje")
+    void kyc_rechazado_con_motivo_lo_propaga() {
+        stubUsuarioParaSocio();
+        String motivo = "La foto de la cédula está borrosa";
+
+        publisher.notificarSocioKycRechazado(socioId, motivo);
+
+        ArgumentCaptor<Notificacion> captor = ArgumentCaptor.forClass(Notificacion.class);
+        verify(notificacionRepository).guardar(captor.capture());
+        Notificacion n = captor.getValue();
+
+        assertThat(n.getTipo()).isEqualTo(TipoNotificacion.KYC_RECHAZADO);
+        assertThat(n.getPrioridad()).isEqualTo(PrioridadNotificacion.URGENTE);
+        // CRÍTICO: el socio necesita saber QUÉ corregir
+        assertThat(n.getMensaje()).contains(motivo);
+    }
+
+    @Test
+    @DisplayName("notificarSocioCreditoAprobado: monto y número en el mensaje")
+    void credito_aprobado_incluye_monto_y_numero() {
+        stubUsuarioParaSocio();
+        publisher.notificarSocioCreditoAprobado(
+                socioId, new BigDecimal("5000.00"), "Bs", "SOL-CRED-2026-000001");
+
+        ArgumentCaptor<Notificacion> captor = ArgumentCaptor.forClass(Notificacion.class);
+        verify(notificacionRepository).guardar(captor.capture());
+        Notificacion n = captor.getValue();
+
+        assertThat(n.getTipo()).isEqualTo(TipoNotificacion.CREDITO_APROBADO);
+        assertThat(n.getMensaje()).contains("5000.00").contains("SOL-CRED-2026-000001");
+    }
+
+    @Test
+    @DisplayName("notificarSocioCreditoDesembolsado: monto y referencia en el mensaje")
+    void credito_desembolsado_incluye_datos() {
+        stubUsuarioParaSocio();
+        publisher.notificarSocioCreditoDesembolsado(
+                socioId, new BigDecimal("4800.00"), "Bs", "SOL-CRED-2026-000001");
+
+        ArgumentCaptor<Notificacion> captor = ArgumentCaptor.forClass(Notificacion.class);
+        verify(notificacionRepository).guardar(captor.capture());
+        Notificacion n = captor.getValue();
+
+        assertThat(n.getTipo()).isEqualTo(TipoNotificacion.CREDITO_DESEMBOLSADO);
+        assertThat(n.getMensaje()).contains("4800.00");
+    }
+
+    @Test
+    @DisplayName("Issue #214 RESILIENCIA: si socio NO tiene usuario asociado → log + skip, NO lanza")
+    void socio_sin_usuario_skip_silencioso() {
+        UUID socioHuerfano = UUID.randomUUID();
+        when(usuarioRepository.buscarPorSocioId(socioHuerfano)).thenReturn(Optional.empty());
+
+        // NO debe lanzar — el caller (ej. AprobarKycUseCase) no debe abortar
+        // su operación principal por un problema de notificación.
+        publisher.notificarSocioKycAprobado(socioHuerfano);
+
+        verify(notificacionRepository, never()).guardar(any());
+    }
+
+    @Test
+    @DisplayName("Issue #214 RESILIENCIA: socioId null → skip silencioso, no lanza")
+    void socio_null_skip_silencioso() {
+        publisher.notificarSocioKycAprobado(null);
+
+        verify(notificacionRepository, never()).guardar(any());
+        verify(usuarioRepository, never()).buscarPorSocioId(any());
+    }
+
+    @Test
+    @DisplayName("Issue #214 RESILIENCIA: si el repositorio lanza → publisher atrapa, no propaga")
+    void error_persistencia_atrapado() {
+        stubUsuarioParaSocio();
+        doThrow(new RuntimeException("BD caída"))
+                .when(notificacionRepository).guardar(any());
+
+        // NO debe lanzar — el aprobar KYC del caller debe completarse igual
+        publisher.notificarSocioKycAprobado(socioId);
+
+        // Verificamos que SÍ intentó persistir (no fue skip)
+        verify(notificacionRepository).guardar(any());
+        // Sin assert sobre exception — el punto es que NO lanzó
+    }
+
+    @Test
+    @DisplayName("publicarAUsuario: ruta directa sin lookup de socio")
+    void publicar_directo_a_usuario_sin_lookup() {
+        UUID admin = UUID.randomUUID();
+        Notificacion plantilla = Notificacion.builder()
+                .tipo(TipoNotificacion.ADMIN_NUEVO_KYC)
+                .titulo("Nuevo KYC para revisar")
+                .mensaje("Tienes una nueva verificación pendiente.")
+                .prioridad(PrioridadNotificacion.NORMAL)
+                .build();
+
+        publisher.publicarAUsuario(admin, plantilla);
+
+        ArgumentCaptor<Notificacion> captor = ArgumentCaptor.forClass(Notificacion.class);
+        verify(notificacionRepository).guardar(captor.capture());
+        assertThat(captor.getValue().getDestinatarioId()).isEqualTo(admin);
+        // No debió consultar el repo de usuarios (es ruta directa)
+        verify(usuarioRepository, never()).buscarPorSocioId(any());
+    }
+}

--- a/frontend-web/src/app/(dashboard)/dashboard/notificaciones/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/notificaciones/page.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { Bell, CheckCheck, Check, Loader2, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  parseNotificacionesResponse,
+  estiloPorPrioridad,
+  formatearTiempoRelativo,
+  type NotificacionApi,
+} from '@/lib/utils/parse-notificaciones-response';
+
+/**
+ * Página dedicada con histórico paginado de notificaciones (issue #214 PR-B).
+ *
+ * Diferencias con el dropdown del Bell:
+ * - Paginación completa (20 por página, navegación con prev/next).
+ * - Filtro: todas / solo no leídas.
+ * - Click en notificación con link la marca leída y navega.
+ */
+
+const PAGE_SIZE = 20;
+
+export default function NotificacionesPage() {
+  const [items, setItems] = useState<NotificacionApi[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(0);
+  const [totalPaginas, setTotalPaginas] = useState(1);
+  const [noLeidas, setNoLeidas] = useState(0);
+  const [filtro, setFiltro] = useState<'todas' | 'no-leidas'>('todas');
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    try {
+      const qs = new URLSearchParams({
+        page: String(page),
+        size: String(PAGE_SIZE),
+        soloNoLeidas: filtro === 'no-leidas' ? 'true' : 'false',
+      });
+      const res = await fetch(`/api/notificaciones?${qs}`);
+      if (res.ok) {
+        const data = parseNotificacionesResponse(await res.json());
+        setItems(data.notificaciones);
+        setTotalPaginas(Math.max(1, data.totalPaginas));
+        setNoLeidas(data.noLeidas);
+      } else {
+        setItems([]);
+      }
+    } catch {
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, filtro]);
+
+  useEffect(() => {
+    cargar();
+  }, [cargar]);
+
+  const marcarLeida = async (id: string) => {
+    try {
+      await fetch(`/api/notificaciones/${id}/leida`, { method: 'PATCH' });
+      setItems((prev) =>
+        prev.map((n) => (n.id === id ? { ...n, leida: true } : n))
+      );
+      setNoLeidas((prev) => Math.max(0, prev - 1));
+    } catch {
+      cargar();
+    }
+  };
+
+  const marcarTodas = async () => {
+    try {
+      await fetch('/api/notificaciones/marcar-todas-leidas', { method: 'POST' });
+      cargar();
+    } catch {
+      cargar();
+    }
+  };
+
+  return (
+    <div className="p-4 lg:p-6 max-w-4xl mx-auto space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-[#0F2744]">Notificaciones</h1>
+          <p className="text-sm text-slate-500 mt-1">
+            {noLeidas > 0
+              ? `Tienes ${noLeidas} ${noLeidas === 1 ? 'notificación' : 'notificaciones'} sin leer`
+              : 'Estás al día — sin notificaciones pendientes'}
+          </p>
+        </div>
+        {noLeidas > 0 && (
+          <button
+            onClick={marcarTodas}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-[#16A34A] bg-emerald-50 hover:bg-emerald-100 rounded-lg transition-colors"
+          >
+            <CheckCheck className="w-4 h-4" />
+            Marcar todas como leídas
+          </button>
+        )}
+      </div>
+
+      {/* Filtros */}
+      <div role="tablist" className="inline-flex bg-slate-100 rounded-lg p-1 text-sm">
+        <FiltroTab
+          activo={filtro === 'todas'}
+          onClick={() => {
+            setPage(0);
+            setFiltro('todas');
+          }}
+          label="Todas"
+        />
+        <FiltroTab
+          activo={filtro === 'no-leidas'}
+          onClick={() => {
+            setPage(0);
+            setFiltro('no-leidas');
+          }}
+          label="No leídas"
+          badge={noLeidas > 0 ? String(noLeidas) : undefined}
+        />
+      </div>
+
+      {/* Lista */}
+      <Card className="border-slate-200">
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="p-12 text-center">
+              <Loader2 className="w-6 h-6 animate-spin text-[#16A34A] mx-auto" />
+            </div>
+          ) : items.length === 0 ? (
+            <div className="p-12 text-center">
+              <Bell className="w-12 h-12 text-slate-300 mx-auto mb-3" />
+              <p className="text-sm text-slate-500">
+                {filtro === 'no-leidas'
+                  ? 'No tienes notificaciones sin leer'
+                  : 'Aún no tienes notificaciones'}
+              </p>
+            </div>
+          ) : (
+            items.map((n) => (
+              <NotificacionRow key={n.id} notif={n} onMarcarLeida={() => marcarLeida(n.id)} />
+            ))
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Paginación */}
+      {totalPaginas > 1 && (
+        <div className="flex items-center justify-between">
+          <button
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            disabled={page === 0}
+            className="inline-flex items-center gap-1 px-3 py-2 text-sm text-slate-600 hover:text-slate-900 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <ChevronLeft className="w-4 h-4" /> Anterior
+          </button>
+          <span className="text-sm text-slate-500">
+            Página {page + 1} de {totalPaginas}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPaginas - 1, p + 1))}
+            disabled={page >= totalPaginas - 1}
+            className="inline-flex items-center gap-1 px-3 py-2 text-sm text-slate-600 hover:text-slate-900 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Siguiente <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FiltroTab({
+  activo,
+  onClick,
+  label,
+  badge,
+}: {
+  activo: boolean;
+  onClick: () => void;
+  label: string;
+  badge?: string;
+}) {
+  return (
+    <button
+      role="tab"
+      aria-selected={activo}
+      onClick={onClick}
+      className={`inline-flex items-center gap-2 px-4 py-1.5 rounded-md transition-colors ${
+        activo ? 'bg-white text-[#0F2744] shadow-sm font-medium' : 'text-slate-600 hover:text-slate-900'
+      }`}
+    >
+      {label}
+      {badge && (
+        <span className="bg-red-500 text-white text-[10px] font-bold rounded-full min-w-[1rem] h-4 px-1 flex items-center justify-center">
+          {badge}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function NotificacionRow({
+  notif,
+  onMarcarLeida,
+}: {
+  notif: NotificacionApi;
+  onMarcarLeida: () => void;
+}) {
+  const estilo = estiloPorPrioridad(notif.prioridad as string);
+  const dotColor = {
+    urgent: 'bg-red-500',
+    normal: 'bg-blue-500',
+    low: 'bg-slate-400',
+  }[estilo];
+
+  const wrapperClass = `block px-5 py-4 border-b border-slate-100 last:border-0 ${
+    notif.leida ? 'opacity-60' : 'bg-blue-50/30'
+  } hover:bg-slate-50 transition-colors`;
+
+  const contenido = (
+    <div className="flex items-start gap-3">
+      <span
+        className={`flex-shrink-0 w-2 h-2 mt-2 rounded-full ${
+          notif.leida ? 'bg-slate-300' : dotColor
+        }`}
+      />
+      <div className="flex-1 min-w-0">
+        <p
+          className={`text-sm ${notif.leida ? 'text-slate-700' : 'font-semibold text-[#0F2744]'}`}
+        >
+          {notif.titulo}
+        </p>
+        <p className="text-sm text-slate-600 mt-1">{notif.mensaje}</p>
+        <p className="text-xs text-slate-400 mt-2">
+          {formatearTiempoRelativo(notif.createdAt)}
+        </p>
+      </div>
+      {!notif.leida && (
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onMarcarLeida();
+          }}
+          aria-label="Marcar como leída"
+          title="Marcar como leída"
+          className="flex-shrink-0 text-slate-400 hover:text-emerald-600 transition-colors p-2"
+        >
+          <Check className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  );
+
+  if (notif.linkAccion) {
+    return (
+      <Link href={notif.linkAccion} className={wrapperClass}>
+        {contenido}
+      </Link>
+    );
+  }
+  return <div className={wrapperClass}>{contenido}</div>;
+}

--- a/frontend-web/src/app/api/notificaciones/[id]/leida/route.ts
+++ b/frontend-web/src/app/api/notificaciones/[id]/leida/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+/**
+ * BFF para PATCH /api/v1/notificaciones/{id}/leida (issue #214 PR-B).
+ *
+ * El backend valida ownership (anti-IDOR). Aquí solo proxy.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const accessToken = request.cookies.get('access_token')?.value;
+    if (!accessToken) {
+      return NextResponse.json({ message: 'No autenticado' }, { status: 401 });
+    }
+
+    const backendResponse = await fetch(
+      `${BACKEND_URL}/api/v1/notificaciones/${params.id}/leida`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      }
+    );
+
+    if (!backendResponse.ok) {
+      const errorData = await backendResponse.json().catch(() => ({}));
+      return NextResponse.json(
+        { message: errorData.message || 'Error al marcar como leída' },
+        { status: backendResponse.status }
+      );
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    console.error('Marcar leída error:', error);
+    return NextResponse.json({ message: 'Error interno' }, { status: 500 });
+  }
+}

--- a/frontend-web/src/app/api/notificaciones/count/route.ts
+++ b/frontend-web/src/app/api/notificaciones/count/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+/**
+ * BFF para /api/v1/notificaciones/count (issue #214 PR-B).
+ *
+ * Endpoint ligero para el badge del NotificationBell. El frontend hace
+ * polling cada 30s sobre esto — debe ser barato y rápido.
+ *
+ * No cacheable: el badge debe reflejar cambios casi-realtime.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const accessToken = request.cookies.get('access_token')?.value;
+    if (!accessToken) {
+      // Para el polling, devolvemos 0 sin auth en vez de 401 — evita ruido
+      // en consola del browser cuando expira la sesión. El Bell se ocultará
+      // de todas formas (no hay usuario en el store).
+      return NextResponse.json({ noLeidas: 0 }, { status: 200 });
+    }
+
+    const backendResponse = await fetch(
+      `${BACKEND_URL}/api/v1/notificaciones/count`,
+      {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      }
+    );
+
+    if (!backendResponse.ok) {
+      // Fallar abierto: devolver 0 en vez de error — el badge se oculta
+      // pero no rompe la UI.
+      return NextResponse.json({ noLeidas: 0 }, { status: 200 });
+    }
+
+    const data = await backendResponse.json();
+    return NextResponse.json(data, {
+      status: 200,
+      headers: { 'Cache-Control': 'no-store' },
+    });
+  } catch (error) {
+    console.error('Notificaciones count error:', error);
+    return NextResponse.json({ noLeidas: 0 }, { status: 200 });
+  }
+}

--- a/frontend-web/src/app/api/notificaciones/marcar-todas-leidas/route.ts
+++ b/frontend-web/src/app/api/notificaciones/marcar-todas-leidas/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+/**
+ * BFF para POST /api/v1/notificaciones/marcar-todas-leidas (issue #214 PR-B).
+ *
+ * Marca todas las notificaciones no-leídas del usuario actual.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const accessToken = request.cookies.get('access_token')?.value;
+    if (!accessToken) {
+      return NextResponse.json({ message: 'No autenticado' }, { status: 401 });
+    }
+
+    const backendResponse = await fetch(
+      `${BACKEND_URL}/api/v1/notificaciones/marcar-todas-leidas`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      }
+    );
+
+    if (!backendResponse.ok) {
+      const errorData = await backendResponse.json().catch(() => ({}));
+      return NextResponse.json(
+        { message: errorData.message || 'Error al marcar todas como leídas' },
+        { status: backendResponse.status }
+      );
+    }
+
+    const data = await backendResponse.json();
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    console.error('Marcar todas leídas error:', error);
+    return NextResponse.json({ message: 'Error interno' }, { status: 500 });
+  }
+}

--- a/frontend-web/src/app/api/notificaciones/route.ts
+++ b/frontend-web/src/app/api/notificaciones/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+/**
+ * BFF para /api/v1/notificaciones del backend (issue #214 PR-B).
+ *
+ * GET con query params:
+ *  - page (default 0)
+ *  - size (default 20)
+ *  - soloNoLeidas (default false) — para el dropdown del Bell
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const accessToken = request.cookies.get('access_token')?.value;
+    if (!accessToken) {
+      return NextResponse.json({ message: 'No autenticado' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const page = searchParams.get('page') || '0';
+    const size = searchParams.get('size') || '20';
+    const soloNoLeidas = searchParams.get('soloNoLeidas') || 'false';
+
+    const qs = new URLSearchParams({ page, size, soloNoLeidas });
+
+    const backendResponse = await fetch(
+      `${BACKEND_URL}/api/v1/notificaciones?${qs}`,
+      {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      }
+    );
+
+    if (!backendResponse.ok) {
+      const errorData = await backendResponse.json().catch(() => ({}));
+      return NextResponse.json(
+        { message: errorData.message || 'Error al obtener notificaciones' },
+        { status: backendResponse.status }
+      );
+    }
+
+    const data = await backendResponse.json();
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    console.error('Notificaciones GET error:', error);
+    return NextResponse.json({ message: 'Error interno' }, { status: 500 });
+  }
+}

--- a/frontend-web/src/components/layouts/socio/socio-shell.tsx
+++ b/frontend-web/src/components/layouts/socio/socio-shell.tsx
@@ -7,6 +7,7 @@ import { useAuthStore } from '@/stores/auth-store';
 import { ProtectedRoute } from '@/components/shared/protected-route';
 import { LogoutButton } from '@/components/shared/logout-button';
 import { IdleTimeoutWatcher } from '@/components/shared/idle-timeout-watcher';
+import { NotificationBell } from '@/components/shared/notification-bell';
 import {
   LayoutDashboard,
   Wallet,
@@ -17,7 +18,6 @@ import {
   Menu,
   X,
   ChevronRight,
-  Bell,
   Settings,
   LogOut,
   Shield,
@@ -224,15 +224,18 @@ export function SocioShell({ children }: { children: React.ReactNode }) {
                 </div>
               </div>
 
-              {/* Right: Profile */}
-              <div ref={profileRef} className="relative">
-                <button
-                  onClick={() => setProfileOpen(!profileOpen)}
-                  className="flex items-center gap-3 p-1.5 hover:bg-slate-100 rounded-xl transition-colors"
-                >
-                  <AvatarSocio name={user?.nombreCompleto || 'U'} size="sm" />
-                  <ChevronRight className={`w-4 h-4 text-slate-400 hidden sm:block transition-transform ${profileOpen ? 'rotate-90' : ''}`} />
-                </button>
+              {/* Right: Bell + Profile (issue #214 — Bell ya no es un dead import) */}
+              <div className="flex items-center gap-2">
+                <NotificationBell />
+
+                <div ref={profileRef} className="relative">
+                  <button
+                    onClick={() => setProfileOpen(!profileOpen)}
+                    className="flex items-center gap-3 p-1.5 hover:bg-slate-100 rounded-xl transition-colors"
+                  >
+                    <AvatarSocio name={user?.nombreCompleto || 'U'} size="sm" />
+                    <ChevronRight className={`w-4 h-4 text-slate-400 hidden sm:block transition-transform ${profileOpen ? 'rotate-90' : ''}`} />
+                  </button>
 
                 {profileOpen && (
                   <div className="absolute right-0 mt-2 w-64 bg-white rounded-2xl shadow-xl border border-slate-200 overflow-hidden">
@@ -262,6 +265,7 @@ export function SocioShell({ children }: { children: React.ReactNode }) {
                     </div>
                   </div>
                 )}
+                </div>
               </div>
             </div>
           </header>

--- a/frontend-web/src/components/shared/notification-bell.tsx
+++ b/frontend-web/src/components/shared/notification-bell.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+import Link from 'next/link';
+import { Bell, Check, CheckCheck } from 'lucide-react';
+import { useAuthStore } from '@/stores/auth-store';
+import {
+  parseNotificacionesResponse,
+  formatearBadgeCount,
+  estiloPorPrioridad,
+  formatearTiempoRelativo,
+  type NotificacionApi,
+} from '@/lib/utils/parse-notificaciones-response';
+
+/**
+ * Campana de notificaciones con badge + dropdown (issue #214 PR-B).
+ *
+ * <p>Polling cada 30s al endpoint ligero `/api/notificaciones/count` para
+ * el badge. El dropdown completo (lista de últimas 5) solo se carga al
+ * abrir, para no transferir datos innecesarios.</p>
+ *
+ * <p>Diseño "anti-mock": antes del PR-A había `<Bell />` importado pero
+ * nunca renderizado, y `mockNotifications` hardcoded en admin-shell.
+ * Este componente reemplaza ambos.</p>
+ */
+
+const POLLING_INTERVAL_MS = 30_000;
+const NOTIFICACIONES_EN_DROPDOWN = 5;
+
+export function NotificationBell() {
+  const user = useAuthStore((state) => state.user);
+  const [count, setCount] = useState(0);
+  const [open, setOpen] = useState(false);
+  const [notificaciones, setNotificaciones] = useState<NotificacionApi[]>([]);
+  const [loadingList, setLoadingList] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // === Polling del badge ===
+  const fetchCount = useCallback(async () => {
+    if (!user) return;
+    try {
+      const res = await fetch('/api/notificaciones/count', { cache: 'no-store' });
+      if (res.ok) {
+        const data = await res.json();
+        setCount(Number(data?.noLeidas) || 0);
+      }
+    } catch {
+      // Silent — el polling no debe ensuciar consola con errores transitorios
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (!user) return;
+    fetchCount();
+    const interval = setInterval(fetchCount, POLLING_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [user, fetchCount]);
+
+  // === Cargar lista al abrir el dropdown ===
+  const cargarLista = useCallback(async () => {
+    setLoadingList(true);
+    try {
+      const res = await fetch(
+        `/api/notificaciones?page=0&size=${NOTIFICACIONES_EN_DROPDOWN}`
+      );
+      if (res.ok) {
+        const data = parseNotificacionesResponse(await res.json());
+        setNotificaciones(data.notificaciones);
+        setCount(data.noLeidas);
+      }
+    } catch {
+      // Empty state se ve igual al de "sin notificaciones"
+    } finally {
+      setLoadingList(false);
+    }
+  }, []);
+
+  // Cerrar al click fuera
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const toggleDropdown = () => {
+    const willOpen = !open;
+    setOpen(willOpen);
+    if (willOpen) cargarLista();
+  };
+
+  // === Acciones ===
+  const marcarLeida = async (id: string) => {
+    try {
+      await fetch(`/api/notificaciones/${id}/leida`, { method: 'PATCH' });
+      // Optimistic update local
+      setNotificaciones((prev) =>
+        prev.map((n) => (n.id === id ? { ...n, leida: true } : n))
+      );
+      // Refrescar contador con el real
+      fetchCount();
+    } catch {
+      // Si falla, recargar para recuperar estado real
+      cargarLista();
+    }
+  };
+
+  const marcarTodas = async () => {
+    try {
+      await fetch('/api/notificaciones/marcar-todas-leidas', { method: 'POST' });
+      setNotificaciones((prev) => prev.map((n) => ({ ...n, leida: true })));
+      setCount(0);
+    } catch {
+      cargarLista();
+    }
+  };
+
+  if (!user) return null;
+
+  const badge = formatearBadgeCount(count);
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        onClick={toggleDropdown}
+        aria-label={
+          badge
+            ? `Notificaciones (${count} no leídas)`
+            : 'Notificaciones'
+        }
+        data-testid="notification-bell-trigger"
+        className="relative p-2 text-slate-600 hover:text-slate-900 hover:bg-slate-100 rounded-lg transition-colors"
+      >
+        <Bell className="w-5 h-5" />
+        {badge && (
+          <span
+            data-testid="notification-badge"
+            className="absolute -top-0.5 -right-0.5 min-w-[1.25rem] h-5 px-1 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center"
+          >
+            {badge}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          data-testid="notification-dropdown"
+          className="absolute right-0 mt-2 w-80 sm:w-96 bg-white rounded-2xl shadow-xl border border-slate-200 z-50 overflow-hidden"
+        >
+          <div className="flex items-center justify-between px-4 py-3 border-b border-slate-100">
+            <h3 className="text-sm font-semibold text-[#0F2744]">Notificaciones</h3>
+            {count > 0 && (
+              <button
+                onClick={marcarTodas}
+                className="text-xs text-[#16A34A] font-medium hover:underline flex items-center gap-1"
+              >
+                <CheckCheck className="w-3 h-3" />
+                Marcar todas
+              </button>
+            )}
+          </div>
+
+          <div className="max-h-96 overflow-y-auto">
+            {loadingList ? (
+              <div className="p-8 text-center text-sm text-slate-500">
+                Cargando...
+              </div>
+            ) : notificaciones.length === 0 ? (
+              <div className="p-8 text-center">
+                <Bell className="w-10 h-10 text-slate-300 mx-auto mb-2" />
+                <p className="text-sm text-slate-500">Sin notificaciones</p>
+              </div>
+            ) : (
+              notificaciones.map((n) => (
+                <NotificationItem
+                  key={n.id}
+                  notif={n}
+                  onMarcarLeida={() => marcarLeida(n.id)}
+                />
+              ))
+            )}
+          </div>
+
+          <div className="border-t border-slate-100 p-2">
+            <Link
+              href="/dashboard/notificaciones"
+              onClick={() => setOpen(false)}
+              className="block w-full text-center text-xs font-medium text-[#16A34A] hover:bg-slate-50 py-2 rounded-lg transition-colors"
+            >
+              Ver todas las notificaciones
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NotificationItem({
+  notif,
+  onMarcarLeida,
+}: {
+  notif: NotificacionApi;
+  onMarcarLeida: () => void;
+}) {
+  const estilo = estiloPorPrioridad(notif.prioridad as string);
+  const tiempo = formatearTiempoRelativo(notif.createdAt);
+
+  const dotColor = {
+    urgent: 'bg-red-500',
+    normal: 'bg-blue-500',
+    low: 'bg-slate-400',
+  }[estilo];
+
+  const wrapperClass = `block px-4 py-3 border-b border-slate-50 last:border-0 ${
+    notif.leida ? 'opacity-60' : 'bg-blue-50/40'
+  } hover:bg-slate-50 transition-colors`;
+
+  const contenido = (
+    <div className="flex items-start gap-3">
+      <span
+        className={`flex-shrink-0 w-2 h-2 mt-2 rounded-full ${
+          notif.leida ? 'bg-slate-300' : dotColor
+        }`}
+      />
+      <div className="flex-1 min-w-0">
+        <p
+          className={`text-sm ${
+            notif.leida ? 'text-slate-600' : 'font-semibold text-[#0F2744]'
+          } truncate`}
+        >
+          {notif.titulo}
+        </p>
+        <p className="text-xs text-slate-500 line-clamp-2 mt-0.5">
+          {notif.mensaje}
+        </p>
+        <p className="text-[11px] text-slate-400 mt-1">{tiempo}</p>
+      </div>
+      {!notif.leida && (
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onMarcarLeida();
+          }}
+          aria-label="Marcar como leída"
+          title="Marcar como leída"
+          className="flex-shrink-0 text-slate-400 hover:text-emerald-600 transition-colors p-1"
+        >
+          <Check className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  );
+
+  if (notif.linkAccion) {
+    return (
+      <Link href={notif.linkAccion} className={wrapperClass}>
+        {contenido}
+      </Link>
+    );
+  }
+  return <div className={wrapperClass}>{contenido}</div>;
+}

--- a/frontend-web/src/lib/utils/parse-notificaciones-response.test.ts
+++ b/frontend-web/src/lib/utils/parse-notificaciones-response.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseNotificacionesResponse,
+  formatearBadgeCount,
+  estiloPorPrioridad,
+  formatearTiempoRelativo,
+  type NotificacionApi,
+} from './parse-notificaciones-response';
+
+/**
+ * Tests para issue #214 PR-B: helpers de parsing y formato.
+ */
+describe('parse-notificaciones-response (issue #214 PR-B)', () => {
+  const notif: NotificacionApi = {
+    id: 'n1',
+    tipo: 'KYC_APROBADO',
+    titulo: 'Tu KYC fue aprobado',
+    mensaje: 'Felicidades.',
+    leida: false,
+    prioridad: 'NORMAL',
+    createdAt: '2026-05-17T10:00:00Z',
+  };
+
+  describe('parseNotificacionesResponse', () => {
+    it('Formato real del backend → extrae fields correctos', () => {
+      const respuesta = {
+        notificaciones: [notif],
+        pagina: 0,
+        tamanio: 20,
+        totalElementos: 1,
+        totalPaginas: 1,
+        noLeidas: 1,
+      };
+
+      const r = parseNotificacionesResponse(respuesta);
+      expect(r.notificaciones).toHaveLength(1);
+      expect(r.notificaciones[0].id).toBe('n1');
+      expect(r.noLeidas).toBe(1);
+    });
+
+    it('Wrap con campos faltantes → completa con defaults razonables', () => {
+      const r = parseNotificacionesResponse({ notificaciones: [notif] });
+      expect(r.notificaciones).toHaveLength(1);
+      expect(r.pagina).toBe(0);
+      expect(r.totalElementos).toBe(1);
+      expect(r.noLeidas).toBe(0);
+    });
+
+    it('Array directo (futuro-proof) → lo envuelve', () => {
+      const r = parseNotificacionesResponse([notif]);
+      expect(r.notificaciones).toHaveLength(1);
+      expect(r.totalElementos).toBe(1);
+    });
+
+    it('null/undefined/string → payload vacío (UI muestra empty state)', () => {
+      expect(parseNotificacionesResponse(null).notificaciones).toEqual([]);
+      expect(parseNotificacionesResponse(undefined).notificaciones).toEqual([]);
+      expect(parseNotificacionesResponse('error').notificaciones).toEqual([]);
+    });
+
+    it('Objeto con `notificaciones` no-array → vacío', () => {
+      const r = parseNotificacionesResponse({ notificaciones: 'broken' });
+      expect(r.notificaciones).toEqual([]);
+    });
+  });
+
+  describe('formatearBadgeCount', () => {
+    it('0 o negativo → null (no mostrar badge)', () => {
+      expect(formatearBadgeCount(0)).toBeNull();
+      expect(formatearBadgeCount(-5)).toBeNull();
+    });
+
+    it('1-99 → string del número', () => {
+      expect(formatearBadgeCount(1)).toBe('1');
+      expect(formatearBadgeCount(42)).toBe('42');
+      expect(formatearBadgeCount(99)).toBe('99');
+    });
+
+    it('Issue #214: 100+ → "99+" (visual compacto)', () => {
+      expect(formatearBadgeCount(100)).toBe('99+');
+      expect(formatearBadgeCount(9999)).toBe('99+');
+    });
+
+    it('NaN o Infinity → null (defensive)', () => {
+      expect(formatearBadgeCount(NaN)).toBeNull();
+      expect(formatearBadgeCount(Infinity)).toBeNull();
+    });
+  });
+
+  describe('estiloPorPrioridad', () => {
+    it('URGENTE → "urgent" (rojo)', () => {
+      expect(estiloPorPrioridad('URGENTE')).toBe('urgent');
+    });
+
+    it('NORMAL → "normal" (azul, default)', () => {
+      expect(estiloPorPrioridad('NORMAL')).toBe('normal');
+    });
+
+    it('BAJA → "low" (gris)', () => {
+      expect(estiloPorPrioridad('BAJA')).toBe('low');
+    });
+
+    it('Valor desconocido → "normal" (default seguro)', () => {
+      expect(estiloPorPrioridad('FUTURO_VALOR')).toBe('normal');
+    });
+  });
+
+  describe('formatearTiempoRelativo', () => {
+    const ahora = new Date('2026-05-17T12:00:00Z');
+
+    it('Hace menos de 1 minuto → "ahora mismo"', () => {
+      const hace30s = new Date('2026-05-17T11:59:30Z').toISOString();
+      expect(formatearTiempoRelativo(hace30s, ahora)).toBe('ahora mismo');
+    });
+
+    it('Hace 5 minutos → "hace 5 minutos"', () => {
+      const hace5m = new Date('2026-05-17T11:55:00Z').toISOString();
+      expect(formatearTiempoRelativo(hace5m, ahora)).toBe('hace 5 minutos');
+    });
+
+    it('Singular "1 minuto" (no "1 minutos")', () => {
+      const hace1m = new Date('2026-05-17T11:59:00Z').toISOString();
+      expect(formatearTiempoRelativo(hace1m, ahora)).toBe('hace 1 minuto');
+    });
+
+    it('Hace 3 horas → "hace 3 horas"', () => {
+      const hace3h = new Date('2026-05-17T09:00:00Z').toISOString();
+      expect(formatearTiempoRelativo(hace3h, ahora)).toBe('hace 3 horas');
+    });
+
+    it('Hace 3 días → "hace 3 días"', () => {
+      const hace3d = new Date('2026-05-14T12:00:00Z').toISOString();
+      expect(formatearTiempoRelativo(hace3d, ahora)).toBe('hace 3 días');
+    });
+
+    it('Más de 7 días → fecha localizada', () => {
+      const hace15d = new Date('2026-05-01T12:00:00Z').toISOString();
+      const r = formatearTiempoRelativo(hace15d, ahora);
+      expect(r).toMatch(/\d{2}/);  // contiene día
+    });
+
+    it('Inputs inválidos → string vacío (defensive)', () => {
+      expect(formatearTiempoRelativo('', ahora)).toBe('');
+      expect(formatearTiempoRelativo('no-iso', ahora)).toBe('');
+    });
+  });
+});

--- a/frontend-web/src/lib/utils/parse-notificaciones-response.ts
+++ b/frontend-web/src/lib/utils/parse-notificaciones-response.ts
@@ -1,0 +1,129 @@
+/**
+ * Parsea y formatea respuestas de notificaciones del backend (issue #214 PR-B).
+ *
+ * Wrap del backend: `{notificaciones, pagina, tamanio, totalElementos,
+ * totalPaginas, noLeidas}`.
+ *
+ * Defensive: acepta también array directo o formas inesperadas (lección de
+ * los parsers previos de cuentas/movimientos/beneficiarios).
+ */
+
+export type TipoNotificacion =
+  | 'KYC_APROBADO' | 'KYC_RECHAZADO' | 'KYC_REQUIERE_INFO'
+  | 'CREDITO_APROBADO' | 'CREDITO_RECHAZADO' | 'CREDITO_DESEMBOLSADO'
+  | 'CUOTA_PROXIMA_VENCER' | 'CUOTA_VENCIDA'
+  | 'DEPOSITO_RECIBIDO' | 'RETIRO_PROCESADO'
+  | 'NUEVO_DISPOSITIVO_LOGIN'
+  | 'ADMIN_NUEVA_SOLICITUD' | 'ADMIN_NUEVO_KYC'
+  | 'GENERAL';
+
+export type PrioridadNotificacion = 'URGENTE' | 'NORMAL' | 'BAJA';
+
+export interface NotificacionApi {
+  id: string;
+  tipo: TipoNotificacion | string;
+  titulo: string;
+  mensaje: string;
+  linkAccion?: string | null;
+  leida: boolean;
+  fechaLectura?: string | null;
+  prioridad: PrioridadNotificacion | string;
+  createdAt: string;
+}
+
+export interface NotificacionListPayload {
+  notificaciones: NotificacionApi[];
+  pagina: number;
+  tamanio: number;
+  totalElementos: number;
+  totalPaginas: number;
+  noLeidas: number;
+}
+
+const EMPTY: NotificacionListPayload = {
+  notificaciones: [],
+  pagina: 0,
+  tamanio: 0,
+  totalElementos: 0,
+  totalPaginas: 0,
+  noLeidas: 0,
+};
+
+/**
+ * Parsea el response JSON del backend en una estructura tipada.
+ * Cuando el formato no se reconoce, retorna el payload vacío para que la UI
+ * pueda renderizar empty state sin romper.
+ */
+export function parseNotificacionesResponse(data: unknown): NotificacionListPayload {
+  if (!data) return EMPTY;
+
+  // Caso normal: objeto del backend
+  if (typeof data === 'object' && 'notificaciones' in (data as object)) {
+    const d = data as Partial<NotificacionListPayload>;
+    const list = Array.isArray(d.notificaciones) ? d.notificaciones : [];
+    return {
+      notificaciones: list,
+      pagina: typeof d.pagina === 'number' ? d.pagina : 0,
+      tamanio: typeof d.tamanio === 'number' ? d.tamanio : list.length,
+      totalElementos:
+        typeof d.totalElementos === 'number' ? d.totalElementos : list.length,
+      totalPaginas: typeof d.totalPaginas === 'number' ? d.totalPaginas : 1,
+      noLeidas: typeof d.noLeidas === 'number' ? d.noLeidas : 0,
+    };
+  }
+
+  // Caso defensive: array directo (futuro-proof)
+  if (Array.isArray(data)) {
+    return { ...EMPTY, notificaciones: data as NotificacionApi[], totalElementos: data.length };
+  }
+
+  return EMPTY;
+}
+
+/**
+ * Formatea el contador del badge: si es 0 retorna `null` (no mostrar badge),
+ * si es > 99 retorna `'99+'` (apto para visual).
+ */
+export function formatearBadgeCount(noLeidas: number): string | null {
+  if (!Number.isFinite(noLeidas) || noLeidas <= 0) return null;
+  if (noLeidas > 99) return '99+';
+  return String(Math.floor(noLeidas));
+}
+
+/**
+ * Devuelve el tipo CSS de prioridad (warning/info/error) para colorear
+ * el item en la UI. Mismo patrón que `decidir-kyc-banner`.
+ */
+export function estiloPorPrioridad(
+  prioridad: string
+): 'urgent' | 'normal' | 'low' {
+  if (prioridad === 'URGENTE') return 'urgent';
+  if (prioridad === 'BAJA') return 'low';
+  return 'normal';
+}
+
+/**
+ * Formatea timestamp ISO a "hace X minutos / hace X horas / DD MMM".
+ * Localizado a es-VE.
+ */
+export function formatearTiempoRelativo(isoString: string, ahora: Date = new Date()): string {
+  if (!isoString) return '';
+  try {
+    const fecha = new Date(isoString);
+    if (Number.isNaN(fecha.getTime())) return '';
+
+    const diffMs = ahora.getTime() - fecha.getTime();
+    const diffMin = Math.floor(diffMs / 60_000);
+    const diffH = Math.floor(diffMs / 3_600_000);
+    const diffDays = Math.floor(diffMs / 86_400_000);
+
+    if (diffMin < 1) return 'ahora mismo';
+    if (diffMin < 60) return `hace ${diffMin} ${diffMin === 1 ? 'minuto' : 'minutos'}`;
+    if (diffH < 24) return `hace ${diffH} ${diffH === 1 ? 'hora' : 'horas'}`;
+    if (diffDays < 7) return `hace ${diffDays} ${diffDays === 1 ? 'día' : 'días'}`;
+
+    return fecha.toLocaleDateString('es-VE', { day: '2-digit', month: 'short' });
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
Closes #214 (último de los 3 PRs del sistema de notificaciones in-app)
Depends on: #241 (PR-A backend), #242 (PR-B frontend)

## Resumen

**PR-C de 3, cierra #214.** Las acciones de los analistas/admins ahora generan notificaciones reales para los socios. Combinado con PR-A y PR-B, el socio ve un badge rojo y un mensaje en el dropdown poco después de que el analista aprueba/rechaza su KYC o crédito.

## Disparadores integrados (6 eventos en 4 use cases)

| Evento del dominio | Tipo notificación | Prioridad | Mensaje incluye |
|---|---|---|---|
| Analista aprueba KYC | KYC_APROBADO | NORMAL | Felicitación + link |
| Analista rechaza KYC | KYC_RECHAZADO | **URGENTE** | **El motivo del rechazo** |
| Analista solicita info KYC | KYC_REQUIERE_INFO | NORMAL | Detalle requerido |
| Admin aprueba crédito | CREDITO_APROBADO | NORMAL | Monto + número solicitud |
| Admin rechaza crédito | CREDITO_RECHAZADO | NORMAL | Motivo + número |
| Admin desembolsa crédito | CREDITO_DESEMBOLSADO | NORMAL | Monto neto + número |

## Arquitectura: `NotificacionPublisher`

Fachada con métodos semánticos del dominio. Los use cases inyectan el publisher y llaman \`notificarSocioKycAprobado(socioId)\` sin preocuparse por:
- Resolución \`socioId → usuarioId\` (vía \`UsuarioRepository.buscarPorSocioId\`)
- Construcción del mensaje
- Elección de prioridad
- Manejo de errores

### Resiliencia crítica (3 capas de defensa)

1. **\`@Transactional(REQUIRES_NEW)\`**: la persistencia de la notificación va en una transacción separada. Si falla, NO hace rollback de la operación principal del caller (aprobar KYC sigue commit-eando).

2. **Atrapa Throwable**: cualquier excepción (BD caída, constraint violation, NullPointerException) queda atrapada con log error. Nunca propaga.

3. **Skip silencioso para datos inválidos**: \`socioId\` null o socio sin usuario asociado → log warn + return. No tira NPE ni IllegalArgumentException.

> **Por qué importa**: una falla de notificación NUNCA debe romper aprobar un KYC o desembolsar un crédito. Si el día de mañana la tabla \`notificacion\` se corrompe, el negocio sigue funcionando — solo el socio se queda sin avisos hasta que se arregle.

## Tests TDD (8 nuevos)

| Test | Tipo | Verifica |
|------|------|----------|
| KYC_APROBADO persiste con linkAccion + leida=false | happy | Estructura correcta |
| **KYC_RECHAZADO CON motivo → motivo en el mensaje** | **regression crítica** | El socio sabe qué corregir |
| CREDITO_APROBADO incluye monto + número | happy | Mensaje informativo |
| CREDITO_DESEMBOLSADO incluye monto | happy | Mensaje informativo |
| **Resiliencia: socio sin usuario → skip silencioso** | **edge** | No rompe caller |
| **Resiliencia: socioId null → skip silencioso** | **edge** | No rompe caller |
| **Resiliencia: repository lanza → publisher atrapa** | **edge crítico** | Caller del aprobar-KYC se completa |
| publicarAUsuario: ruta directa sin lookup | happy | Variante para admins |

Mockito strict mode pulido (sin stubs no-usados).

**Suite completa backend: 376/376** (\`mvn clean test\`), 368 previos + 8 nuevos. Cero regresión en KYC ni créditos (sus tests existentes siguen pasando).

## Test plan QA — flujo end-to-end

### 1. Como ADMIN, aprobar KYC de un socio
\`\`\`bash
# Login admin, ir a Admin > KYC pendientes, click "Aprobar" en uno
\`\`\`

### 2. Como SOCIO, login después
- Esperar ≤30s (polling del Bell).
- Badge rojo "1" debe aparecer.
- Click Bell → ver \"Tu verificación KYC fue aprobada\".
- Click → navega a /dashboard/kyc.

### 3. Como ADMIN, rechazar KYC con motivo \"Foto borrosa\"
- Socio recibe notificación con prioridad URGENTE.
- El mensaje contiene literalmente \"Motivo: Foto borrosa.\".

### 4. Como ADMIN, aprobar crédito
- Socio recibe notificación con monto + número de solicitud.

### 5. Verificación de resiliencia (manual)
- Drop temp de la tabla \`notificacion\`.
- Aprobar KYC → DEBE funcionar (KYC queda APROBADO).
- Logs muestran error de la notificación pero el flujo continúa.

## NO incluido en este PR (issues separados si se priorizan)

- **Job programado de cuotas próximas a vencer** (requiere scheduler + consulta del plan de amortización + lógica de fechas — scope grande)
- **Login desde nuevo dispositivo** (requiere device fingerprinting comparando user-agent + IP — complejo)
- **Depósito recibido** (RealizarDepositoUseCase — fácil, omitido por scope)
- **Notificaciones para admin** (NUEVA_SOLICITUD, NUEVO_KYC al equipo)
- **Limpiar \`mockNotifications\` del admin-shell** (sigue ahí, no se ve afectado porque el admin todavía no consume el endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)