### PR TITLE
feat(cuentas): movimientos clicables + modal de detalle (#220 PR-A)

### DIFF
--- a/frontend-web/src/app/(dashboard)/dashboard/cuentas/[numero]/movimientos/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/cuentas/[numero]/movimientos/page.tsx
@@ -11,6 +11,7 @@ import { Label } from '@/components/ui/label';
 import { Loader2 } from 'lucide-react';
 import Link from 'next/link';
 import { toast } from 'sonner';
+import { MovimientoDetailModal } from '@/components/features/cuentas/movimiento-detail-modal';
 
 interface Movimiento {
   id: string;
@@ -90,8 +91,16 @@ export default function MovimientosPage() {
   const [tipoFiltro, setTipoFiltro] = useState<string>('');
   const [fechaInicio, setFechaInicio] = useState<string>('');
   const [fechaFin, setFechaFin] = useState<string>('');
+  // Filtros de monto: aplicados client-side sobre la página actual. Si en el
+  // futuro se necesita filtrar sobre todo el histórico, mover a backend (PR-B
+  // del issue #220).
+  const [montoMinimo, setMontoMinimo] = useState<string>('');
+  const [montoMaximo, setMontoMaximo] = useState<string>('');
 
   const [totales, setTotales] = useState({ depositos: 0, retiros: 0 });
+
+  // Movimiento seleccionado para el modal de detalle (issue #220).
+  const [selectedMov, setSelectedMov] = useState<Movimiento | null>(null);
 
   useEffect(() => {
     if (!numeroCuenta || isLoading) return;
@@ -158,10 +167,36 @@ export default function MovimientosPage() {
     setTipoFiltro('');
     setFechaInicio('');
     setFechaFin('');
+    setMontoMinimo('');
+    setMontoMaximo('');
     setPage(0);
   };
 
   const moneda = cuenta?.moneda || 'VES';
+
+  // Filtro de monto client-side sobre la página actual.
+  // Justificación de scope: la página trae 10 movimientos por defecto,
+  // filtrar 10 en cliente es razonable y evita un round-trip extra.
+  // Si en el futuro se necesita filtrar sobre todo el histórico, se mueve
+  // a backend (PR-B del issue #220) extendiendo el endpoint de movimientos.
+  const movimientosFiltrados = useMemo(() => {
+    const min = montoMinimo ? parseFloat(montoMinimo) : null;
+    const max = montoMaximo ? parseFloat(montoMaximo) : null;
+    // Si ningún filtro de monto es válido, devolver el array original
+    if ((min === null || isNaN(min)) && (max === null || isNaN(max))) {
+      return movimientos;
+    }
+    return movimientos.filter((m) => {
+      const monto = Number(m.monto);
+      if (min !== null && !isNaN(min) && monto < min) return false;
+      if (max !== null && !isNaN(max) && monto > max) return false;
+      return true;
+    });
+  }, [movimientos, montoMinimo, montoMaximo]);
+
+  const hayFiltroMontoActivo =
+    (montoMinimo !== '' && !isNaN(parseFloat(montoMinimo))) ||
+    (montoMaximo !== '' && !isNaN(parseFloat(montoMaximo)));
 
   if (loading) {
     return (
@@ -209,7 +244,7 @@ export default function MovimientosPage() {
           <CardTitle className="text-lg">Filtros</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div className="space-y-2">
               <Label htmlFor="tipo">Tipo de Movimiento</Label>
               <select
@@ -241,6 +276,37 @@ export default function MovimientosPage() {
                 value={fechaFin}
                 onChange={(e) => setFechaFin(e.target.value)}
               />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="monto-minimo">Monto mínimo</Label>
+              <Input
+                id="monto-minimo"
+                type="number"
+                inputMode="decimal"
+                step="0.01"
+                min="0"
+                placeholder="0.00"
+                aria-describedby="monto-help"
+                value={montoMinimo}
+                onChange={(e) => setMontoMinimo(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="monto-maximo">Monto máximo</Label>
+              <Input
+                id="monto-maximo"
+                type="number"
+                inputMode="decimal"
+                step="0.01"
+                min="0"
+                placeholder="Sin límite"
+                aria-describedby="monto-help"
+                value={montoMaximo}
+                onChange={(e) => setMontoMaximo(e.target.value)}
+              />
+              <p id="monto-help" className="text-xs text-gray-500">
+                Filtra solo la página actual
+              </p>
             </div>
             <div className="flex items-end gap-2">
               <Button
@@ -302,15 +368,25 @@ export default function MovimientosPage() {
             <div className="flex justify-center py-8">
               <Loader2 className="h-6 w-6 animate-spin text-green-600" />
             </div>
-          ) : movimientos.length === 0 ? (
+          ) : movimientosFiltrados.length === 0 ? (
             <div className="text-center py-12">
-              <p className="text-gray-500 mb-4">No hay movimientos que coincidan con los filtros</p>
+              <p className="text-gray-500 mb-4">
+                {hayFiltroMontoActivo && movimientos.length > 0
+                  ? 'Ningún movimiento de la página actual coincide con el filtro de monto. Intenta cambiar de página o ajustar el rango.'
+                  : 'No hay movimientos que coincidan con los filtros'}
+              </p>
               <Button variant="outline" onClick={limpiarFiltros}>
                 Limpiar filtros
               </Button>
             </div>
           ) : (
             <>
+              {hayFiltroMontoActivo && (
+                <p className="mb-3 text-xs text-gray-500" role="status">
+                  Mostrando {movimientosFiltrados.length} de {movimientos.length} movimientos
+                  de la página actual (filtro de monto aplicado en cliente).
+                </p>
+              )}
               <div className="overflow-x-auto">
                 <table className="w-full">
                   <thead>
@@ -324,8 +400,21 @@ export default function MovimientosPage() {
                     </tr>
                   </thead>
                   <tbody>
-                    {movimientos.map((mov) => (
-                      <tr key={mov.id} className="border-b hover:bg-gray-50">
+                    {movimientosFiltrados.map((mov) => (
+                      <tr
+                        key={mov.id}
+                        className="border-b hover:bg-gray-50 cursor-pointer focus:outline-none focus:bg-gray-50"
+                        role="button"
+                        tabIndex={0}
+                        aria-label={`Ver detalle del movimiento ${mov.numeroOperacion}`}
+                        onClick={() => setSelectedMov(mov)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            setSelectedMov(mov);
+                          }
+                        }}
+                      >
                         <td className="py-3 px-3 text-sm">
                           <div>{formatFechaCorta(mov.fechaMovimiento)}</div>
                           <div className="text-gray-400 text-xs">{mov.numeroOperacion}</div>
@@ -391,6 +480,12 @@ export default function MovimientosPage() {
           )}
         </CardContent>
       </Card>
+
+      <MovimientoDetailModal
+        movimiento={selectedMov}
+        moneda={moneda}
+        onClose={() => setSelectedMov(null)}
+      />
     </div>
   );
 }

--- a/frontend-web/src/components/features/cuentas/movimiento-detail-modal.test.tsx
+++ b/frontend-web/src/components/features/cuentas/movimiento-detail-modal.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  MovimientoDetailModal,
+  type MovimientoDetail,
+} from '@/components/features/cuentas/movimiento-detail-modal';
+
+/**
+ * Tests del modal de detalle de movimiento (issue #220).
+ * Cubre: render condicional, secciones del modal, cálculo del delta,
+ * etiqueta de canal, botón de comprobante deshabilitado (placeholder
+ * hasta PR-B con endpoint backend).
+ */
+
+const movimientoDeposito: MovimientoDetail = {
+  id: 'mov-1',
+  numeroOperacion: 'OP-2026-000001',
+  tipo: 'DEPOSITO',
+  monto: 1500.5,
+  saldoAnterior: 8000,
+  saldoPosterior: 9500.5,
+  descripcion: 'Depósito en caja Centro',
+  referencia: 'REF-XYZ-123',
+  canalOrigen: 'CAJA',
+  estado: 'COMPLETADO',
+  fechaMovimiento: '2026-05-17T14:30:45',
+  fechaValor: '2026-05-17T14:30:45',
+};
+
+const movimientoRetiro: MovimientoDetail = {
+  id: 'mov-2',
+  numeroOperacion: 'OP-2026-000002',
+  tipo: 'RETIRO',
+  monto: 250,
+  saldoAnterior: 9500.5,
+  saldoPosterior: 9250.5,
+  descripcion: null,
+  referencia: null,
+  canalOrigen: 'WEB',
+  estado: 'PENDIENTE',
+  fechaMovimiento: '2026-05-17T15:00:00',
+  fechaValor: '2026-05-17T15:00:00',
+};
+
+describe('MovimientoDetailModal', () => {
+  it('no renderiza cuando movimiento es null', () => {
+    render(<MovimientoDetailModal movimiento={null} moneda="VES" onClose={vi.fn()} />);
+    expect(screen.queryByText(/Detalle del movimiento/i)).toBeNull();
+  });
+
+  it('renderiza secciones principales cuando hay movimiento (depósito)', () => {
+    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" onClose={vi.fn()} />);
+
+    expect(screen.getByText(/Detalle del movimiento/i)).toBeTruthy();
+    // Header con el numero de operación
+    expect(screen.getAllByText('OP-2026-000001').length).toBeGreaterThan(0);
+    // 4 secciones
+    expect(screen.getByText(/Datos básicos/i)).toBeTruthy();
+    expect(screen.getByText(/Referencias/i)).toBeTruthy();
+    expect(screen.getByText(/Saldos/i)).toBeTruthy();
+    expect(screen.getByText(/Canal/i)).toBeTruthy();
+  });
+
+  it('muestra signo + y monto formateado para depósitos', () => {
+    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" onClose={vi.fn()} />);
+    // El monto se muestra con signo + y prefijo Bs (VES)
+    expect(screen.getByText(/\+ Bs/)).toBeTruthy();
+  });
+
+  it('muestra signo − y monto formateado para retiros', () => {
+    render(<MovimientoDetailModal movimiento={movimientoRetiro} moneda="VES" onClose={vi.fn()} />);
+    expect(screen.getByText(/− Bs/)).toBeTruthy();
+  });
+
+  it('mapea canal CAJA a etiqueta legible "Caja presencial"', () => {
+    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" onClose={vi.fn()} />);
+    expect(screen.getByText(/Caja presencial/i)).toBeTruthy();
+  });
+
+  it('mapea canal WEB a etiqueta "Banca en línea"', () => {
+    render(<MovimientoDetailModal movimiento={movimientoRetiro} moneda="VES" onClose={vi.fn()} />);
+    expect(screen.getByText(/Banca en línea/i)).toBeTruthy();
+  });
+
+  it('estado PENDIENTE se renderiza con su etiqueta legible', () => {
+    render(<MovimientoDetailModal movimiento={movimientoRetiro} moneda="VES" onClose={vi.fn()} />);
+    expect(screen.getByText('Pendiente')).toBeTruthy();
+  });
+
+  it('omite la sección de referencia externa cuando es null', () => {
+    render(<MovimientoDetailModal movimiento={movimientoRetiro} moneda="VES" onClose={vi.fn()} />);
+    expect(screen.queryByText(/Referencia externa/i)).toBeNull();
+  });
+
+  it('botón "Descargar comprobante" está deshabilitado (placeholder PR-B)', () => {
+    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" onClose={vi.fn()} />);
+    const btn = screen.getByRole('button', { name: /descargar comprobante/i });
+    expect(btn.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('botón Cerrar invoca onClose', () => {
+    const onClose = vi.fn();
+    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /cerrar/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('formatea moneda USD con prefijo $ en lugar de Bs', () => {
+    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="USD" onClose={vi.fn()} />);
+    expect(screen.getByText(/\+ \$/)).toBeTruthy();
+  });
+});

--- a/frontend-web/src/components/features/cuentas/movimiento-detail-modal.tsx
+++ b/frontend-web/src/components/features/cuentas/movimiento-detail-modal.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { ArrowDownToLine, ArrowUpFromLine, ArrowRight, FileDown } from 'lucide-react';
+
+/**
+ * Modal de detalle de un movimiento (issue #220).
+ *
+ * Muestra todos los campos relevantes de un movimiento individual
+ * agrupados en secciones (datos básicos, referencias, saldos, canal).
+ *
+ * Botón "Descargar comprobante" queda como placeholder deshabilitado
+ * — el endpoint backend que genera el comprobante PDF se entregará en
+ * un PR-B siguiente del mismo issue.
+ */
+
+export interface MovimientoDetail {
+  id: string;
+  numeroOperacion: string;
+  tipo: string;
+  monto: number;
+  saldoAnterior: number;
+  saldoPosterior: number;
+  descripcion: string | null;
+  referencia: string | null;
+  canalOrigen: string;
+  estado: string;
+  fechaMovimiento: string;
+  fechaValor: string;
+}
+
+interface Props {
+  movimiento: MovimientoDetail | null;
+  moneda: string;
+  onClose: () => void;
+}
+
+const formatMonto = (monto: number | null | undefined, moneda: string) => {
+  if (monto == null) return '-';
+  const simbolo = moneda === 'VES' ? 'Bs' : '$';
+  return `${simbolo} ${monto.toLocaleString('es-VE', { minimumFractionDigits: 2 })}`;
+};
+
+const formatFechaCompleta = (fecha: string) => {
+  return new Date(fecha).toLocaleString('es-VE', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+};
+
+const formatFechaCorta = (fecha: string) => {
+  return new Date(fecha).toLocaleDateString('es-VE', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
+const etiquetaCanal = (canal: string): string => {
+  switch (canal?.toUpperCase()) {
+    case 'WEB':
+      return 'Banca en línea';
+    case 'MOVIL':
+    case 'MÓVIL':
+      return 'Aplicación móvil';
+    case 'CAJA':
+      return 'Caja presencial';
+    case 'TRANSFERENCIA':
+      return 'Transferencia';
+    case 'API':
+      return 'API';
+    default:
+      return canal || '—';
+  }
+};
+
+const etiquetaEstado = (estado: string): { texto: string; clase: string } => {
+  switch (estado?.toUpperCase()) {
+    case 'COMPLETADO':
+    case 'COMPLETADA':
+    case 'EXITOSO':
+      return { texto: 'Completado', clase: 'bg-green-100 text-green-800' };
+    case 'PENDIENTE':
+      return { texto: 'Pendiente', clase: 'bg-amber-100 text-amber-800' };
+    case 'RECHAZADO':
+    case 'FALLIDO':
+      return { texto: 'Rechazado', clase: 'bg-red-100 text-red-800' };
+    case 'REVERSADO':
+      return { texto: 'Reversado', clase: 'bg-slate-200 text-slate-800' };
+    default:
+      return { texto: estado || '—', clase: 'bg-slate-100 text-slate-700' };
+  }
+};
+
+export function MovimientoDetailModal({ movimiento, moneda, onClose }: Props) {
+  const open = movimiento !== null;
+  const esDeposito = movimiento?.tipo === 'DEPOSITO';
+  const delta = movimiento ? movimiento.saldoPosterior - movimiento.saldoAnterior : 0;
+  const estadoUi = movimiento ? etiquetaEstado(movimiento.estado) : null;
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-[#0F2744]">
+            {esDeposito ? (
+              <ArrowDownToLine className="w-5 h-5 text-green-600" aria-hidden="true" />
+            ) : (
+              <ArrowUpFromLine className="w-5 h-5 text-red-600" aria-hidden="true" />
+            )}
+            Detalle del movimiento
+          </DialogTitle>
+          <DialogDescription>
+            Operación{' '}
+            <span className="font-mono text-xs text-slate-700">
+              {movimiento?.numeroOperacion}
+            </span>
+          </DialogDescription>
+        </DialogHeader>
+
+        {movimiento && (
+          <div className="space-y-5">
+            {/* Sección: Datos básicos */}
+            <section aria-labelledby="seccion-basicos">
+              <h3 id="seccion-basicos" className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-2">
+                Datos básicos
+              </h3>
+              <dl className="space-y-2 text-sm">
+                <DataRow label="Tipo">
+                  <span
+                    className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full ${
+                      esDeposito ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+                    }`}
+                  >
+                    {esDeposito ? 'Depósito' : 'Retiro'}
+                  </span>
+                </DataRow>
+                <DataRow label="Monto">
+                  <span className={`text-lg font-bold ${esDeposito ? 'text-green-600' : 'text-red-600'}`}>
+                    {esDeposito ? '+' : '−'} {formatMonto(movimiento.monto, moneda)}
+                  </span>
+                </DataRow>
+                <DataRow label="Estado">
+                  {estadoUi && (
+                    <span className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${estadoUi.clase}`}>
+                      {estadoUi.texto}
+                    </span>
+                  )}
+                </DataRow>
+                <DataRow label="Fecha de movimiento">
+                  <span className="text-slate-800">{formatFechaCompleta(movimiento.fechaMovimiento)}</span>
+                </DataRow>
+                {movimiento.fechaValor && movimiento.fechaValor !== movimiento.fechaMovimiento && (
+                  <DataRow label="Fecha valor">
+                    <span className="text-slate-800">{formatFechaCorta(movimiento.fechaValor)}</span>
+                  </DataRow>
+                )}
+              </dl>
+            </section>
+
+            {/* Sección: Referencias */}
+            <section aria-labelledby="seccion-referencias" className="pt-2 border-t border-slate-100">
+              <h3 id="seccion-referencias" className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-2">
+                Referencias
+              </h3>
+              <dl className="space-y-2 text-sm">
+                <DataRow label="Número de operación">
+                  <span className="font-mono text-xs text-slate-800">{movimiento.numeroOperacion}</span>
+                </DataRow>
+                {movimiento.referencia && (
+                  <DataRow label="Referencia externa">
+                    <span className="font-mono text-xs text-slate-800">{movimiento.referencia}</span>
+                  </DataRow>
+                )}
+                {movimiento.descripcion && (
+                  <DataRow label="Descripción">
+                    <span className="text-slate-800">{movimiento.descripcion}</span>
+                  </DataRow>
+                )}
+              </dl>
+            </section>
+
+            {/* Sección: Saldos */}
+            <section aria-labelledby="seccion-saldos" className="pt-2 border-t border-slate-100">
+              <h3 id="seccion-saldos" className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-2">
+                Saldos
+              </h3>
+              <div className="flex items-center justify-between gap-3 rounded-lg bg-slate-50 px-4 py-3">
+                <div className="text-center">
+                  <p className="text-xs text-slate-500">Anterior</p>
+                  <p className="text-sm font-semibold text-slate-800">
+                    {formatMonto(movimiento.saldoAnterior, moneda)}
+                  </p>
+                </div>
+                <ArrowRight className="w-4 h-4 text-slate-400 flex-shrink-0" aria-hidden="true" />
+                <div className="text-center">
+                  <p className="text-xs text-slate-500">Delta</p>
+                  <p className={`text-sm font-semibold ${delta >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    {delta >= 0 ? '+' : ''}{formatMonto(Math.abs(delta), moneda)}
+                  </p>
+                </div>
+                <ArrowRight className="w-4 h-4 text-slate-400 flex-shrink-0" aria-hidden="true" />
+                <div className="text-center">
+                  <p className="text-xs text-slate-500">Posterior</p>
+                  <p className="text-sm font-semibold text-slate-800">
+                    {formatMonto(movimiento.saldoPosterior, moneda)}
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            {/* Sección: Canal */}
+            <section aria-labelledby="seccion-canal" className="pt-2 border-t border-slate-100">
+              <h3 id="seccion-canal" className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-2">
+                Canal
+              </h3>
+              <dl className="space-y-2 text-sm">
+                <DataRow label="Origen">
+                  <span className="text-slate-800">{etiquetaCanal(movimiento.canalOrigen)}</span>
+                </DataRow>
+              </dl>
+            </section>
+
+            {/* Acciones */}
+            <div className="pt-4 border-t border-slate-100 flex flex-col sm:flex-row gap-2 sm:justify-end">
+              <Button
+                variant="outline"
+                disabled
+                title="Disponible próximamente — pendiente endpoint backend (issue #220 PR-B)"
+                className="gap-2"
+              >
+                <FileDown className="w-4 h-4" aria-hidden="true" />
+                Descargar comprobante
+              </Button>
+              <Button onClick={onClose} className="bg-[#16A34A] hover:bg-green-700">
+                Cerrar
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** Helper local: fila label / value alineada a la izquierda/derecha. */
+function DataRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-baseline justify-between gap-2">
+      <dt className="text-xs text-slate-500">{label}</dt>
+      <dd className="text-right">{children}</dd>
+    </div>
+  );
+}


### PR DESCRIPTION
Parte de #220 (PR-A — modal + filtro de monto client-side). Ver "Próximos pasos" para PR-B (PDF comprobante) y PR-C (filtro server-side).

## Problema

`dashboard/cuentas/[numero]/movimientos/page.tsx:327-360` renderiza la tabla con fecha, tipo, descripción, monto y saldo, pero el usuario **no puede ver detalle**: no ve saldo anterior, no ve referencia externa, no ve canal específico, no puede descargar comprobante. Toda esa data ya viene en el response del backend — solo faltaba exponerla.

## Cambios

### Nuevo: `MovimientoDetailModal`
Componente shadcn Dialog con 4 secciones bien delimitadas:

| Sección | Contenido |
|---|---|
| **Datos básicos** | Tipo con badge color, monto con signo +/−, estado con etiqueta legible, fecha completa, fecha valor si difiere |
| **Referencias** | Número de operación (mono), referencia externa cuando aplica, descripción |
| **Saldos** | Visualización anterior → delta → posterior |
| **Canal** | Mapeo legible: WEB→Banca en línea, MOVIL→App móvil, CAJA→Caja presencial |

### Filas clicables
- `cursor-pointer` + `hover:bg-gray-50`
- `role=\"button\"` + `tabIndex={0}` para keyboard nav
- `Enter` y `Space` también abren el modal
- `aria-label` por fila incluye el número de operación (accesibilidad)

### Filtros: monto mínimo y monto máximo
- Inputs `type=\"number\"` con `step=0.01`, `min=0`, `inputMode=\"decimal\"` (móvil teclado numérico)
- **Aplicación client-side** sobre la página actual (cada página son 10 movimientos por defecto)
- Nota visual cuando filtro activo: `Mostrando X de N movimientos de la página actual`
- Mensaje específico cuando filtro elimina todo: `Ningún movimiento de la página actual coincide [...] Intenta cambiar de página`
- **Justificación documentada en el código**: filtrar 10 elementos en cliente es razonable y evita un round-trip; si se necesita filtrar sobre todo el histórico, se mueve a backend en PR-C extendiendo el endpoint.

### Botón \"Descargar comprobante\"
- Presente pero `disabled` con `title` explicativo
- Placeholder hasta que el PR-B implemente el endpoint backend que genera el PDF

### Mobile-friendly
- `max-h-[90vh]` + `overflow-y-auto` en el modal — funciona en mobile sin desbordar viewport
- Inputs nuevos respetan `grid-cols-1 md:grid-cols-3` para stackearse en mobile
- Botones de acción `flex-col sm:flex-row` (apilados en mobile, alineados en desktop)

## Tests

11 tests nuevos en `movimiento-detail-modal.test.tsx`:
- Render condicional (no renderiza con `movimiento=null`)
- Secciones renderizadas (Datos básicos, Referencias, Saldos, Canal)
- Signos +/− según tipo (depósito vs retiro)
- Mapeo de etiquetas legibles para canal (CAJA, WEB) y estado (PENDIENTE)
- Omisión de \"Referencia externa\" cuando es null
- Botón comprobante deshabilitado (placeholder PR-B)
- `onClose` invocado por botón Cerrar
- Formato de moneda USD (\$) vs VES (Bs)

## Verificación

- [x] `npm run build`: OK
- [x] `npm test`: **491 passing / 17 preexistentes failing (508 total)**
  - +11 nuevos verdes del modal
  - Los 17 failing son preexistentes en `develop` (admin/reportes/estado-cuenta y otros) — verificado: no son regresión de este PR

## Test plan QA

- [ ] `/dashboard/cuentas/{numero}/movimientos` carga normalmente
- [ ] Click en una fila abre modal con todos los campos correctos
- [ ] Modal muestra saldo anterior → delta → posterior alineado
- [ ] Tab + Enter sobre una fila también abre el modal (keyboard)
- [ ] Botón \"Descargar comprobante\" está deshabilitado con tooltip
- [ ] Botón \"Cerrar\" cierra el modal; click fuera también
- [ ] Inputs montoMin/montoMax filtran la lista visible
- [ ] Si pongo monto fuera de rango, sale el mensaje \"Ningún movimiento de la página actual coincide\"
- [ ] Filtro de monto + click \"Limpiar filtros\" → todos los inputs se vacían
- [ ] Mobile (≤768px): inputs y botones se apilan; modal no desborda

## Próximos pasos (issues/PRs futuros del #220)

| Scope | PR | Por qué se difiere |
|---|---|---|
| Endpoint `GET /api/v1/cuentas/{n}/movimientos/{op}/comprobante` + integración del botón en el modal | PR-B | Backend nuevo: use case en módulo `documentospdf`, template del PDF, BFF route, security check. ~500 líneas. |
| Filtro de monto server-side (params `montoMinimo`, `montoMaximo` en endpoint + use case + repo) | PR-C | Útil si se necesita escalar más allá de la página actual. Refactor del cascada if/else en `ListarMovimientosUseCase`. Opcional según feedback de QA. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)