### PR TITLE
fix(cuentas): spinner infinito en /movimientos (#248)

### DIFF
--- a/frontend-web/src/app/(dashboard)/dashboard/cuentas/[numero]/movimientos/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/cuentas/[numero]/movimientos/page.tsx
@@ -112,6 +112,10 @@ export default function MovimientosPage() {
       } catch (err) {
         console.error('Error al cargar cuenta:', err);
         setError('Error al cargar los datos de la cuenta');
+      } finally {
+        // Issue #248: si NO se llama aquí, `loading` queda en true para
+        // siempre y la página se atasca en el spinner inicial.
+        setLoading(false);
       }
     }
 


### PR DESCRIPTION
Closes #248.

## TL;DR — Hotfix de 1 línea

\`page.tsx\` de \`/dashboard/cuentas/{n}/movimientos\` queda **infinitamente** en el spinner inicial. \`loading\` se inicializa en \`true\` y **nunca se actualiza a \`false\`** — el render bloquea con \`if (loading) return <Spinner/>\` antes de mostrar la tabla.

\`\`\`diff
 async function cargarCuenta() {
   try {
     const res = await cuentasApi.getCuenta(numeroCuenta);
     setCuenta(res.data);
   } catch (err) {
     console.error('Error al cargar cuenta:', err);
     setError('Error al cargar los datos de la cuenta');
+  } finally {
+    setLoading(false);
   }
 }
\`\`\`

## Historia (NO es regresión)

- Bug presente desde commit \`5768f9e7\` (issue #42, creación original de la página).
- No se había detectado porque la página está enterrada a 3 clicks de profundidad (Cuentas → Ver Detalle → Ver Detalle Saldo → Ver Todos los Movimientos).
- Surgió en QA tras el deploy de #246/#247 que son los primeros que invitan al usuario a usarla activamente (modal de detalle + descarga de comprobante PDF).

## Por qué sin test unitario

- El fix es 1 línea, riesgo cero
- Testear \`page.tsx\` requiere mockear \`useAuthStore\` + \`cuentasApi\` (~100 líneas de setup) para validar 1 línea de fix
- Verificación manual es obvia: cargar la página y ver que carga

## Test plan QA

- [ ] Login como socio → Cuentas → Ver Detalle (cualquier cuenta) → Ver Detalle Saldo → **Ver Todos los Movimientos**
- [ ] La tabla de movimientos **renderiza** (no spinner infinito)
- [ ] El modal de detalle (PR-A #246) sigue funcionando al click en fila
- [ ] La descarga de comprobante PDF (PR-B #247) sigue funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)