### PR TITLE
refactor(socios): eliminar obtenerSocioIdPorCuenta muerto (#199)

### DIFF
--- a/backend/src/main/java/com/tufondo/core/port/SocioQueryPort.java
+++ b/backend/src/main/java/com/tufondo/core/port/SocioQueryPort.java
@@ -4,17 +4,21 @@ package com.tufondo.core.port;
 import java.util.UUID;
 
 /**
- * Puerto para consultar datos del módulo Socios.
+ * Puerto para consultar datos del módulo Socios desde otros módulos
+ * (ej. documentospdf) sin acoplarse al modelo de dominio interno.
+ *
+ * <p><strong>Nota arquitectónica (issue #199):</strong> previamente este
+ * puerto tenía un método {@code obtenerSocioIdPorCuenta(UUID)} que se
+ * eliminó porque (a) era código muerto — ningún consumidor lo llamaba
+ * y todos los flujos resuelven cuentaId→socioId vía
+ * {@code CuentaQueryPort.obtenerDatosCuenta()} que ya retorna el
+ * socioId; (b) implementarlo aquí violaría hexagonal — el módulo
+ * {@code socios} no debe depender del módulo {@code ahorros}. Si en el
+ * futuro algún flujo necesita la relación cuenta→socio fuera de
+ * Cuenta, créese un puerto en {@code core.port} que el módulo
+ * {@code ahorros} implemente.</p>
  */
 public interface SocioQueryPort {
-
-    /**
-     * Obtiene el ID del socio asociado a una cuenta.
-     *
-     * @param cuentaId ID de la cuenta
-     * @return UUID del socio
-     */
-    UUID obtenerSocioIdPorCuenta(UUID cuentaId);
 
     /**
      * Verifica si un socio existe.
@@ -28,7 +32,7 @@ public interface SocioQueryPort {
      * Obtiene datos públicos del socio para el PDF.
      *
      * @param socioId ID del socio
-     * @return Mapa con datos del socio
+     * @return Mapa con datos del socio o {@code null} si no existe
      */
     java.util.Map<String, Object> obtenerDatosSocioParaPdf(UUID socioId);
 }

--- a/backend/src/main/java/com/tufondo/socios/infrastructure/adapter/SocioQueryPortAdapter.java
+++ b/backend/src/main/java/com/tufondo/socios/infrastructure/adapter/SocioQueryPortAdapter.java
@@ -14,13 +14,17 @@ import java.util.Optional;
 import java.util.UUID;
 
 /**
- * Adaptador para el puerto SocioQueryPort.
- * Provee datos del módulo Socios para el módulo Documentos PDF.
+ * Adaptador del puerto {@link SocioQueryPort}.
  *
- * NOTA: El método obtenerSocioIdPorCuenta() requiere la relación cuenta-socio
- * que actualmente no está expuesta. Sin embargo, el flujo actual de
- * GenerarEstadoCuentaUseCase obtiene el socioId directamente de
- * CuentaQueryPort.obtenerDatosCuenta(), por lo que este método no es necesario.
+ * <p>Provee datos del módulo Socios al módulo Documentos PDF (constancia
+ * de afiliación, contrato de adhesión, etc.) sin que ese módulo dependa
+ * del modelo de dominio interno de {@code socios}.</p>
+ *
+ * <p><strong>Historia (#199):</strong> este adapter tenía un método
+ * {@code obtenerSocioIdPorCuenta(UUID)} que era un stub sin callers
+ * reales (lanzaba {@code OperacionNoDisponibleException}). Se eliminó
+ * junto con la inner exception class — ver JavaDoc del puerto para la
+ * justificación arquitectónica.</p>
  */
 @Slf4j
 @Service
@@ -28,24 +32,6 @@ import java.util.UUID;
 public class SocioQueryPortAdapter implements SocioQueryPort {
 
     private final SocioJpaRepository socioJpaRepository;
-
-    /**
-     * Obtiene el socioId por cuentaId.
-     *
-     * NOTA: Este método requiere que el módulo Ahorros exponga la relación.
-     * El flujo actual de documentos obtiene socioId desde CuentaQueryPort,
-     * por lo que este método podría no ser necesario.
-     *
-     * @throws OperacionNoDisponibleException si la relación no está implementada
-     */
-    @Override
-    public UUID obtenerSocioIdPorCuenta(UUID cuentaId) {
-        log.warn("METODO NO IMPLEMENTADO: obtenerSocioIdPorCuenta({})", cuentaId);
-        log.warn("El flujo de generación de estados de cuenta obtiene socioId desde CuentaQueryPort");
-        throw new OperacionNoDisponibleException(
-                "No disponible: La relación cuenta-socio debe ser implementada por el módulo Ahorros. " +
-                "Use CuentaQueryPort.obtenerDatosCuenta() que ya retorna socioId.");
-    }
 
     @Override
     public boolean existeSocio(UUID socioId) {
@@ -109,14 +95,5 @@ public class SocioQueryPortAdapter implements SocioQueryPort {
             sb.append(" ").append(socio.getSegundoApellido());
         }
         return sb.toString().trim();
-    }
-
-    /**
-     * Excepción para operaciones no disponibles.
-     */
-    public static class OperacionNoDisponibleException extends RuntimeException {
-        public OperacionNoDisponibleException(String mensaje) {
-            super(mensaje);
-        }
     }
 }

--- a/backend/src/test/java/com/tufondo/socios/infrastructure/adapter/SocioQueryPortAdapterTest.java
+++ b/backend/src/test/java/com/tufondo/socios/infrastructure/adapter/SocioQueryPortAdapterTest.java
@@ -1,0 +1,163 @@
+package com.tufondo.socios.infrastructure.adapter;
+
+import com.tufondo.socios.domain.model.enums.EstadoSocio;
+import com.tufondo.socios.domain.model.enums.TipoContrato;
+import com.tufondo.socios.domain.model.enums.TipoDocumento;
+import com.tufondo.socios.infrastructure.persistence.entity.SocioEntity;
+import com.tufondo.socios.infrastructure.persistence.jpa.SocioJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests del adaptador {@link SocioQueryPortAdapter} (issue #199).
+ *
+ * <p>Cobertura de los dos métodos que siguen vivos tras el cleanup del
+ * issue #199 (que eliminó {@code obtenerSocioIdPorCuenta}, un stub sin
+ * callers reales que solo lanzaba excepción).</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class SocioQueryPortAdapterTest {
+
+    @Mock
+    private SocioJpaRepository socioJpaRepository;
+
+    @InjectMocks
+    private SocioQueryPortAdapter adapter;
+
+    private UUID socioId;
+
+    @BeforeEach
+    void setUp() {
+        socioId = UUID.randomUUID();
+    }
+
+    // === existeSocio ===
+
+    @Test
+    @DisplayName("existeSocio: delega en existsById y devuelve true cuando el socio existe")
+    void existeSocio_devuelve_true_cuando_existe() {
+        when(socioJpaRepository.existsById(socioId)).thenReturn(true);
+
+        assertThat(adapter.existeSocio(socioId)).isTrue();
+    }
+
+    @Test
+    @DisplayName("existeSocio: devuelve false cuando el socio no existe")
+    void existeSocio_devuelve_false_cuando_no_existe() {
+        when(socioJpaRepository.existsById(socioId)).thenReturn(false);
+
+        assertThat(adapter.existeSocio(socioId)).isFalse();
+    }
+
+    // === obtenerDatosSocioParaPdf ===
+
+    @Test
+    @DisplayName("obtenerDatosSocioParaPdf: devuelve null cuando el socio no existe (no rompe el PDF)")
+    void obtenerDatos_devuelve_null_cuando_socio_no_existe() {
+        when(socioJpaRepository.findById(socioId)).thenReturn(Optional.empty());
+
+        Map<String, Object> datos = adapter.obtenerDatosSocioParaPdf(socioId);
+
+        assertThat(datos).isNull();
+    }
+
+    @Test
+    @DisplayName("obtenerDatosSocioParaPdf: mapea todos los campos del socio al map del PDF")
+    void obtenerDatos_mapea_campos_del_socio() {
+        SocioEntity socio = nuevoSocioMock();
+        when(socioJpaRepository.findById(socioId)).thenReturn(Optional.of(socio));
+
+        Map<String, Object> datos = adapter.obtenerDatosSocioParaPdf(socioId);
+
+        assertThat(datos).isNotNull();
+        assertThat(datos.get("id")).isEqualTo(socioId);
+        assertThat(datos.get("numeroSocio")).isEqualTo("SOC-001");
+        assertThat(datos.get("primerNombre")).isEqualTo("Juan");
+        assertThat(datos.get("primerApellido")).isEqualTo("Pérez");
+        // El nombre completo concatena nombres y apellidos saltando vacíos
+        assertThat(datos.get("nombreCompleto")).isEqualTo("Juan Carlos Pérez González");
+        assertThat(datos.get("cedula")).isEqualTo("V-12345678");
+        assertThat(datos.get("numeroDocumento")).isEqualTo("V-12345678");
+        // Enums serializados como String (.name())
+        assertThat(datos.get("tipoDocumento")).isEqualTo("CEDULA");
+        assertThat(datos.get("estado")).isEqualTo("ACTIVO");
+        assertThat(datos.get("tipoContrato")).isEqualTo("INDEFINIDO");
+        // Datos laborales
+        assertThat(datos.get("empresa")).isEqualTo("Cooperativa Transporte XYZ");
+        assertThat(datos.get("cargo")).isEqualTo("Conductor");
+    }
+
+    @Test
+    @DisplayName("obtenerDatosSocioParaPdf: maneja nombres/apellidos opcionales sin null pointer")
+    void obtenerDatos_construye_nombre_sin_segundos() {
+        SocioEntity socio = nuevoSocioMockMinimo();
+        when(socioJpaRepository.findById(socioId)).thenReturn(Optional.of(socio));
+
+        Map<String, Object> datos = adapter.obtenerDatosSocioParaPdf(socioId);
+
+        assertThat(datos).isNotNull();
+        // Sin segundo nombre ni segundo apellido — el helper no debe romperse
+        assertThat(datos.get("nombreCompleto")).isEqualTo("María López");
+    }
+
+    @Test
+    @DisplayName("obtenerDatosSocioParaPdf: enums null no rompen el mapeo (serializa a null)")
+    void obtenerDatos_enums_null_no_rompen() {
+        SocioEntity socio = nuevoSocioMockMinimo();
+        when(socioJpaRepository.findById(socioId)).thenReturn(Optional.of(socio));
+
+        Map<String, Object> datos = adapter.obtenerDatosSocioParaPdf(socioId);
+
+        // Estado y tipoDocumento se quedaron null en el mock mínimo
+        assertThat(datos).containsKey("estado").containsKey("tipoDocumento").containsKey("tipoContrato");
+        assertThat(datos.get("tipoContrato")).isNull();
+    }
+
+    // === Helpers ===
+
+    /** Socio mock con todos los datos relevantes para el PDF. */
+    private SocioEntity nuevoSocioMock() {
+        SocioEntity socio = org.mockito.Mockito.mock(SocioEntity.class);
+        lenient().when(socio.getId()).thenReturn(socioId);
+        lenient().when(socio.getNumeroSocio()).thenReturn("SOC-001");
+        lenient().when(socio.getPrimerNombre()).thenReturn("Juan");
+        lenient().when(socio.getSegundoNombre()).thenReturn("Carlos");
+        lenient().when(socio.getPrimerApellido()).thenReturn("Pérez");
+        lenient().when(socio.getSegundoApellido()).thenReturn("González");
+        lenient().when(socio.getTipoDocumento()).thenReturn(TipoDocumento.CEDULA);
+        lenient().when(socio.getNumeroDocumento()).thenReturn("V-12345678");
+        lenient().when(socio.getCorreoElectronico()).thenReturn("juan@example.com");
+        lenient().when(socio.getTelefonoPrincipal()).thenReturn("+584141234567");
+        lenient().when(socio.getEmpresa()).thenReturn("Cooperativa Transporte XYZ");
+        lenient().when(socio.getCargo()).thenReturn("Conductor");
+        lenient().when(socio.getTipoContrato()).thenReturn(TipoContrato.INDEFINIDO);
+        lenient().when(socio.getEstado()).thenReturn(EstadoSocio.ACTIVO);
+        lenient().when(socio.getFechaRegistro()).thenReturn(LocalDateTime.now());
+        return socio;
+    }
+
+    /** Socio mock sin segundo nombre ni apellido — para probar el helper. */
+    private SocioEntity nuevoSocioMockMinimo() {
+        SocioEntity socio = org.mockito.Mockito.mock(SocioEntity.class);
+        lenient().when(socio.getId()).thenReturn(socioId);
+        lenient().when(socio.getPrimerNombre()).thenReturn("María");
+        lenient().when(socio.getSegundoNombre()).thenReturn("");  // vacío, no null
+        lenient().when(socio.getPrimerApellido()).thenReturn("López");
+        lenient().when(socio.getSegundoApellido()).thenReturn(null);  // null directo
+        return socio;
+    }
+}


### PR DESCRIPTION
Closes #199.

## TL;DR

El issue pedía implementar un método de un puerto que parecía un fallback inseguro. Tras auditar, **el método tiene cero callers reales** y la "amenaza" descrita en el issue (`retorna vacío → no protege nada`) no existe — el adapter lanza excepción, y nadie lo invoca de todos modos. Lo correcto es eliminar el código muerto.

## Análisis (corrige premisa del issue)

El issue describe:
> \`return Optional.empty();\`
> Es un port [...] que necesita resolver \"dada una cuenta, ¿qué socio la posee?\". **Hoy retorna vacío → cualquier check que dependa de esto no protege nada.**

Realidad del código en `develop`:

```java
@Override
public UUID obtenerSocioIdPorCuenta(UUID cuentaId) {
    log.warn(\"METODO NO IMPLEMENTADO: ...\");
    throw new OperacionNoDisponibleException(\"...\");  // ← lanza, no retorna empty
}
```

Y la búsqueda de callers:

```
$ grep -rn \".obtenerSocioIdPorCuenta\" backend/src/
(sin resultados)
```

**Cero invocaciones reales en todo el backend.** El método solo aparece declarado en la interfaz `core.port.SocioQueryPort` e implementado como stub en `SocioQueryPortAdapter`. Los use cases que inyectan `SocioQueryPort` (6 en `documentospdf`) solo usan los otros dos métodos (`existeSocio`, `obtenerDatosSocioParaPdf`).

## Por qué no \"implementarlo de verdad\"

El fix propuesto en el issue era:

```java
public Optional<UUID> obtenerSocioIdPorCuenta(UUID cuentaId) {
    return cuentaAhorroRepository.findById(cuentaId).map(CuentaAhorro::getSocioId);
}
```

Eso requeriría inyectar el repositorio de **`ahorros`** dentro del módulo **`socios`**, lo cual **viola hexagonal** (dependencia inversa entre módulos del mismo nivel). El patrón correcto si en el futuro un flujo necesita esto sería: crear un puerto en `core.port` (ej. `AhorrosQueryPort.obtenerSocioIdPorCuenta`) que el módulo `ahorros` implemente. Pero hoy nadie lo necesita — todos los flujos resuelven `cuentaId→socioId` vía `CuentaQueryPort.obtenerDatosCuenta()` que ya retorna el `socioId`.

Documenté esta decisión en el JavaDoc del puerto para que un futuro lector no caiga en el mismo malentendido.

## Cambios

### Eliminado (código muerto)
- `SocioQueryPort.obtenerSocioIdPorCuenta(UUID)` — declaración del método del contrato.
- `SocioQueryPortAdapter.obtenerSocioIdPorCuenta(UUID)` — el stub que lanzaba.
- `SocioQueryPortAdapter.OperacionNoDisponibleException` — inner exception que ya no se usa en ningún lado (su única invocación era desde el método eliminado; verificado que el `BeneficiarioQueryPortAdapter` declara su propia inner class con el mismo nombre, independiente).

### Añadido
- `SocioQueryPortAdapterTest` (6 tests) cubriendo los dos métodos vivos:
  - `existeSocio`: caso existe + caso no existe.
  - `obtenerDatosSocioParaPdf`: caso socio no existe (devuelve `null`), mapeo completo de campos al map del PDF, construcción del nombre completo con segundos nombres/apellidos vacíos o `null` sin NPE, manejo de enums null.

### Documentación
- JavaDoc en el puerto explica el historial y el patrón correcto si el caso de uso aparece en el futuro.

## Verificación

- [x] `mvn test`: **382 passing / 0 failures / 0 errors**
  - Suite saltó de 376 (post #214 PR-C) a 382 con los 6 nuevos tests.
  - **La eliminación del método no rompió ningún test** — empíricamente confirma que era código muerto.

## Notas para QA

Este PR no toca ningún flujo de negocio observable por el usuario. Es un refactor interno de un puerto. QA puede:
- [ ] Verificar que la app levanta sin error (`docker compose up`).
- [ ] Verificar que la generación de PDFs sigue funcionando (estado de cuenta, constancia de afiliación, tabla de amortización) — son los consumidores del puerto.
- [ ] No hay endpoints nuevos ni rotos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)