### PR TITLE
feat(cuentas): comprobante PDF de movimiento on-demand (#220 PR-B)

### DIFF
--- a/backend/src/main/java/com/tufondo/ahorros/api/controller/AhorroController.java
+++ b/backend/src/main/java/com/tufondo/ahorros/api/controller/AhorroController.java
@@ -45,6 +45,7 @@ public class AhorroController {
     private final RealizarRetiroUseCase realizarRetiroUseCase;
     private final ListarMovimientosUseCase listarMovimientosUseCase;
     private final ObtenerMovimientoDetalleUseCase obtenerMovimientoDetalleUseCase;
+    private final GenerarComprobanteMovimientoUseCase generarComprobanteMovimientoUseCase;
     private final CalcularRendimientoUseCase calcularRendimientoUseCase;
     private final ListarRendimientosUseCase listarRendimientosUseCase;
     private final CerrarCuentaUseCase cerrarCuentaUseCase;
@@ -173,6 +174,29 @@ public class AhorroController {
         MovimientoResponse response = obtenerMovimientoDetalleUseCase.ejecutar(
                 numeroCuenta, numeroOperacion, socioIdToken, isAdmin);
         return ResponseEntity.ok(response);
+    }
+
+    // 8b. GET /cuentas/{numeroCuenta}/movimientos/{numeroOperacion}/comprobante - Comprobante PDF (#220 PR-B)
+    @GetMapping("/{numeroCuenta}/movimientos/{numeroOperacion}/comprobante")
+    @Operation(summary = "Descargar comprobante PDF del movimiento")
+    public ResponseEntity<byte[]> descargarComprobanteMovimiento(
+            @PathVariable String numeroCuenta,
+            @PathVariable String numeroOperacion,
+            Authentication authentication) {
+        UUID socioIdToken = extraerSocioId(authentication);
+        boolean isAdmin = esAdmin(authentication);
+        byte[] pdfBytes = generarComprobanteMovimientoUseCase.ejecutar(
+                numeroCuenta, numeroOperacion, socioIdToken, isAdmin);
+
+        String filename = String.format("Comprobante_%s.pdf", numeroOperacion);
+        return ResponseEntity.ok()
+                .header(org.springframework.http.HttpHeaders.CONTENT_TYPE,
+                        org.springframework.http.MediaType.APPLICATION_PDF_VALUE)
+                .header(org.springframework.http.HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"" + filename + "\"")
+                .header(org.springframework.http.HttpHeaders.CACHE_CONTROL,
+                        "no-store, no-cache, must-revalidate, private")
+                .body(pdfBytes);
     }
 
     // 9. POST /cuentas/{numeroCuenta}/rendimientos/calcular - Calcular Rendimiento

--- a/backend/src/main/java/com/tufondo/ahorros/application/usecase/GenerarComprobanteMovimientoUseCase.java
+++ b/backend/src/main/java/com/tufondo/ahorros/application/usecase/GenerarComprobanteMovimientoUseCase.java
@@ -1,0 +1,125 @@
+package com.tufondo.ahorros.application.usecase;
+
+import com.tufondo.ahorros.domain.exception.AccesoCuentaAjenaException;
+import com.tufondo.ahorros.domain.exception.CuentaAhorroNoEncontradaException;
+import com.tufondo.ahorros.domain.exception.MovimientoNoEncontradoException;
+import com.tufondo.ahorros.domain.model.CuentaAhorro;
+import com.tufondo.ahorros.domain.model.Movimiento;
+import com.tufondo.ahorros.domain.repository.CuentaAhorroRepository;
+import com.tufondo.ahorros.domain.repository.MovimientoRepository;
+import com.tufondo.core.port.SocioQueryPort;
+import com.tufondo.documentospdf.application.port.PdfGeneratorPort;
+import com.tufondo.documentospdf.domain.exception.GeneracionPDFException;
+import com.tufondo.documentospdf.domain.model.enums.TipoDocumento;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Genera el comprobante PDF on-demand de un movimiento individual
+ * (issue #220 PR-B).
+ *
+ * <p><strong>Diseño:</strong> a diferencia de los demás generadores del
+ * módulo {@code documentospdf}, este NO persiste el archivo en MinIO ni
+ * en la tabla {@code documentos}. El movimiento original es inmutable
+ * (RN-006) y constituye la fuente de verdad — el PDF se reconstruye
+ * cada vez que el socio lo solicita. Beneficios: cero infraestructura
+ * adicional, cero malware scan, sin presigned URLs que expiran. Costo:
+ * unos ms de CPU por descarga (insignificante).</p>
+ *
+ * <p><strong>Seguridad (IDOR):</strong> el socio solo puede descargar
+ * comprobantes de cuentas de las que es titular. Admin tiene paso
+ * libre por su rol.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GenerarComprobanteMovimientoUseCase {
+
+    private static final DateTimeFormatter FECHA_LEGIBLE =
+            DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+    private static final DateTimeFormatter FECHA_EMISION =
+            DateTimeFormatter.ofPattern("dd 'de' MMMM 'de' yyyy HH:mm");
+
+    private final CuentaAhorroRepository cuentaRepository;
+    private final MovimientoRepository movimientoRepository;
+    private final SocioQueryPort socioQueryPort;
+    private final PdfGeneratorPort pdfGeneratorPort;
+
+    public byte[] ejecutar(String numeroCuenta, String numeroOperacion,
+                           UUID socioIdToken, boolean isAdmin) {
+        log.info("Generando comprobante: cuenta={}, operacion={}, socioIdToken={}, isAdmin={}",
+                numeroCuenta, numeroOperacion, socioIdToken, isAdmin);
+
+        // 1. Validar cuenta + IDOR
+        CuentaAhorro cuenta = cuentaRepository.buscarPorNumeroCuenta(numeroCuenta)
+                .orElseThrow(() -> new CuentaAhorroNoEncontradaException(numeroCuenta));
+
+        if (!isAdmin && !cuenta.getSocioId().equals(socioIdToken)) {
+            log.warn("Violación IDOR: socioIdToken={} intentó descargar comprobante "
+                    + "de cuenta {} que pertenece a socio {}",
+                    socioIdToken, numeroCuenta, cuenta.getSocioId());
+            throw new AccesoCuentaAjenaException();
+        }
+
+        // 2. Validar movimiento + pertenencia a la cuenta
+        Movimiento movimiento = movimientoRepository.buscarPorNumeroOperacion(numeroOperacion)
+                .orElseThrow(() -> new MovimientoNoEncontradoException(numeroOperacion));
+
+        if (!movimiento.getCuentaAhorroId().equals(cuenta.getId())) {
+            log.warn("Movimiento {} no pertenece a cuenta {} — posible enumeración",
+                    numeroOperacion, numeroCuenta);
+            throw new MovimientoNoEncontradoException(numeroOperacion);
+        }
+
+        // 3. Construir el data map para el generador
+        Map<String, Object> datos = new HashMap<>();
+        datos.put("socio", socioQueryPort.obtenerDatosSocioParaPdf(cuenta.getSocioId()));
+        datos.put("cuenta", construirDatosCuenta(cuenta));
+        datos.put("movimiento", construirDatosMovimiento(movimiento));
+        datos.put("fechaEmision", LocalDateTime.now().format(FECHA_EMISION));
+
+        // 4. Generar PDF — propagar excepción del generador como GeneracionPDFException
+        try {
+            byte[] pdf = pdfGeneratorPort.generarPdf(TipoDocumento.COMPROBANTE_MOVIMIENTO, datos);
+            log.info("Comprobante generado: {} bytes para operacion {}", pdf.length, numeroOperacion);
+            return pdf;
+        } catch (GeneracionPDFException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Error inesperado generando comprobante operacion={}", numeroOperacion, e);
+            throw new GeneracionPDFException("Error al generar comprobante: " + e.getMessage());
+        }
+    }
+
+    private Map<String, Object> construirDatosCuenta(CuentaAhorro cuenta) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("numeroCuenta", cuenta.getNumeroCuenta());
+        m.put("tipoCuenta", cuenta.getTipoCuenta() != null ? cuenta.getTipoCuenta().name() : null);
+        m.put("moneda", cuenta.getMoneda() != null ? cuenta.getMoneda().name() : null);
+        return m;
+    }
+
+    private Map<String, Object> construirDatosMovimiento(Movimiento mov) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("numeroOperacion", mov.getNumeroOperacion());
+        m.put("tipo", mov.getTipo() != null ? mov.getTipo().name() : null);
+        m.put("monto", mov.getMonto());
+        m.put("saldoAnterior", mov.getSaldoAnterior());
+        m.put("saldoPosterior", mov.getSaldoPosterior());
+        m.put("descripcion", mov.getDescripcion());
+        m.put("referencia", mov.getReferencia());
+        m.put("canalOrigen", mov.getCanalOrigen() != null ? mov.getCanalOrigen().name() : null);
+        m.put("estado", mov.getEstado() != null ? mov.getEstado().name() : null);
+        m.put("fechaMovimiento", mov.getFechaMovimiento() != null
+                ? mov.getFechaMovimiento().format(FECHA_LEGIBLE)
+                : null);
+        return m;
+    }
+}

--- a/backend/src/main/java/com/tufondo/documentospdf/application/usecase/DescargarDocumentoUseCase.java
+++ b/backend/src/main/java/com/tufondo/documentospdf/application/usecase/DescargarDocumentoUseCase.java
@@ -93,6 +93,12 @@ public class DescargarDocumentoUseCase {
             case CONTRATO_ADHESION -> "bucket-contratos";
             case PAGARE -> "bucket-pagares";
             case TABLA_AMORTIZACION -> "bucket-creditos";
+            // COMPROBANTE_MOVIMIENTO (issue #220) NO se persiste — se regenera
+            // on-demand desde el movimiento. Si llega aquí, es un bug: un
+            // comprobante nunca debería estar guardado en la tabla documentos.
+            case COMPROBANTE_MOVIMIENTO -> throw new IllegalStateException(
+                    "COMPROBANTE_MOVIMIENTO no se persiste; este flujo solo aplica "
+                            + "a documentos almacenados. Use el endpoint /movimientos/{op}/comprobante.");
         };
     }
 }

--- a/backend/src/main/java/com/tufondo/documentospdf/domain/model/enums/TipoDocumento.java
+++ b/backend/src/main/java/com/tufondo/documentospdf/domain/model/enums/TipoDocumento.java
@@ -11,7 +11,13 @@ public enum TipoDocumento {
     CONTRATO_ADHESION("Contrato de Adhesión", true),
     PAGARE("Pagaré de Crédito", true),
     TABLA_AMORTIZACION("Tabla de Amortización", false),
-    CARTA_BENEFICIARIOS("Carta de Beneficiarios", false);
+    CARTA_BENEFICIARIOS("Carta de Beneficiarios", false),
+    /**
+     * Comprobante on-demand de un movimiento individual (issue #220).
+     * NO se persiste en MinIO — se regenera cada vez desde el movimiento
+     * almacenado (que es la fuente de verdad inmutable, RN-006).
+     */
+    COMPROBANTE_MOVIMIENTO("Comprobante de Movimiento", false);
 
     private final String descripcion;
     private final boolean requiereFirmaDigital;

--- a/backend/src/main/java/com/tufondo/documentospdf/infrastructure/pdf/OpenPdfGeneratorService.java
+++ b/backend/src/main/java/com/tufondo/documentospdf/infrastructure/pdf/OpenPdfGeneratorService.java
@@ -73,6 +73,7 @@ public class OpenPdfGeneratorService implements PdfGeneratorPort {
                 case PAGARE -> generarPagare(datos);
                 case TABLA_AMORTIZACION -> generarTablaAmortizacion(datos);
                 case CARTA_BENEFICIARIOS -> generarCartaBeneficiarios(datos);
+                case COMPROBANTE_MOVIMIENTO -> generarComprobanteMovimiento(datos);
             };
         } catch (GeneracionPDFException | FirmaDigitalException e) {
             throw e;
@@ -291,6 +292,82 @@ public class OpenPdfGeneratorService implements PdfGeneratorPort {
 
         document.close();
         return baos.toByteArray();
+    }
+
+    /**
+     * Genera comprobante on-demand de un movimiento individual (issue #220).
+     *
+     * <p>Diferencia clave con los otros generadores: NO se persiste en
+     * MinIO ni en la tabla {@code documentos}. El movimiento original
+     * (inmutable, RN-006) es la fuente de verdad — el PDF se reconstruye
+     * cada vez. Esto simplifica el flujo y evita duplicar storage.</p>
+     *
+     * <p>Datos esperados en el map:
+     * <ul>
+     *   <li>{@code socio}: map con nombreCompleto, cedula</li>
+     *   <li>{@code cuenta}: map con numeroCuenta, tipoCuenta, moneda</li>
+     *   <li>{@code movimiento}: map con numeroOperacion, tipo (DEPOSITO/RETIRO/...),
+     *       monto, saldoAnterior, saldoPosterior, fechaMovimiento, descripcion,
+     *       referencia, canalOrigen, estado</li>
+     *   <li>{@code fechaEmision}: timestamp legible de generación</li>
+     * </ul>
+     */
+    @SuppressWarnings("unchecked")
+    private byte[] generarComprobanteMovimiento(Map<String, Object> datos) throws DocumentException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Document document = new Document(PageSize.A4);
+        PdfWriter.getInstance(document, baos);
+        document.open();
+
+        Map<String, Object> socio = (Map<String, Object>) datos.get("socio");
+        Map<String, Object> cuenta = (Map<String, Object>) datos.get("cuenta");
+        Map<String, Object> mov = (Map<String, Object>) datos.get("movimiento");
+
+        addHeader(document, "COMPROBANTE DE MOVIMIENTO");
+        addFecha(safeStr(datos.get("fechaEmision")), document);
+
+        addSectionTitle(document, "Datos del Socio");
+        addKeyValue(document, "Nombre:", safeStr(socio != null ? socio.get("nombreCompleto") : null));
+        addKeyValue(document, "Cédula:", safeStr(socio != null ? socio.get("cedula") : null));
+
+        addSectionTitle(document, "Datos de la Cuenta");
+        addKeyValue(document, "Número de Cuenta:", safeStr(cuenta != null ? cuenta.get("numeroCuenta") : null));
+        addKeyValue(document, "Tipo de Cuenta:", safeStr(cuenta != null ? cuenta.get("tipoCuenta") : null));
+        addKeyValue(document, "Moneda:", safeStr(cuenta != null ? cuenta.get("moneda") : null));
+
+        addSectionTitle(document, "Detalle del Movimiento");
+        addKeyValue(document, "Número de Operación:", safeStr(mov != null ? mov.get("numeroOperacion") : null));
+        addKeyValue(document, "Tipo:", safeStr(mov != null ? mov.get("tipo") : null));
+        addKeyValue(document, "Fecha:", safeStr(mov != null ? mov.get("fechaMovimiento") : null));
+        addKeyValue(document, "Canal:", safeStr(mov != null ? mov.get("canalOrigen") : null));
+        addKeyValue(document, "Estado:", safeStr(mov != null ? mov.get("estado") : null));
+        if (mov != null && mov.get("descripcion") != null) {
+            addKeyValue(document, "Descripción:", safeStr(mov.get("descripcion")));
+        }
+        if (mov != null && mov.get("referencia") != null) {
+            addKeyValue(document, "Referencia:", safeStr(mov.get("referencia")));
+        }
+
+        addSectionTitle(document, "Importes");
+        addKeyValue(document, "Monto:", formatMonto(mov != null ? mov.get("monto") : null));
+        addKeyValue(document, "Saldo Anterior:", formatMonto(mov != null ? mov.get("saldoAnterior") : null));
+        addKeyValue(document, "Saldo Posterior:", formatMonto(mov != null ? mov.get("saldoPosterior") : null));
+
+        addEmptyLine(document);
+        addParagraph(document, "Este comprobante es un duplicado generado a partir del registro "
+                + "original del movimiento. El movimiento queda registrado en los libros del "
+                + "Fondo de Ahorro con carácter inmutable conforme a las normativas vigentes.",
+                NORMAL_FONT);
+
+        addWatermarkRobusto(document, "COMPROBANTE", datos);
+
+        document.close();
+        return baos.toByteArray();
+    }
+
+    /** Helper local: convierte un Object a String tratando null. */
+    private static String safeStr(Object o) {
+        return o == null ? "—" : o.toString();
     }
 
     /**

--- a/backend/src/test/java/com/tufondo/ahorros/application/usecase/GenerarComprobanteMovimientoUseCaseTest.java
+++ b/backend/src/test/java/com/tufondo/ahorros/application/usecase/GenerarComprobanteMovimientoUseCaseTest.java
@@ -1,0 +1,257 @@
+package com.tufondo.ahorros.application.usecase;
+
+import com.tufondo.ahorros.domain.exception.AccesoCuentaAjenaException;
+import com.tufondo.ahorros.domain.exception.CuentaAhorroNoEncontradaException;
+import com.tufondo.ahorros.domain.exception.MovimientoNoEncontradoException;
+import com.tufondo.ahorros.domain.model.CuentaAhorro;
+import com.tufondo.ahorros.domain.model.Movimiento;
+import com.tufondo.ahorros.domain.model.enums.CanalOrigen;
+import com.tufondo.ahorros.domain.model.enums.EstadoMovimiento;
+import com.tufondo.ahorros.domain.model.enums.Moneda;
+import com.tufondo.ahorros.domain.model.enums.TipoCuenta;
+import com.tufondo.ahorros.domain.model.enums.TipoMovimiento;
+import com.tufondo.ahorros.domain.repository.CuentaAhorroRepository;
+import com.tufondo.ahorros.domain.repository.MovimientoRepository;
+import com.tufondo.core.port.SocioQueryPort;
+import com.tufondo.documentospdf.application.port.PdfGeneratorPort;
+import com.tufondo.documentospdf.domain.exception.GeneracionPDFException;
+import com.tufondo.documentospdf.domain.model.enums.TipoDocumento;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests del use case que genera comprobantes PDF on-demand (issue #220 PR-B).
+ *
+ * <p>Cubre: validación IDOR (socio ajeno → AccesoCuentaAjenaException),
+ * cuenta inexistente, movimiento inexistente, movimiento que no pertenece
+ * a la cuenta (defensa contra enumeración), happy path y construcción
+ * correcta del data map para el generador, admin con paso libre, y
+ * propagación de GeneracionPDFException.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class GenerarComprobanteMovimientoUseCaseTest {
+
+    @Mock private CuentaAhorroRepository cuentaRepository;
+    @Mock private MovimientoRepository movimientoRepository;
+    @Mock private SocioQueryPort socioQueryPort;
+    @Mock private PdfGeneratorPort pdfGeneratorPort;
+
+    @InjectMocks
+    private GenerarComprobanteMovimientoUseCase useCase;
+
+    private UUID socioOwner;
+    private UUID socioAjeno;
+    private UUID cuentaId;
+    private CuentaAhorro cuenta;
+    private Movimiento movimiento;
+    private final String numeroCuenta = "AHO-2026-000001";
+    private final String numeroOperacion = "MOV-2026-000042";
+
+    @BeforeEach
+    void setUp() {
+        socioOwner = UUID.randomUUID();
+        socioAjeno = UUID.randomUUID();
+        cuentaId = UUID.randomUUID();
+
+        cuenta = CuentaAhorro.builder()
+                .id(cuentaId)
+                .numeroCuenta(numeroCuenta)
+                .socioId(socioOwner)
+                .tipoCuenta(TipoCuenta.AHORRO)
+                .moneda(Moneda.VES)
+                .build();
+
+        movimiento = Movimiento.builder()
+                .id(UUID.randomUUID())
+                .numeroOperacion(numeroOperacion)
+                .cuentaAhorroId(cuentaId)
+                .socioId(socioOwner)
+                .tipo(TipoMovimiento.DEPOSITO)
+                .monto(new BigDecimal("1500.50"))
+                .saldoAnterior(new BigDecimal("8000.00"))
+                .saldoPosterior(new BigDecimal("9500.50"))
+                .descripcion("Depósito caja")
+                .referencia("REF-XYZ-1")
+                .canalOrigen(CanalOrigen.SUCURSAL)
+                .estado(EstadoMovimiento.PROCESADO)
+                .fechaMovimiento(LocalDateTime.of(2026, 5, 17, 14, 30))
+                .fechaValor(LocalDate.of(2026, 5, 17))
+                .build();
+    }
+
+    @Test
+    @DisplayName("IDOR: socio ajeno intenta descargar comprobante → AccesoCuentaAjenaException, NO genera PDF")
+    void socio_ajeno_no_puede_descargar() {
+        when(cuentaRepository.buscarPorNumeroCuenta(numeroCuenta)).thenReturn(Optional.of(cuenta));
+
+        assertThatThrownBy(() ->
+                useCase.ejecutar(numeroCuenta, numeroOperacion, socioAjeno, false))
+                .isInstanceOf(AccesoCuentaAjenaException.class);
+
+        // CRÍTICO: no se debe llamar al generador ni al repo de movimientos
+        verify(movimientoRepository, never()).buscarPorNumeroOperacion(any());
+        verify(pdfGeneratorPort, never()).generarPdf(any(), any());
+    }
+
+    @Test
+    @DisplayName("Cuenta inexistente → CuentaAhorroNoEncontradaException")
+    void cuenta_inexistente_lanza() {
+        when(cuentaRepository.buscarPorNumeroCuenta(numeroCuenta)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                useCase.ejecutar(numeroCuenta, numeroOperacion, socioOwner, false))
+                .isInstanceOf(CuentaAhorroNoEncontradaException.class);
+
+        verify(pdfGeneratorPort, never()).generarPdf(any(), any());
+    }
+
+    @Test
+    @DisplayName("Movimiento inexistente → MovimientoNoEncontradoException")
+    void movimiento_inexistente_lanza() {
+        when(cuentaRepository.buscarPorNumeroCuenta(numeroCuenta)).thenReturn(Optional.of(cuenta));
+        when(movimientoRepository.buscarPorNumeroOperacion(numeroOperacion))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                useCase.ejecutar(numeroCuenta, numeroOperacion, socioOwner, false))
+                .isInstanceOf(MovimientoNoEncontradoException.class);
+    }
+
+    @Test
+    @DisplayName("Defensa contra enumeración: movimiento existe pero NO pertenece a la cuenta → MovimientoNoEncontradoException")
+    void movimiento_de_otra_cuenta_lanza_no_encontrado() {
+        // Movimiento de OTRA cuenta — no debe filtrar info al usuario
+        Movimiento movDeOtraCuenta = Movimiento.builder()
+                .id(UUID.randomUUID())
+                .numeroOperacion(numeroOperacion)
+                .cuentaAhorroId(UUID.randomUUID())  // ← cuenta distinta
+                .socioId(socioOwner)
+                .tipo(TipoMovimiento.DEPOSITO)
+                .monto(BigDecimal.TEN)
+                .saldoAnterior(BigDecimal.ZERO)
+                .saldoPosterior(BigDecimal.TEN)
+                .estado(EstadoMovimiento.PROCESADO)
+                .fechaMovimiento(LocalDateTime.now())
+                .build();
+
+        when(cuentaRepository.buscarPorNumeroCuenta(numeroCuenta)).thenReturn(Optional.of(cuenta));
+        when(movimientoRepository.buscarPorNumeroOperacion(numeroOperacion))
+                .thenReturn(Optional.of(movDeOtraCuenta));
+
+        assertThatThrownBy(() ->
+                useCase.ejecutar(numeroCuenta, numeroOperacion, socioOwner, false))
+                .isInstanceOf(MovimientoNoEncontradoException.class);
+
+        verify(pdfGeneratorPort, never()).generarPdf(any(), any());
+    }
+
+    @Test
+    @DisplayName("Happy path: socio dueño descarga su propio comprobante — devuelve bytes del PDF")
+    void happy_path_socio_propietario() {
+        byte[] pdfFalso = "%PDF-FALSO-1.4".getBytes();
+        when(cuentaRepository.buscarPorNumeroCuenta(numeroCuenta)).thenReturn(Optional.of(cuenta));
+        when(movimientoRepository.buscarPorNumeroOperacion(numeroOperacion))
+                .thenReturn(Optional.of(movimiento));
+        when(socioQueryPort.obtenerDatosSocioParaPdf(socioOwner)).thenReturn(datosSocioMock());
+        when(pdfGeneratorPort.generarPdf(eq(TipoDocumento.COMPROBANTE_MOVIMIENTO), any()))
+                .thenReturn(pdfFalso);
+
+        byte[] resultado = useCase.ejecutar(numeroCuenta, numeroOperacion, socioOwner, false);
+
+        assertThat(resultado).isSameAs(pdfFalso);
+    }
+
+    @Test
+    @DisplayName("Admin puede descargar comprobante de cualquier socio (paso libre por rol)")
+    void admin_puede_descargar_de_otro_socio() {
+        byte[] pdfFalso = "%PDF-ADMIN".getBytes();
+        when(cuentaRepository.buscarPorNumeroCuenta(numeroCuenta)).thenReturn(Optional.of(cuenta));
+        when(movimientoRepository.buscarPorNumeroOperacion(numeroOperacion))
+                .thenReturn(Optional.of(movimiento));
+        when(socioQueryPort.obtenerDatosSocioParaPdf(socioOwner)).thenReturn(datosSocioMock());
+        when(pdfGeneratorPort.generarPdf(eq(TipoDocumento.COMPROBANTE_MOVIMIENTO), any()))
+                .thenReturn(pdfFalso);
+
+        // socioAjeno (admin) descarga comprobante de cuenta de socioOwner — debe pasar
+        byte[] resultado = useCase.ejecutar(numeroCuenta, numeroOperacion, socioAjeno, true);
+
+        assertThat(resultado).isSameAs(pdfFalso);
+    }
+
+    @Test
+    @DisplayName("El data map enviado al generador contiene socio, cuenta, movimiento y fechaEmision")
+    void data_map_contiene_secciones_esperadas() {
+        when(cuentaRepository.buscarPorNumeroCuenta(numeroCuenta)).thenReturn(Optional.of(cuenta));
+        when(movimientoRepository.buscarPorNumeroOperacion(numeroOperacion))
+                .thenReturn(Optional.of(movimiento));
+        when(socioQueryPort.obtenerDatosSocioParaPdf(socioOwner)).thenReturn(datosSocioMock());
+        when(pdfGeneratorPort.generarPdf(any(), any())).thenReturn(new byte[]{0x01});
+
+        useCase.ejecutar(numeroCuenta, numeroOperacion, socioOwner, false);
+
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(pdfGeneratorPort).generarPdf(eq(TipoDocumento.COMPROBANTE_MOVIMIENTO), captor.capture());
+        Map<String, Object> datos = captor.getValue();
+
+        assertThat(datos).containsKeys("socio", "cuenta", "movimiento", "fechaEmision");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> cuentaMap = (Map<String, Object>) datos.get("cuenta");
+        assertThat(cuentaMap.get("numeroCuenta")).isEqualTo(numeroCuenta);
+        assertThat(cuentaMap.get("tipoCuenta")).isEqualTo("AHORRO");
+        assertThat(cuentaMap.get("moneda")).isEqualTo("VES");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> movMap = (Map<String, Object>) datos.get("movimiento");
+        assertThat(movMap.get("numeroOperacion")).isEqualTo(numeroOperacion);
+        assertThat(movMap.get("tipo")).isEqualTo("DEPOSITO");
+        assertThat(movMap.get("canalOrigen")).isEqualTo("SUCURSAL");
+        assertThat(movMap.get("estado")).isEqualTo("PROCESADO");
+        assertThat(movMap.get("monto")).isEqualTo(new BigDecimal("1500.50"));
+        assertThat(movMap.get("saldoAnterior")).isEqualTo(new BigDecimal("8000.00"));
+        assertThat(movMap.get("saldoPosterior")).isEqualTo(new BigDecimal("9500.50"));
+    }
+
+    @Test
+    @DisplayName("Si el generador lanza GeneracionPDFException, se propaga tal cual")
+    void propaga_excepcion_del_generador() {
+        when(cuentaRepository.buscarPorNumeroCuenta(numeroCuenta)).thenReturn(Optional.of(cuenta));
+        when(movimientoRepository.buscarPorNumeroOperacion(numeroOperacion))
+                .thenReturn(Optional.of(movimiento));
+        when(socioQueryPort.obtenerDatosSocioParaPdf(socioOwner)).thenReturn(datosSocioMock());
+        when(pdfGeneratorPort.generarPdf(any(), any()))
+                .thenThrow(new GeneracionPDFException("fallo de openpdf"));
+
+        assertThatThrownBy(() ->
+                useCase.ejecutar(numeroCuenta, numeroOperacion, socioOwner, false))
+                .isInstanceOf(GeneracionPDFException.class)
+                .hasMessageContaining("fallo de openpdf");
+    }
+
+    private Map<String, Object> datosSocioMock() {
+        Map<String, Object> m = new HashMap<>();
+        m.put("nombreCompleto", "Juan Pérez");
+        m.put("cedula", "V-12345678");
+        return m;
+    }
+}

--- a/frontend-web/src/app/(dashboard)/dashboard/cuentas/[numero]/movimientos/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/cuentas/[numero]/movimientos/page.tsx
@@ -484,6 +484,7 @@ export default function MovimientosPage() {
       <MovimientoDetailModal
         movimiento={selectedMov}
         moneda={moneda}
+        numeroCuenta={numeroCuenta}
         onClose={() => setSelectedMov(null)}
       />
     </div>

--- a/frontend-web/src/app/api/cuentas/[numeroCuenta]/movimientos/[numeroOperacion]/comprobante/route.ts
+++ b/frontend-web/src/app/api/cuentas/[numeroCuenta]/movimientos/[numeroOperacion]/comprobante/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+/**
+ * BFF para descargar el comprobante PDF de un movimiento (issue #220 PR-B).
+ *
+ * A diferencia de otros endpoints de documentos que devuelven JSON con una
+ * presigned URL, este pasa los bytes del PDF tal cual desde el backend al
+ * cliente. El backend no persiste el comprobante — lo regenera on-demand
+ * desde el movimiento (RN-006).
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ numeroCuenta: string; numeroOperacion: string }> }
+) {
+  try {
+    const accessToken = request.cookies.get('access_token')?.value;
+    if (!accessToken) {
+      return NextResponse.json({ message: 'No autenticado' }, { status: 401 });
+    }
+
+    const { numeroCuenta, numeroOperacion } = await params;
+
+    const backendResponse = await fetch(
+      `${BACKEND_URL}/api/v1/cuentas/${encodeURIComponent(numeroCuenta)}/movimientos/${encodeURIComponent(numeroOperacion)}/comprobante`,
+      {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+        },
+        // No 'Content-Type' aquí — es una GET sin body
+      }
+    );
+
+    if (!backendResponse.ok) {
+      // El backend devuelve JSON en caso de error (gracias al exception handler)
+      const errorBody = await backendResponse.text();
+      let errorMessage = `Error al descargar comprobante (${backendResponse.status})`;
+      try {
+        const parsed = JSON.parse(errorBody);
+        errorMessage = parsed.message || parsed.error || errorMessage;
+      } catch {
+        // Body no es JSON — usar el text crudo si no está vacío
+        if (errorBody) errorMessage = errorBody.substring(0, 200);
+      }
+      return NextResponse.json(
+        { message: errorMessage },
+        { status: backendResponse.status }
+      );
+    }
+
+    // Pasar bytes del PDF al cliente
+    const pdfBuffer = await backendResponse.arrayBuffer();
+    const filename = `Comprobante_${numeroOperacion}.pdf`;
+
+    return new NextResponse(pdfBuffer, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+        'Cache-Control': 'no-store, no-cache, must-revalidate, private',
+      },
+    });
+
+  } catch (error) {
+    console.error('Comprobante movimiento error:', error);
+    return NextResponse.json(
+      { message: 'Error interno del servidor' },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend-web/src/components/features/cuentas/movimiento-detail-modal.test.tsx
+++ b/frontend-web/src/components/features/cuentas/movimiento-detail-modal.test.tsx
@@ -1,15 +1,22 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import {
   MovimientoDetailModal,
   type MovimientoDetail,
 } from '@/components/features/cuentas/movimiento-detail-modal';
 
+// Sonner — mock para no contar con DOM extra en los tests
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 /**
- * Tests del modal de detalle de movimiento (issue #220).
- * Cubre: render condicional, secciones del modal, cálculo del delta,
- * etiqueta de canal, botón de comprobante deshabilitado (placeholder
- * hasta PR-B con endpoint backend).
+ * Tests del modal de detalle de movimiento (issue #220 PR-A + PR-B).
+ * Cubre: render condicional, secciones del modal, etiquetas legibles,
+ * descarga del comprobante PDF (botón habilitado, fetch, toast).
  */
 
 const movimientoDeposito: MovimientoDetail = {
@@ -44,12 +51,12 @@ const movimientoRetiro: MovimientoDetail = {
 
 describe('MovimientoDetailModal', () => {
   it('no renderiza cuando movimiento es null', () => {
-    render(<MovimientoDetailModal movimiento={null} moneda="VES" onClose={vi.fn()} />);
+    render(<MovimientoDetailModal movimiento={null} moneda="VES" numeroCuenta="AHO-2026-000001" onClose={vi.fn()} />);
     expect(screen.queryByText(/Detalle del movimiento/i)).toBeNull();
   });
 
   it('renderiza secciones principales cuando hay movimiento (depósito)', () => {
-    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" onClose={vi.fn()} />);
+    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" numeroCuenta="AHO-2026-000001" onClose={vi.fn()} />);
 
     expect(screen.getByText(/Detalle del movimiento/i)).toBeTruthy();
     // Header con el numero de operación
@@ -62,51 +69,118 @@ describe('MovimientoDetailModal', () => {
   });
 
   it('muestra signo + y monto formateado para depósitos', () => {
-    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" onClose={vi.fn()} />);
+    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" numeroCuenta="AHO-2026-000001" onClose={vi.fn()} />);
     // El monto se muestra con signo + y prefijo Bs (VES)
     expect(screen.getByText(/\+ Bs/)).toBeTruthy();
   });
 
   it('muestra signo − y monto formateado para retiros', () => {
-    render(<MovimientoDetailModal movimiento={movimientoRetiro} moneda="VES" onClose={vi.fn()} />);
+    render(<MovimientoDetailModal movimiento={movimientoRetiro} moneda="VES" numeroCuenta="AHO-2026-000001" onClose={vi.fn()} />);
     expect(screen.getByText(/− Bs/)).toBeTruthy();
   });
 
   it('mapea canal CAJA a etiqueta legible "Caja presencial"', () => {
-    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" onClose={vi.fn()} />);
+    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" numeroCuenta="AHO-2026-000001" onClose={vi.fn()} />);
     expect(screen.getByText(/Caja presencial/i)).toBeTruthy();
   });
 
   it('mapea canal WEB a etiqueta "Banca en línea"', () => {
-    render(<MovimientoDetailModal movimiento={movimientoRetiro} moneda="VES" onClose={vi.fn()} />);
+    render(<MovimientoDetailModal movimiento={movimientoRetiro} moneda="VES" numeroCuenta="AHO-2026-000001" onClose={vi.fn()} />);
     expect(screen.getByText(/Banca en línea/i)).toBeTruthy();
   });
 
   it('estado PENDIENTE se renderiza con su etiqueta legible', () => {
-    render(<MovimientoDetailModal movimiento={movimientoRetiro} moneda="VES" onClose={vi.fn()} />);
+    render(<MovimientoDetailModal movimiento={movimientoRetiro} moneda="VES" numeroCuenta="AHO-2026-000001" onClose={vi.fn()} />);
     expect(screen.getByText('Pendiente')).toBeTruthy();
   });
 
   it('omite la sección de referencia externa cuando es null', () => {
-    render(<MovimientoDetailModal movimiento={movimientoRetiro} moneda="VES" onClose={vi.fn()} />);
+    render(<MovimientoDetailModal movimiento={movimientoRetiro} moneda="VES" numeroCuenta="AHO-2026-000001" onClose={vi.fn()} />);
     expect(screen.queryByText(/Referencia externa/i)).toBeNull();
   });
 
-  it('botón "Descargar comprobante" está deshabilitado (placeholder PR-B)', () => {
-    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" onClose={vi.fn()} />);
-    const btn = screen.getByRole('button', { name: /descargar comprobante/i });
-    expect(btn.hasAttribute('disabled')).toBe(true);
+  it('botón "Descargar comprobante" está habilitado con aria-label descriptivo', () => {
+    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" numeroCuenta="AHO-2026-000001" onClose={vi.fn()} />);
+    const btn = screen.getByRole('button', { name: /descargar comprobante pdf del movimiento op-2026-000001/i });
+    expect(btn.hasAttribute('disabled')).toBe(false);
   });
 
   it('botón Cerrar invoca onClose', () => {
     const onClose = vi.fn();
-    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" onClose={onClose} />);
+    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" numeroCuenta="AHO-2026-000001" onClose={onClose} />);
     fireEvent.click(screen.getByRole('button', { name: /cerrar/i }));
     expect(onClose).toHaveBeenCalled();
   });
 
   it('formatea moneda USD con prefijo $ en lugar de Bs', () => {
-    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="USD" onClose={vi.fn()} />);
+    render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="USD" numeroCuenta="AHO-2026-000001" onClose={vi.fn()} />);
     expect(screen.getByText(/\+ \$/)).toBeTruthy();
+  });
+
+  describe('descarga de comprobante (PR-B)', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      // jsdom no implementa URL.createObjectURL / revokeObjectURL
+      Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        value: vi.fn(() => 'blob:mock-url'),
+      });
+      Object.defineProperty(URL, 'revokeObjectURL', {
+        configurable: true,
+        value: vi.fn(),
+      });
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('click llama al BFF con la URL correcta', async () => {
+      const mockBlob = new Blob([new Uint8Array([0x25, 0x50, 0x44, 0x46])], { type: 'application/pdf' });
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" numeroCuenta="AHO-2026-000001" onClose={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: /descargar comprobante pdf/i }));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/api/cuentas/AHO-2026-000001/movimientos/OP-2026-000001/comprobante',
+        );
+      });
+    });
+
+    it('si BFF devuelve error, muestra toast.error con el mensaje del backend', async () => {
+      const { toast } = await import('sonner');
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ message: 'Acceso denegado' }),
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" numeroCuenta="AHO-2026-000001" onClose={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: /descargar comprobante pdf/i }));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith('Acceso denegado');
+      });
+    });
+
+    it('si fetch lanza (red caída), muestra toast.error genérico', async () => {
+      const { toast } = await import('sonner');
+      const fetchMock = vi.fn().mockRejectedValue(new Error('NetworkError'));
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      render(<MovimientoDetailModal movimiento={movimientoDeposito} moneda="VES" numeroCuenta="AHO-2026-000001" onClose={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: /descargar comprobante pdf/i }));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith('Error de red al descargar el comprobante');
+      });
+    });
   });
 });

--- a/frontend-web/src/components/features/cuentas/movimiento-detail-modal.tsx
+++ b/frontend-web/src/components/features/cuentas/movimiento-detail-modal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -8,17 +9,16 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { ArrowDownToLine, ArrowUpFromLine, ArrowRight, FileDown } from 'lucide-react';
+import { ArrowDownToLine, ArrowUpFromLine, ArrowRight, FileDown, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
 
 /**
  * Modal de detalle de un movimiento (issue #220).
  *
- * Muestra todos los campos relevantes de un movimiento individual
- * agrupados en secciones (datos básicos, referencias, saldos, canal).
- *
- * Botón "Descargar comprobante" queda como placeholder deshabilitado
- * — el endpoint backend que genera el comprobante PDF se entregará en
- * un PR-B siguiente del mismo issue.
+ * Muestra todos los campos del movimiento agrupados en secciones (datos
+ * básicos, referencias, saldos, canal). El botón "Descargar comprobante"
+ * llama al BFF `/api/cuentas/{n}/movimientos/{op}/comprobante` que a su
+ * vez pide al backend regenerar el PDF on-demand (issue #220 PR-B).
  */
 
 export interface MovimientoDetail {
@@ -39,6 +39,8 @@ export interface MovimientoDetail {
 interface Props {
   movimiento: MovimientoDetail | null;
   moneda: string;
+  /** Número de cuenta para construir la URL del comprobante. */
+  numeroCuenta: string;
   onClose: () => void;
 }
 
@@ -103,11 +105,51 @@ const etiquetaEstado = (estado: string): { texto: string; clase: string } => {
   }
 };
 
-export function MovimientoDetailModal({ movimiento, moneda, onClose }: Props) {
+export function MovimientoDetailModal({ movimiento, moneda, numeroCuenta, onClose }: Props) {
   const open = movimiento !== null;
   const esDeposito = movimiento?.tipo === 'DEPOSITO';
   const delta = movimiento ? movimiento.saldoPosterior - movimiento.saldoAnterior : 0;
   const estadoUi = movimiento ? etiquetaEstado(movimiento.estado) : null;
+  const [descargando, setDescargando] = useState(false);
+
+  const handleDescargar = async () => {
+    if (!movimiento || descargando) return;
+    setDescargando(true);
+    try {
+      const res = await fetch(
+        `/api/cuentas/${encodeURIComponent(numeroCuenta)}/movimientos/${encodeURIComponent(movimiento.numeroOperacion)}/comprobante`,
+      );
+      if (!res.ok) {
+        let msg = `No se pudo descargar el comprobante (HTTP ${res.status})`;
+        try {
+          const body = await res.json();
+          if (body?.message) msg = body.message;
+        } catch {
+          /* respuesta sin body JSON */
+        }
+        toast.error(msg);
+        return;
+      }
+      // Disparar descarga del blob via <a download>
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `Comprobante_${movimiento.numeroOperacion}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      // Liberar memoria del object URL tras un pequeño delay para que el navegador
+      // tenga tiempo de iniciar la descarga
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
+      toast.success('Comprobante descargado');
+    } catch (err) {
+      console.error('Error descargando comprobante:', err);
+      toast.error('Error de red al descargar el comprobante');
+    } finally {
+      setDescargando(false);
+    }
+  };
 
   return (
     <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
@@ -236,12 +278,22 @@ export function MovimientoDetailModal({ movimiento, moneda, onClose }: Props) {
             <div className="pt-4 border-t border-slate-100 flex flex-col sm:flex-row gap-2 sm:justify-end">
               <Button
                 variant="outline"
-                disabled
-                title="Disponible próximamente — pendiente endpoint backend (issue #220 PR-B)"
+                onClick={handleDescargar}
+                disabled={descargando}
+                aria-label={`Descargar comprobante PDF del movimiento ${movimiento.numeroOperacion}`}
                 className="gap-2"
               >
-                <FileDown className="w-4 h-4" aria-hidden="true" />
-                Descargar comprobante
+                {descargando ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+                    Generando...
+                  </>
+                ) : (
+                  <>
+                    <FileDown className="w-4 h-4" aria-hidden="true" />
+                    Descargar comprobante
+                  </>
+                )}
               </Button>
               <Button onClick={onClose} className="bg-[#16A34A] hover:bg-green-700">
                 Cerrar


### PR DESCRIPTION
Cierra el resto de #220 funcional (el botón "Descargar comprobante" del modal PR-A queda funcional). Solo queda PR-C opcional (filtro de monto server-side).

## Problema

En PR-A (#246) el modal de detalle quedó con el botón **"Descargar comprobante"** presente pero deshabilitado y un tooltip que decía "pendiente endpoint backend". Este PR implementa ese endpoint y conecta el botón.

## Diseño: PDF on-demand sin storage

A diferencia de los demás generadores del módulo `documentospdf` (estado de cuenta, constancia, contrato, pagaré, tabla de amortización, carta de beneficiarios) que persisten en MinIO + tabla `documentos` con malware scan + presigned URL, el comprobante de movimiento **no se persiste**:

| Decisión | Justificación |
|---|---|
| No persiste en MinIO | El movimiento es inmutable (RN-006). El PDF se reconstruye 1-a-1 desde la BD cada vez. |
| No registra en tabla `documentos` | No hay valor en auditar comprobantes — el movimiento original ya está auditado. |
| Sin malware scan | El PDF lo generamos nosotros; no hay user-uploaded content. |
| Sin presigned URL | El backend devuelve los bytes directamente con `Content-Disposition: attachment`. |

**Costo**: ~ms de CPU por descarga. **Beneficio**: cero infraestructura nueva, sin URLs que expiran, sin escaneos innecesarios.

## Cambios backend

### Enum
- `TipoDocumento.COMPROBANTE_MOVIMIENTO` (sin firma digital)

### Generador
- `OpenPdfGeneratorService.generarComprobanteMovimiento()`: secciones Datos del Socio, Datos de la Cuenta, Detalle del Movimiento (incluye canal/estado/referencia/descripción), Importes (anterior/monto/posterior), watermark "COMPROBANTE"
- Fix de switch exhaustivo en `DescargarDocumentoUseCase.obtenerBucketPorTipo`: añadir `COMPROBANTE_MOVIMIENTO` como case que lanza `IllegalStateException` con mensaje explicativo (si llega allí es un bug — los comprobantes no se persisten)

### Use case (módulo `ahorros`)
`GenerarComprobanteMovimientoUseCase.ejecutar(numeroCuenta, numeroOperacion, socioIdToken, isAdmin) → byte[]`:
1. Busca cuenta → IDOR check (socioOwner vs token; admin paso libre)
2. Busca movimiento → verifica que pertenece a la cuenta (**defensa contra enumeración**: si el movimiento existe pero es de otra cuenta, devuelve `MovimientoNoEncontradoException` — no `AccesoDenegado` — para no filtrar info)
3. Carga datos del socio vía `SocioQueryPort`
4. Construye data map y llama al generador
5. Devuelve bytes

### Endpoint
`GET /api/v1/cuentas/{numeroCuenta}/movimientos/{numeroOperacion}/comprobante`
- `Content-Type: application/pdf`
- `Content-Disposition: attachment; filename="Comprobante_{numeroOperacion}.pdf"`
- `Cache-Control: no-store, no-cache, must-revalidate, private`

## Cambios frontend

### BFF route
`/api/cuentas/{numeroCuenta}/movimientos/{numeroOperacion}/comprobante`
- Proxy a backend con `Authorization: Bearer {access_token}` (cookie HttpOnly)
- Pasa bytes binarios al cliente (NO JSON como otras rutas de documentos): `arrayBuffer()` del backend → `NextResponse` con headers de PDF
- Manejo defensivo: si el backend devuelve error, intenta parsear JSON y forwardear el `message` con el status code original

### MovimientoDetailModal
- Nuevo prop `numeroCuenta` (necesario para la URL del endpoint)
- Handler `handleDescargar`: `fetch` → `blob` → `<a download>` → `click()` → `revokeObjectURL` (con delay para que el navegador inicie la descarga)
- Estados de UI: `disabled` mientras descarga + texto "Generando…" + spinner; `toast.error` con mensaje del backend cuando falla; `toast.success` cuando completa
- `aria-label` descriptivo con el número de operación

## Tests

### Backend (8 nuevos)
- `IDOR`: socio ajeno → `AccesoCuentaAjenaException`, NO genera PDF
- Cuenta inexistente → `CuentaAhorroNoEncontradaException`
- Movimiento inexistente → `MovimientoNoEncontradoException`
- **Defensa contra enumeración**: movimiento existe pero pertenece a otra cuenta → `MovimientoNoEncontradoException`
- Happy path: socio dueño → devuelve bytes
- Admin paso libre: descarga comprobante de otro socio
- Construcción del data map (`socio`, `cuenta`, `movimiento`, `fechaEmision` con todos los campos esperados)
- Propagación de `GeneracionPDFException`

### Frontend (3 nuevos + 1 actualizado)
- Botón ahora **habilitado** con `aria-label` (antes era `disabled`)
- Click llama al BFF con la URL exacta
- Error del BFF → `toast.error` con mensaje del backend
- `fetch` que lanza → `toast.error` genérico de red

## Verificación

- [x] `mvn test`: **390 passing / 0 failures** (+8 nuevos; 382→390)
- [x] `npm run build`: OK
- [x] `npm test`: **494 passing / 17 preexistentes failing (511 total)**
  - +3 nuevos verdes del modal
  - 17 failing siguen siendo preexistentes en `develop` (admin/reportes/estado-cuenta) — no regresión

## Test plan QA

- [ ] Logueado como socio: `/dashboard/cuentas/{n}/movimientos` → click fila → modal abre
- [ ] Click "Descargar comprobante" → spinner "Generando…" → descarga `Comprobante_{numeroOperacion}.pdf`
- [ ] Abrir el PDF: tiene secciones Datos del Socio, Datos de la Cuenta, Detalle del Movimiento, Importes
- [ ] Como socio, intentar descargar comprobante de cuenta de otro socio (manualmente armando la URL) → 403/404 + toast
- [ ] Como admin (rol ADMIN o ANALISTA según permisos): puede descargar comprobantes de cualquier cuenta
- [ ] Cerrar red (DevTools → Offline) → toast "Error de red al descargar el comprobante"
- [ ] Mobile: el botón muestra spinner correctamente, no rompe layout

## Próximos pasos del #220

Solo queda **PR-C (opcional)**: mover el filtro de monto (hoy client-side sobre la página actual) a server-side extendiendo el endpoint de movimientos con params `montoMinimo`/`montoMaximo`. Solo hace falta si QA dice que filtrar 10 items en cliente no es suficiente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)