### PR TITLE
feat(legal): páginas /terminos /lopdp /cookies (#205 PR-A)

### DIFF
--- a/frontend-web/src/app/(public)/cookies/page.tsx
+++ b/frontend-web/src/app/(public)/cookies/page.tsx
@@ -1,0 +1,173 @@
+import type { Metadata } from 'next';
+import { LegalPageShell } from '@/components/legal/legal-page-shell';
+
+export const metadata: Metadata = {
+  title: 'Política de Cookies | Fatrans',
+  description:
+    'Información sobre las cookies utilizadas en la plataforma Fatrans y cómo gestionarlas.',
+};
+
+/**
+ * Página /cookies (issue #205) — Política de Cookies.
+ *
+ * Incluye una tabla con las cookies efectivamente utilizadas (sesión,
+ * preferencias, anti-CSRF). Si en el futuro se incorporan cookies de
+ * analítica o marketing, esta tabla debe actualizarse y el banner de
+ * consentimiento granular debe permitir activarlas/desactivarlas
+ * (alcance del issue #218 — banner de cookies).
+ */
+export default function CookiesPage() {
+  return (
+    <LegalPageShell
+      titulo="Política de Cookies"
+      subtitulo="Qué cookies usamos en la plataforma Fatrans y cómo puedes gestionarlas"
+      version="1.0-borrador"
+      ultimaActualizacion="17 de mayo de 2026"
+      borrador
+    >
+      <h2>1. ¿Qué es una cookie?</h2>
+      <p>
+        Una cookie es un pequeño archivo de texto que un sitio web guarda
+        en su navegador para recordar información sobre su visita: idioma
+        preferido, sesión iniciada, configuración, etc. Las cookies son
+        útiles para que la plataforma funcione correctamente y para mejorar
+        su experiencia.
+      </p>
+
+      <h2>2. Tipos de cookies según su finalidad</h2>
+      <ul>
+        <li>
+          <strong>Estrictamente necesarias:</strong> imprescindibles para
+          que la plataforma funcione (sesión, seguridad). No requieren
+          consentimiento del usuario.
+        </li>
+        <li>
+          <strong>Preferencias:</strong> recuerdan opciones como idioma o
+          tema visual.
+        </li>
+        <li>
+          <strong>Analíticas:</strong> miden uso de la plataforma de forma
+          anónima y agregada (no usadas actualmente).
+        </li>
+        <li>
+          <strong>Marketing:</strong> usadas para personalizar publicidad
+          (no usadas actualmente).
+        </li>
+      </ul>
+
+      <h2>3. Cookies utilizadas por Fatrans</h2>
+      <p>
+        Esta es la lista completa de cookies activas en la plataforma a la
+        fecha de esta política:
+      </p>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm border-collapse my-4">
+          <thead>
+            <tr className="bg-slate-100 text-[#0F2744]">
+              <th className="border border-slate-200 px-3 py-2 text-left font-semibold">Cookie</th>
+              <th className="border border-slate-200 px-3 py-2 text-left font-semibold">Tipo</th>
+              <th className="border border-slate-200 px-3 py-2 text-left font-semibold">Finalidad</th>
+              <th className="border border-slate-200 px-3 py-2 text-left font-semibold">Duración</th>
+            </tr>
+          </thead>
+          <tbody className="text-slate-700">
+            <tr>
+              <td className="border border-slate-200 px-3 py-2 font-mono text-xs">access_token</td>
+              <td className="border border-slate-200 px-3 py-2">Necesaria</td>
+              <td className="border border-slate-200 px-3 py-2">
+                Mantener la sesión autenticada del usuario (HttpOnly, Secure).
+              </td>
+              <td className="border border-slate-200 px-3 py-2">Sesión</td>
+            </tr>
+            <tr className="bg-slate-50">
+              <td className="border border-slate-200 px-3 py-2 font-mono text-xs">refresh_token</td>
+              <td className="border border-slate-200 px-3 py-2">Necesaria</td>
+              <td className="border border-slate-200 px-3 py-2">
+                Renovar el token de acceso sin pedir credenciales nuevamente (HttpOnly, Secure).
+              </td>
+              <td className="border border-slate-200 px-3 py-2">7 días</td>
+            </tr>
+            <tr>
+              <td className="border border-slate-200 px-3 py-2 font-mono text-xs">XSRF-TOKEN</td>
+              <td className="border border-slate-200 px-3 py-2">Necesaria</td>
+              <td className="border border-slate-200 px-3 py-2">
+                Protección contra ataques CSRF en operaciones que modifican
+                datos.
+              </td>
+              <td className="border border-slate-200 px-3 py-2">Sesión</td>
+            </tr>
+            <tr className="bg-slate-50">
+              <td className="border border-slate-200 px-3 py-2 font-mono text-xs">theme</td>
+              <td className="border border-slate-200 px-3 py-2">Preferencias</td>
+              <td className="border border-slate-200 px-3 py-2">
+                Recordar el tema visual elegido por el usuario.
+              </td>
+              <td className="border border-slate-200 px-3 py-2">1 año</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-sm text-slate-500">
+        Fatrans <strong>no utiliza</strong> actualmente cookies de
+        analítica, marketing ni de terceros (Google Analytics, Meta Pixel,
+        etc.). Si en el futuro se incorporan, esta política será actualizada
+        y se solicitará consentimiento expreso mediante el banner de
+        cookies.
+      </p>
+
+      <h2>4. Gestión de cookies</h2>
+      <p>
+        Puede aceptar o rechazar las cookies no esenciales desde el banner
+        que aparece en su primera visita. También puede gestionarlas
+        directamente desde su navegador:
+      </p>
+      <ul>
+        <li>
+          <strong>Chrome:</strong> Configuración → Privacidad y seguridad →
+          Cookies y otros datos de sitios.
+        </li>
+        <li>
+          <strong>Firefox:</strong> Opciones → Privacidad &amp; Seguridad →
+          Cookies y datos del sitio.
+        </li>
+        <li>
+          <strong>Safari:</strong> Preferencias → Privacidad → Gestionar
+          datos de sitios web.
+        </li>
+        <li>
+          <strong>Edge:</strong> Configuración → Cookies y permisos del
+          sitio.
+        </li>
+      </ul>
+      <p>
+        Tenga en cuenta que <strong>desactivar las cookies estrictamente
+        necesarias impedirá el uso de la plataforma</strong> (no podrá
+        iniciar sesión).
+      </p>
+
+      <h2>5. Cookies de terceros</h2>
+      <p>
+        Actualmente Fatrans no carga cookies de terceros. Cualquier cambio
+        en este sentido será comunicado y publicado en esta misma política.
+      </p>
+
+      <h2>6. Cambios a esta política</h2>
+      <p>
+        Esta política puede actualizarse cuando agreguemos o retiremos
+        cookies. La fecha de "Última actualización" en la parte superior de
+        esta página refleja la versión vigente.
+      </p>
+
+      <h2>7. Contacto</h2>
+      <p>
+        Para cualquier consulta sobre el uso de cookies, escriba a{' '}
+        <a href="mailto:dpo@fatrans.com.ve" className="text-[#16A34A] hover:underline">
+          dpo@fatrans.com.ve
+        </a>
+        .
+      </p>
+    </LegalPageShell>
+  );
+}

--- a/frontend-web/src/app/(public)/lopdp/page.tsx
+++ b/frontend-web/src/app/(public)/lopdp/page.tsx
@@ -1,0 +1,218 @@
+import type { Metadata } from 'next';
+import { LegalPageShell } from '@/components/legal/legal-page-shell';
+
+export const metadata: Metadata = {
+  title: 'Política de Protección de Datos | Fatrans',
+  description:
+    'Política de tratamiento de datos personales conforme a la LOPDP venezolana y mejores prácticas internacionales.',
+};
+
+/**
+ * Página /lopdp (issue #205) — Política de Protección de Datos Personales.
+ *
+ * Cubre los puntos mínimos del issue: qué datos se recopilan, finalidad,
+ * con quién se comparten, derechos ARCO, contacto del DPO.
+ *
+ * El contenido es plantilla y requiere revisión legal — ver banner.
+ */
+export default function LopdpPage() {
+  return (
+    <LegalPageShell
+      titulo="Política de Protección de Datos Personales"
+      subtitulo="Tratamiento de datos conforme a la Ley Orgánica de Protección de Datos Personales (LOPDP) de Venezuela"
+      version="1.0-borrador"
+      ultimaActualizacion="17 de mayo de 2026"
+      borrador
+    >
+      <h2>1. Responsable del tratamiento</h2>
+      <p>
+        Fatrans es el responsable del tratamiento de los datos personales
+        recolectados a través de la plataforma. Para cualquier consulta,
+        rectificación o solicitud relativa a sus datos personales, el
+        titular puede contactar al Delegado de Protección de Datos (DPO) en{' '}
+        <a href="mailto:dpo@fatrans.com.ve" className="text-[#16A34A] hover:underline">
+          dpo@fatrans.com.ve
+        </a>
+        .
+      </p>
+
+      <h2>2. Datos que recopilamos</h2>
+      <h3>2.1 Datos de identificación</h3>
+      <ul>
+        <li>Nombres y apellidos completos.</li>
+        <li>Cédula de identidad o RIF, según corresponda.</li>
+        <li>Fecha de nacimiento, nacionalidad y estado civil.</li>
+        <li>Fotografía y captura biométrica facial (proceso KYC).</li>
+      </ul>
+
+      <h3>2.2 Datos de contacto</h3>
+      <ul>
+        <li>Correo electrónico, teléfono móvil y fijo.</li>
+        <li>Dirección de residencia y dirección laboral.</li>
+      </ul>
+
+      <h3>2.3 Datos financieros y laborales</h3>
+      <ul>
+        <li>Ingresos declarados, fuente de ingresos, ocupación.</li>
+        <li>
+          Información de la unidad de transporte (placa, modelo, ruta) si
+          aplica.
+        </li>
+        <li>Historial de operaciones realizadas en la plataforma.</li>
+      </ul>
+
+      <h3>2.4 Datos técnicos</h3>
+      <ul>
+        <li>Dirección IP, identificador de dispositivo, sistema operativo.</li>
+        <li>Registros de actividad (logs) y sesiones de uso.</li>
+        <li>Cookies — ver <a href="/cookies" className="text-[#16A34A] hover:underline">Política de Cookies</a>.</li>
+      </ul>
+
+      <h2>3. Finalidad del tratamiento</h2>
+      <p>
+        Sus datos personales serán tratados únicamente para las siguientes
+        finalidades:
+      </p>
+      <ul>
+        <li>
+          <strong>Identificación y prevención de fraude:</strong> verificar
+          la identidad del Socio (KYC) y prevenir operaciones ilícitas
+          conforme a la normativa anti-lavado (LOCDOFT).
+        </li>
+        <li>
+          <strong>Prestación del servicio:</strong> ejecutar las
+          operaciones solicitadas (ahorro, crédito, depósitos, retiros).
+        </li>
+        <li>
+          <strong>Cumplimiento normativo:</strong> reportar a SUDEBAN,
+          SUNACRIP, SENIAT y demás autoridades cuando sea legalmente
+          requerido.
+        </li>
+        <li>
+          <strong>Mejora del servicio:</strong> análisis estadístico
+          agregado y anonimizado para mejorar la plataforma.
+        </li>
+        <li>
+          <strong>Comunicaciones operativas:</strong> envío de
+          notificaciones transaccionales, estados de cuenta y avisos
+          legales.
+        </li>
+      </ul>
+
+      <h2>4. Base legal</h2>
+      <p>El tratamiento se ampara en:</p>
+      <ul>
+        <li>El consentimiento expreso otorgado al aceptar esta política.</li>
+        <li>La ejecución del contrato (T&amp;C).</li>
+        <li>
+          El cumplimiento de obligaciones legales aplicables al sector
+          financiero venezolano.
+        </li>
+      </ul>
+
+      <h2>5. ¿Con quién compartimos sus datos?</h2>
+      <p>
+        Sus datos personales no son vendidos ni cedidos a terceros para
+        fines comerciales. Solo se comparten con:
+      </p>
+      <ul>
+        <li>
+          <strong>Autoridades competentes:</strong> SUDEBAN, SUNACRIP,
+          SENIAT, UNIF, tribunales o cualquier ente público que lo requiera
+          por mandato legal.
+        </li>
+        <li>
+          <strong>Proveedores tecnológicos contratados:</strong>{' '}
+          procesadores de pago, proveedores de hosting, servicios de envío
+          de correo y SMS. Todos están vinculados por contratos de
+          confidencialidad y tratamiento de datos.
+        </li>
+        <li>
+          <strong>Centrales de riesgo:</strong> únicamente la información
+          mínima necesaria para reportar mora o consultar comportamiento
+          crediticio, previa autorización del titular.
+        </li>
+      </ul>
+
+      <h2>6. Conservación</h2>
+      <p>
+        Conservamos sus datos durante el tiempo que mantenga la relación
+        comercial con Fatrans y, posteriormente, por el plazo de diez (10)
+        años exigido por la normativa financiera venezolana para fines de
+        auditoría, fiscalización y prevención de lavado de activos.
+        Transcurrido ese plazo, los datos serán bloqueados y, finalmente,
+        eliminados.
+      </p>
+
+      <h2>7. Derechos del titular (ARCO + portabilidad)</h2>
+      <p>
+        Como titular de los datos, usted tiene derecho a:
+      </p>
+      <ul>
+        <li>
+          <strong>Acceso:</strong> conocer qué datos suyos tratamos y con
+          qué finalidad.
+        </li>
+        <li>
+          <strong>Rectificación:</strong> corregir datos inexactos o
+          incompletos.
+        </li>
+        <li>
+          <strong>Cancelación / supresión:</strong> solicitar que se
+          eliminen sus datos, sujeto a los plazos legales de conservación.
+        </li>
+        <li>
+          <strong>Oposición:</strong> oponerse al tratamiento para fines
+          distintos a los esenciales del servicio.
+        </li>
+        <li>
+          <strong>Portabilidad:</strong> recibir sus datos en un formato
+          estructurado y legible por máquina.
+        </li>
+      </ul>
+      <p>
+        Para ejercer estos derechos, envíe una solicitud a{' '}
+        <a href="mailto:dpo@fatrans.com.ve" className="text-[#16A34A] hover:underline">
+          dpo@fatrans.com.ve
+        </a>{' '}
+        adjuntando copia de su documento de identidad. Responderemos en un
+        plazo máximo de quince (15) días hábiles.
+      </p>
+
+      <h2>8. Medidas de seguridad</h2>
+      <p>
+        Aplicamos medidas técnicas y organizativas razonables para proteger
+        sus datos: cifrado en tránsito (TLS 1.3), cifrado de credenciales
+        en reposo (BCrypt), control de acceso por roles, registros de
+        auditoría, y monitoreo de eventos sospechosos. En caso de incidente
+        de seguridad que afecte sus datos, le notificaremos en los plazos
+        legalmente exigidos.
+      </p>
+
+      <h2>9. Transferencias internacionales</h2>
+      <p>
+        Sus datos se almacenan en infraestructura ubicada principalmente en
+        Venezuela. Si en el futuro fuera necesario transferirlos al
+        exterior, se realizará únicamente con países que ofrezcan un nivel
+        adecuado de protección y siempre bajo cláusulas contractuales que
+        garanticen sus derechos.
+      </p>
+
+      <h2>10. Cambios a esta política</h2>
+      <p>
+        Cualquier modificación a esta política será notificada al titular
+        por los medios registrados y, si conlleva cambios sustanciales en
+        las finalidades del tratamiento, requerirá nuevo consentimiento
+        expreso.
+      </p>
+
+      <h2>11. Contacto del DPO</h2>
+      <p>
+        Delegado de Protección de Datos —{' '}
+        <a href="mailto:dpo@fatrans.com.ve" className="text-[#16A34A] hover:underline">
+          dpo@fatrans.com.ve
+        </a>
+      </p>
+    </LegalPageShell>
+  );
+}

--- a/frontend-web/src/app/(public)/page.tsx
+++ b/frontend-web/src/app/(public)/page.tsx
@@ -476,9 +476,9 @@ function Footer() {
           <div>
             <h4 className="font-semibold mb-4">Legal</h4>
             <ul className="space-y-2 text-sm text-slate-400">
-              <li><a href="#" className="hover:text-white transition">Términos de Servicio</a></li>
-              <li><a href="#" className="hover:text-white transition">Política de Privacidad</a></li>
-              <li><a href="#" className="hover:text-white transition">Cumplimiento LOPDP</a></li>
+              <li><a href="/terminos" className="hover:text-white transition">Términos de Servicio</a></li>
+              <li><a href="/lopdp" className="hover:text-white transition">Política de Privacidad (LOPDP)</a></li>
+              <li><a href="/cookies" className="hover:text-white transition">Política de Cookies</a></li>
             </ul>
           </div>
 

--- a/frontend-web/src/app/(public)/terminos/page.tsx
+++ b/frontend-web/src/app/(public)/terminos/page.tsx
@@ -1,0 +1,176 @@
+import type { Metadata } from 'next';
+import { LegalPageShell } from '@/components/legal/legal-page-shell';
+
+export const metadata: Metadata = {
+  title: 'Términos y Condiciones | Fatrans',
+  description:
+    'Términos y condiciones de uso de la plataforma Fatrans — fondo de ahorro para el sector transporte venezolano.',
+};
+
+/**
+ * Página /terminos (issue #205).
+ *
+ * El contenido es una PLANTILLA estructurada que cubre los puntos mínimos
+ * exigidos por el issue (objeto, obligaciones, comisiones, mora,
+ * jurisdicción, contacto). Debe ser revisado por un abogado antes de pasar
+ * a producción — ver banner `borrador` en el shell.
+ */
+export default function TerminosPage() {
+  return (
+    <LegalPageShell
+      titulo="Términos y Condiciones de Uso"
+      subtitulo="Plataforma Fatrans — Fondo de Ahorro para el Sector Transporte"
+      version="1.0-borrador"
+      ultimaActualizacion="17 de mayo de 2026"
+      borrador
+    >
+      <h2>1. Aceptación de los términos</h2>
+      <p>
+        Al registrarse en la plataforma Fatrans (en adelante, "la
+        Plataforma") y aceptar los presentes Términos y Condiciones (en
+        adelante, "T&amp;C"), el usuario (en adelante, "el Socio")
+        manifiesta haberlos leído, entendido y aceptado en su totalidad,
+        comprometiéndose a cumplirlos. Si el Socio no está de acuerdo con
+        alguna de las disposiciones, deberá abstenerse de usar la
+        Plataforma.
+      </p>
+      <p>
+        Estos T&amp;C constituyen un contrato entre el Socio y Fatrans
+        regido por la legislación de la República Bolivariana de Venezuela.
+      </p>
+
+      <h2>2. Objeto del contrato</h2>
+      <p>
+        Fatrans es una plataforma digital que ofrece a personas vinculadas
+        al sector transporte (conductores, propietarios, mecánicos y
+        empresas de transporte) los siguientes servicios:
+      </p>
+      <ul>
+        <li>Apertura y administración de cuentas de ahorro en VES y USD.</li>
+        <li>Acceso a productos crediticios sujetos a evaluación.</li>
+        <li>
+          Operaciones de depósito, retiro y transferencia entre cuentas
+          autorizadas.
+        </li>
+        <li>Servicios de gestión administrativa de la unidad de transporte.</li>
+      </ul>
+
+      <h2>3. Requisitos para ser Socio</h2>
+      <ul>
+        <li>Ser persona natural mayor de edad o persona jurídica legalmente constituida.</li>
+        <li>
+          Poseer documento de identidad válido (cédula venezolana o RIF) y
+          completar el proceso de verificación de identidad (KYC).
+        </li>
+        <li>
+          Aceptar expresamente estos T&amp;C, la Política de Protección de
+          Datos y la Política de Cookies.
+        </li>
+        <li>
+          Acreditar vinculación con el sector transporte según los criterios
+          publicados por Fatrans.
+        </li>
+      </ul>
+
+      <h2>4. Obligaciones del Socio</h2>
+      <ul>
+        <li>
+          Suministrar información veraz, completa y actualizada en el
+          registro y durante toda la relación.
+        </li>
+        <li>
+          Custodiar sus credenciales de acceso (usuario, contraseña, OTP) y
+          notificar de inmediato cualquier uso no autorizado.
+        </li>
+        <li>
+          Usar la Plataforma exclusivamente para fines lícitos y no realizar
+          operaciones que constituyan o faciliten lavado de activos,
+          financiamiento al terrorismo, fraude o cualquier delito tipificado
+          en la legislación venezolana.
+        </li>
+        <li>Mantener actualizados sus datos personales y de contacto.</li>
+        <li>
+          Pagar puntualmente las cuotas de los créditos otorgados según el
+          plan de amortización suscrito.
+        </li>
+      </ul>
+
+      <h2>5. Comisiones y cargos</h2>
+      <p>
+        Las comisiones aplicables a cada operación (apertura, mantenimiento,
+        transferencias, desembolsos, prepagos, mora, etc.) se publican en el
+        tarifario vigente, disponible dentro de la Plataforma y actualizado
+        periódicamente. Fatrans notificará a los Socios cualquier
+        modificación con al menos quince (15) días de anticipación a su
+        entrada en vigor.
+      </p>
+
+      <h2>6. Política de mora</h2>
+      <p>
+        El incumplimiento en el pago de cualquier cuota de un crédito
+        generará intereses de mora calculados conforme a la tasa máxima
+        permitida por el Banco Central de Venezuela vigente al momento del
+        atraso. Adicionalmente, Fatrans podrá:
+      </p>
+      <ul>
+        <li>Reportar la mora a las centrales de riesgo competentes.</li>
+        <li>Suspender el acceso del Socio a nuevos productos crediticios.</li>
+        <li>
+          Iniciar las acciones de cobranza extrajudicial o judicial que
+          correspondan.
+        </li>
+      </ul>
+
+      <h2>7. Limitación de responsabilidad</h2>
+      <p>
+        Fatrans empleará razonables esfuerzos para mantener la Plataforma
+        operativa y segura. No obstante, no se hará responsable por daños
+        derivados de:
+      </p>
+      <ul>
+        <li>Fallas de conectividad o energía ajenas a su control.</li>
+        <li>
+          Uso indebido de las credenciales del Socio por terceros cuando se
+          deba a negligencia del propio Socio.
+        </li>
+        <li>Eventos de fuerza mayor o caso fortuito.</li>
+      </ul>
+
+      <h2>8. Modificaciones</h2>
+      <p>
+        Fatrans podrá modificar estos T&amp;C en cualquier momento. Las
+        modificaciones serán comunicadas al Socio por los medios
+        registrados (correo, notificación in-app) y, si conllevan cambios
+        sustanciales, requerirán re-aceptación expresa al siguiente inicio
+        de sesión.
+      </p>
+
+      <h2>9. Terminación</h2>
+      <p>
+        El Socio podrá solicitar la terminación de la relación en cualquier
+        momento, siempre que haya cumplido con todas sus obligaciones
+        pendientes. Fatrans podrá suspender o cancelar la cuenta del Socio
+        en caso de incumplimiento grave, fraude o cuando sea requerido por
+        autoridad competente.
+      </p>
+
+      <h2>10. Resolución de disputas y jurisdicción</h2>
+      <p>
+        Las partes intentarán resolver cualquier controversia derivada de
+        estos T&amp;C de buena fe. Si no fuera posible, las partes se
+        someten a la jurisdicción de los tribunales competentes de la
+        República Bolivariana de Venezuela.
+      </p>
+
+      <h2>11. Contacto</h2>
+      <p>
+        Para cualquier consulta sobre estos T&amp;C, el Socio puede
+        escribir a{' '}
+        <a href="mailto:soporte@fatrans.com.ve" className="text-[#16A34A] hover:underline">
+          soporte@fatrans.com.ve
+        </a>
+        .
+      </p>
+    </LegalPageShell>
+  );
+}

--- a/frontend-web/src/components/legal/legal-page-shell.tsx
+++ b/frontend-web/src/components/legal/legal-page-shell.tsx
@@ -1,0 +1,121 @@
+import Link from 'next/link';
+import { ChevronLeft, AlertTriangle } from 'lucide-react';
+
+/**
+ * Shell común para páginas legales (T&C, LOPDP, cookies) — issue #205.
+ *
+ * Estructura: header con logo + back a Home, banner de borrador (visible
+ * mientras el contenido no haya pasado revisión legal externa), main con
+ * el contenido pasado como children, footer minimal con fecha y versión.
+ *
+ * NOTA: el banner `borrador` debe permanecer hasta que un abogado valide
+ * el texto. Cuando se reemplace el contenido por la versión definitiva,
+ * eliminar la prop `borrador` (o ponerla en false) y subir la versión.
+ */
+export interface LegalPageShellProps {
+  /** Título visible en el header (ej. "Términos y Condiciones"). */
+  titulo: string;
+  /** Subtítulo opcional bajo el título. */
+  subtitulo?: string;
+  /** Versión del documento (se muestra en el footer). */
+  version: string;
+  /** Fecha de última actualización, formato ISO o legible. */
+  ultimaActualizacion: string;
+  /**
+   * Si `true`, muestra el banner amarillo "BORRADOR — REQUIERE REVISIÓN LEGAL".
+   * Mantenerlo en `true` hasta que un abogado valide y firme el contenido.
+   */
+  borrador?: boolean;
+  children: React.ReactNode;
+}
+
+export function LegalPageShell({
+  titulo,
+  subtitulo,
+  version,
+  ultimaActualizacion,
+  borrador = true,
+  children,
+}: LegalPageShellProps) {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      {/* Header */}
+      <header className="bg-white border-b border-slate-200">
+        <div className="max-w-4xl mx-auto px-6 py-4 flex items-center justify-between">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 text-sm text-slate-600 hover:text-[#0F2744] transition-colors"
+          >
+            <ChevronLeft className="w-4 h-4" />
+            Volver al inicio
+          </Link>
+          <span className="text-sm font-semibold text-[#0F2744]">Fatrans</span>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-6 py-10">
+        {/* Banner de borrador — visible hasta validación legal */}
+        {borrador && (
+          <div
+            role="alert"
+            className="mb-8 flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 p-4"
+          >
+            <AlertTriangle className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
+            <div className="text-sm text-amber-900">
+              <p className="font-semibold">Documento en revisión legal</p>
+              <p className="mt-1 leading-relaxed">
+                Este texto es un borrador estructurado para fines de
+                desarrollo y QA. Debe ser revisado, ajustado y firmado por
+                un abogado especialista en derecho financiero y de
+                protección de datos venezolano antes de pasar a producción.
+                Hasta entonces, su aceptación no constituye un contrato
+                jurídicamente vinculante en su forma final.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Título */}
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-[#0F2744]">{titulo}</h1>
+          {subtitulo && (
+            <p className="text-base text-slate-600 mt-2">{subtitulo}</p>
+          )}
+          <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-500">
+            <span>Versión {version}</span>
+            <span aria-hidden="true">·</span>
+            <span>Última actualización: {ultimaActualizacion}</span>
+          </div>
+        </div>
+
+        {/* Contenido: estilos via selectores arbitrarios para evitar añadir
+            la dependencia @tailwindcss/typography por 3 páginas. */}
+        <article
+          className={[
+            'max-w-none text-slate-700',
+            '[&_h2]:text-xl [&_h2]:font-semibold [&_h2]:text-[#0F2744] [&_h2]:mt-8 [&_h2]:mb-3',
+            '[&_h3]:text-base [&_h3]:font-semibold [&_h3]:text-[#0F2744] [&_h3]:mt-5 [&_h3]:mb-2',
+            '[&_p]:leading-relaxed [&_p]:my-3',
+            '[&_ul]:list-disc [&_ul]:pl-6 [&_ul]:my-3 [&_ul]:space-y-1',
+            '[&_li]:leading-relaxed',
+            '[&_strong]:text-[#0F2744] [&_strong]:font-semibold',
+          ].join(' ')}
+        >
+          {children}
+        </article>
+      </main>
+
+      {/* Footer minimal */}
+      <footer className="mt-16 border-t border-slate-200 bg-white">
+        <div className="max-w-4xl mx-auto px-6 py-6 text-xs text-slate-500 flex flex-wrap items-center justify-between gap-3">
+          <span>© {new Date().getFullYear()} Fatrans · Documento {version}</span>
+          <div className="flex gap-4">
+            <Link href="/terminos" className="hover:text-[#0F2744]">Términos</Link>
+            <Link href="/lopdp" className="hover:text-[#0F2744]">LOPDP</Link>
+            <Link href="/cookies" className="hover:text-[#0F2744]">Cookies</Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes parte de #205 (PR-A — solo las 3 páginas estáticas). Ver "Próximos pasos" para PR-B y PR-C.

## Problema

`registration-form.tsx:679-725` tiene checkboxes que enlazaban a `/terminos` y `/lopdp`, y el footer del landing (`(public)/page.tsx:478-491`) tenía 3 `href="#"` para Términos / Privacidad / LOPDP. **Ninguna de esas páginas existía** — el usuario aceptaba documentos inexistentes (T&C jurídicamente nula, posible incumplimiento de LOPDP).

## Cambios de este PR (PR-A — 3 páginas estáticas)

### Nuevos archivos
- `frontend-web/src/components/legal/legal-page-shell.tsx` — Shell reutilizable: header con back a Home, banner amarillo "BORRADOR — REQUIERE REVISIÓN LEGAL" mientras el texto no esté validado por abogado, footer con cross-links entre las 3 páginas.
- `frontend-web/src/app/(public)/terminos/page.tsx` — 11 secciones (objeto, requisitos, obligaciones, comisiones, mora, limitación de responsabilidad, terminación, jurisdicción Venezuela, contacto).
- `frontend-web/src/app/(public)/lopdp/page.tsx` — 11 secciones LOPDP (categorías de datos recopilados, finalidad, base legal, con quién compartimos, conservación 10 años, derechos ARCO + portabilidad, DPO).
- `frontend-web/src/app/(public)/cookies/page.tsx` — Tabla con las 4 cookies reales (`access_token`, `refresh_token`, `XSRF-TOKEN`, `theme`) y nota explícita de que no hay analítica ni marketing.

### Modificados
- `frontend-web/src/app/(public)/page.tsx` — Footer del landing: los 3 `href=\"#\"` ahora apuntan a las rutas reales.

### Sin tocar
- `registration-form.tsx` ya enlazaba a `/terminos` y `/lopdp` (líneas 693, 717), solo que las rutas no existían — ahora sí.

## Decisiones técnicas

- **No instalamos `@tailwindcss/typography`** por 3 páginas. Usamos selectores arbitrarios `[&_h2]:...` en el shell — mismo resultado, sin dependencia nueva.
- **Páginas estáticas** (`○` en el build, 181 B cada una) — sin overhead de SSR.
- **Banner de borrador prominente y persistente** — debe permanecer hasta que un abogado venezolano valide el contenido (objetivo: removerlo con un PR pequeño cuando llegue el visto bueno legal).

## Scope EXCLUIDO de este PR (issues/PRs futuros del breakdown #205)

| Scope | Por qué se difiere |
|---|---|
| **PR-B**: tabla `terminos_version` + `consentimiento_terminos` con IP/user-agent | Requiere migración Flyway, endpoint nuevo, dominio + repositorio. Independiente de las páginas. |
| **PR-C**: re-aceptación obligatoria al cambiar versión en login | Depende de PR-B (necesita saber qué versión aceptó el usuario). |
| Auditoría legal externa del contenido | Bloqueada por disponibilidad de abogado — el banner queda hasta que pase. |
| Banner de consentimiento granular de cookies | Ya cubierto por #218 (epic separado). |

## Verificación

- [x] `npm run build` OK — las 3 rutas se compilan como estáticas
  ```
  ○ /cookies    181 B    93.7 kB
  ○ /lopdp      181 B    93.7 kB
  ○ /terminos   181 B    93.7 kB
  ```
- [x] Cero regresión en tests: 480 passing igual que en develop. (Los 17 tests fallidos preexistentes en `admin/reportes/estado-cuenta` y otros NO son regresión de este PR — verificado con `git stash`.)
- [ ] **QA manual**: navegar a `/terminos`, `/lopdp`, `/cookies` desde el footer del landing y desde el formulario de registro. Verificar que el banner amarillo "Documento en revisión legal" se ve.

## Test plan QA

- [ ] Visitar `/` (landing) → footer → click "Términos de Servicio" → carga `/terminos` con banner amarillo
- [ ] Footer → click "Política de Privacidad (LOPDP)" → carga `/lopdp`
- [ ] Footer → click "Política de Cookies" → carga `/cookies` con la tabla de 4 cookies
- [ ] En `/registro` paso final → click "términos y condiciones" → carga `/terminos`
- [ ] En `/registro` paso final → click "política de protección de datos personales" → carga `/lopdp`
- [ ] En cualquiera de las 3 páginas → click "Volver al inicio" → vuelve a `/`
- [ ] En cualquiera de las 3 páginas → cross-links del footer interno funcionan

🤖 Generated with [Claude Code](https://claude.com/claude-code)