### PR TITLE
fix(deploy-qa): verificación BD idempotente vía \gexec (evita 'already exists')

### DIFF
--- a/infrastructure/scripts/deploy-qa.sh
+++ b/infrastructure/scripts/deploy-qa.sh
@@ -86,11 +86,26 @@ docker tag fatrans-frontend-qa:latest fatrans-frontend-public-qa:latest
 docker tag fatrans-frontend-qa:latest fatrans-frontend-protected-qa:latest
 log "   Frontend build OK"
 
-# 5. Crear DB fondo_qa si no existe
+# 5. Crear DB fondo_qa si no existe (idempotente)
+#
+# Implementación anterior usaba `psql -tc ... | grep -q 1 || psql -c CREATE`
+# y fallaba intermitentemente con `ERROR: database "fondo_qa" already exists`:
+# con `set -o pipefail` activo, si el primer `docker exec` retornaba exit != 0
+# por cualquier transient (network blip, reattach), el pipe completo era != 0
+# *aunque grep matcheara*, y se ejecutaba el CREATE de todas formas. PostgreSQL
+# además NO soporta `CREATE DATABASE IF NOT EXISTS`, así que el CREATE en una
+# BD ya existente revienta con exit 1 y `set -e` aborta el deploy.
+#
+# Solución: psql `\gexec` — single round-trip, sin pipes, nativamente
+# idempotente. Si la BD existe, el SELECT devuelve 0 filas y `\gexec` no
+# ejecuta nada; si no existe, el SELECT devuelve "CREATE DATABASE fondo_qa"
+# y `\gexec` lo ejecuta. Verificado en QA: ambos casos exit=0.
 log "→ Verificando base de datos fondo_qa..."
-docker exec fatrans-postgres psql -U app -d fondo -tc \
-  "SELECT 1 FROM pg_database WHERE datname='fondo_qa'" 2>/dev/null | grep -q 1 \
-  || docker exec fatrans-postgres psql -U app -d fondo -c "CREATE DATABASE fondo_qa" >> "$LOG_FILE" 2>&1
+docker exec -i fatrans-postgres psql -U app -d fondo >> "$LOG_FILE" 2>&1 <<'SQL'
+SELECT 'CREATE DATABASE fondo_qa'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname='fondo_qa')
+\gexec
+SQL
 log "   DB fondo_qa OK"
 
 # 6. Detener SOLO contenedores QA (nunca tocar prod)


### PR DESCRIPTION
## Síntoma

El último deploy a QA (run #26001205712, tras merge de #249) **falló** con:

\`\`\`
[2026-05-17 22:09:12] → Verificando base de datos fondo_qa...
ERROR: database \"fondo_qa\" already exists
2026/05/17 20:09:12 Process exited with status 1
\`\`\`

El job \`Deploy a QA (qa.fatrans.com.ve)\` reportó *failure* en el step \`Deploy vía SSH al VPS\`.

## Causa raíz

\`infrastructure/scripts/deploy-qa.sh\` línea 91-93:
\`\`\`bash
docker exec fatrans-postgres psql -U app -d fondo -tc \
  \"SELECT 1 FROM pg_database WHERE datname='fondo_qa'\" 2>/dev/null | grep -q 1 \
  || docker exec fatrans-postgres psql -U app -d fondo -c \"CREATE DATABASE fondo_qa\" >> \"\$LOG_FILE\" 2>&1
\`\`\`

Con \`set -o pipefail\` activo:

1. Si el primer \`docker exec\` retorna exit != 0 por cualquier transient (reattach del container, network blip, etc.) **el pipe completo es != 0 aunque \`grep -q 1\` matcheara**.
2. Eso dispara el \`||\` y ejecuta el \`CREATE\`.
3. PostgreSQL **NO soporta \`CREATE DATABASE IF NOT EXISTS\`** → revienta con \"already exists\" si la BD ya está.
4. \`set -e\` aborta el script con exit 1.

**Verificado**: hoy en el VPS la BD \`fondo_qa\` existe y el comando \`psql -tc ... | grep -q 1\` matchea correctamente. La falla fue intermitente.

## Fix

Reemplaza el pipe + grep por **psql \`\gexec\`** — single round-trip, sin pipes, sin race condition, nativamente idempotente:

\`\`\`bash
docker exec -i fatrans-postgres psql -U app -d fondo >> \"\$LOG_FILE\" 2>&1 <<'SQL'
SELECT 'CREATE DATABASE fondo_qa'
WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname='fondo_qa')
\gexec
SQL
\`\`\`

- BD existe → SELECT devuelve 0 filas → \`\gexec\` no ejecuta nada → exit 0
- BD no existe → SELECT devuelve la sentencia CREATE → \`\gexec\` la ejecuta → exit 0

**Verificado en QA** con BD existente Y BD ficticia (creada + dropped): ambos casos exit=0.

## Acción operacional adicional

⚠️ El script ejecutado por GitHub Actions vive en \`/opt/fatrans-qa/deploy-qa.sh\` (VPS) y **está desincronizado** del versionado en el repo (hashes distintos, comprobado). El header del script ya advierte:

> Fuente de verdad versionada: \`infrastructure/scripts/deploy-qa.sh\`. El archivo en \`/opt/fatrans-qa/\` debe mantenerse sincronizado.

Para que este fix surta efecto inmediato hay que \`cp\` del repo del VPS (\`/opt/fatrans/backend/infrastructure/scripts/deploy-qa.sh\`) a \`/opt/fatrans-qa/deploy-qa.sh\` después del merge. **Lo voy a hacer manualmente vía vps_exec una vez se mergee.**

## Mejora futura (out of scope)

Que el propio \`deploy-qa.sh\` se auto-sincronice al inicio (después del \`git pull\`) para eliminar esta desincronización a futuro:

\`\`\`bash
# Después del git pull:
cp \"\$REPO_DIR/infrastructure/scripts/deploy-qa.sh\" \"\$QA_DIR/deploy-qa.sh\"
chmod +x \"\$QA_DIR/deploy-qa.sh\"
exec \"\$QA_DIR/deploy-qa.sh\" \"\$@\"  # re-exec con la versión actualizada
\`\`\`

Lo dejo para un PR separado por scope acotado.

## Test plan post-merge

1. Mergear este PR
2. Yo sincronizo el script al VPS con \`vps_exec\` (\`cp\` del repo a \`/opt/fatrans-qa/\`)
3. Re-disparar el deploy (push trivial o re-run del workflow del run #26001205712)
4. Verificar logs: \`Verificando base de datos fondo_qa...\` → \`DB fondo_qa OK\` sin error
5. Deploy completa el resto de steps hasta \`Deploy QA completado\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)