### PR TITLE
feat(legal): declaración jurada LOCDOFT obligatoria en registro (#218 PR-B)

### DIFF
--- a/backend/src/main/java/com/tufondo/socios/application/dto/SolicitudRegistroRequestDTO.java
+++ b/backend/src/main/java/com/tufondo/socios/application/dto/SolicitudRegistroRequestDTO.java
@@ -98,6 +98,16 @@ public class SolicitudRegistroRequestDTO {
     @AssertTrue(message = "Debe aceptar la política de protección de datos personales")
     private Boolean aceptaLopdp;
 
+    /**
+     * Declaración jurada LOCDOFT (origen lícito de fondos). Issue #218 PR-B.
+     * Obligación de la Ley Orgánica contra la Delincuencia Organizada y
+     * Financiamiento al Terrorismo — los sujetos obligados (Fatrans como
+     * fondo de ahorro) deben recolectar esta declaración al onboarding.
+     */
+    @NotNull(message = "Debe aceptar la declaración LOCDOFT")
+    @AssertTrue(message = "Debe declarar que los fondos provienen de actividades lícitas (LOCDOFT)")
+    private Boolean aceptaLocdoft;
+
     // ---- Metadatos opcionales de auditoría LOPDP ----
     // Provienen del BFF (que ya captura x-forwarded-for + user-agent).
     // El controller usa estos valores como fuente preferida y, si vienen vacíos,

--- a/backend/src/main/java/com/tufondo/socios/application/dto/SolicitudRegistroResponseDTO.java
+++ b/backend/src/main/java/com/tufondo/socios/application/dto/SolicitudRegistroResponseDTO.java
@@ -69,6 +69,8 @@ public class SolicitudRegistroResponseDTO {
     // --- Consentimientos legales ---
     private Boolean aceptaTerminos;
     private Boolean aceptaLopdp;
+    /** Declaración LOCDOFT (#218 PR-B) — origen lícito de fondos. */
+    private Boolean aceptaLocdoft;
 
     // --- Estado y trazabilidad de revisión ---
     private EstadoSolicitud estado;

--- a/backend/src/main/java/com/tufondo/socios/application/usecase/CrearSolicitudRegistroUseCase.java
+++ b/backend/src/main/java/com/tufondo/socios/application/usecase/CrearSolicitudRegistroUseCase.java
@@ -65,11 +65,16 @@ public class CrearSolicitudRegistroUseCase {
                 .emergenciaParentesco(request.getEmergenciaParentesco())
                 .aceptaTerminos(request.getAceptaTerminos())
                 .aceptaLopdp(request.getAceptaLopdp())
+                .aceptaLocdoft(request.getAceptaLocdoft())
                 .ipRegistro(request.getIpRegistro())
                 .userAgentRegistro(request.getUserAgentRegistro())
                 // Sello de tiempo del consentimiento LOPDP: SOLO si el usuario aceptó.
                 // No confiamos en el cliente para esto — siempre Instant.now() server-side.
                 .consentLopdpTimestamp(Boolean.TRUE.equals(request.getAceptaLopdp()) ? Instant.now() : null)
+                // Sello de tiempo del consentimiento LOCDOFT (#218 PR-B). Mismo patrón.
+                // Trazabilidad legal: junto con ipRegistro + userAgentRegistro forma la
+                // prueba documental de la declaración jurada del origen de fondos.
+                .consentLocdoftTimestamp(Boolean.TRUE.equals(request.getAceptaLocdoft()) ? Instant.now() : null)
                 .estado(EstadoSolicitud.PENDIENTE)
                 .fechaSolicitud(LocalDateTime.now())
                 .build();

--- a/backend/src/main/java/com/tufondo/socios/application/usecase/SolicitudRegistroDTOMapper.java
+++ b/backend/src/main/java/com/tufondo/socios/application/usecase/SolicitudRegistroDTOMapper.java
@@ -51,6 +51,7 @@ public class SolicitudRegistroDTOMapper {
                 // Consentimientos
                 .aceptaTerminos(solicitud.getAceptaTerminos())
                 .aceptaLopdp(solicitud.getAceptaLopdp())
+                .aceptaLocdoft(solicitud.getAceptaLocdoft())
                 // Trazabilidad
                 .estado(solicitud.getEstado())
                 .fechaSolicitud(solicitud.getFechaSolicitud())

--- a/backend/src/main/java/com/tufondo/socios/domain/model/SolicitudRegistro.java
+++ b/backend/src/main/java/com/tufondo/socios/domain/model/SolicitudRegistro.java
@@ -48,10 +48,13 @@ public class SolicitudRegistro {
     private String motivoRechazo;
     private Boolean aceptaTerminos;
     private Boolean aceptaLopdp;
-    // ---- Auditoría LOPDP ----
+    /** Declaración jurada LOCDOFT (origen lícito de fondos). Issue #218 PR-B. */
+    private Boolean aceptaLocdoft;
+    // ---- Auditoría LOPDP / LOCDOFT ----
     private String ipRegistro;
     private String userAgentRegistro;
     private Instant consentLopdpTimestamp;
+    private Instant consentLocdoftTimestamp;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -116,12 +119,16 @@ public class SolicitudRegistro {
     public void setAceptaTerminos(Boolean aceptaTerminos) { this.aceptaTerminos = aceptaTerminos; }
     public Boolean getAceptaLopdp() { return aceptaLopdp; }
     public void setAceptaLopdp(Boolean aceptaLopdp) { this.aceptaLopdp = aceptaLopdp; }
+    public Boolean getAceptaLocdoft() { return aceptaLocdoft; }
+    public void setAceptaLocdoft(Boolean aceptaLocdoft) { this.aceptaLocdoft = aceptaLocdoft; }
     public String getIpRegistro() { return ipRegistro; }
     public void setIpRegistro(String ipRegistro) { this.ipRegistro = ipRegistro; }
     public String getUserAgentRegistro() { return userAgentRegistro; }
     public void setUserAgentRegistro(String userAgentRegistro) { this.userAgentRegistro = userAgentRegistro; }
     public Instant getConsentLopdpTimestamp() { return consentLopdpTimestamp; }
     public void setConsentLopdpTimestamp(Instant consentLopdpTimestamp) { this.consentLopdpTimestamp = consentLopdpTimestamp; }
+    public Instant getConsentLocdoftTimestamp() { return consentLocdoftTimestamp; }
+    public void setConsentLocdoftTimestamp(Instant consentLocdoftTimestamp) { this.consentLocdoftTimestamp = consentLocdoftTimestamp; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }
@@ -202,9 +209,11 @@ public class SolicitudRegistro {
         public SolicitudRegistroBuilder motivoRechazo(String v) { s.motivoRechazo = v; return this; }
         public SolicitudRegistroBuilder aceptaTerminos(Boolean v) { s.aceptaTerminos = v; return this; }
         public SolicitudRegistroBuilder aceptaLopdp(Boolean v) { s.aceptaLopdp = v; return this; }
+        public SolicitudRegistroBuilder aceptaLocdoft(Boolean v) { s.aceptaLocdoft = v; return this; }
         public SolicitudRegistroBuilder ipRegistro(String v) { s.ipRegistro = v; return this; }
         public SolicitudRegistroBuilder userAgentRegistro(String v) { s.userAgentRegistro = v; return this; }
         public SolicitudRegistroBuilder consentLopdpTimestamp(Instant v) { s.consentLopdpTimestamp = v; return this; }
+        public SolicitudRegistroBuilder consentLocdoftTimestamp(Instant v) { s.consentLocdoftTimestamp = v; return this; }
         public SolicitudRegistroBuilder createdAt(LocalDateTime v) { s.createdAt = v; return this; }
         public SolicitudRegistroBuilder updatedAt(LocalDateTime v) { s.updatedAt = v; return this; }
         public SolicitudRegistro build() { return s; }

--- a/backend/src/main/java/com/tufondo/socios/infrastructure/persistence/adapter/SolicitudRegistroRepositoryImpl.java
+++ b/backend/src/main/java/com/tufondo/socios/infrastructure/persistence/adapter/SolicitudRegistroRepositoryImpl.java
@@ -105,9 +105,11 @@ public class SolicitudRegistroRepositoryImpl implements SolicitudRegistroReposit
                 .motivoRechazo(domain.getMotivoRechazo())
                 .aceptaTerminos(domain.getAceptaTerminos())
                 .aceptaLopdp(domain.getAceptaLopdp())
+                .aceptaLocdoft(domain.getAceptaLocdoft())
                 .ipRegistro(domain.getIpRegistro())
                 .userAgentRegistro(domain.getUserAgentRegistro())
                 .consentLopdpTimestamp(domain.getConsentLopdpTimestamp())
+                .consentLocdoftTimestamp(domain.getConsentLocdoftTimestamp())
                 .createdAt(domain.getCreatedAt())
                 .updatedAt(domain.getUpdatedAt())
                 .build();
@@ -144,9 +146,11 @@ public class SolicitudRegistroRepositoryImpl implements SolicitudRegistroReposit
                 .motivoRechazo(entity.getMotivoRechazo())
                 .aceptaTerminos(entity.getAceptaTerminos())
                 .aceptaLopdp(entity.getAceptaLopdp())
+                .aceptaLocdoft(entity.getAceptaLocdoft())
                 .ipRegistro(entity.getIpRegistro())
                 .userAgentRegistro(entity.getUserAgentRegistro())
                 .consentLopdpTimestamp(entity.getConsentLopdpTimestamp())
+                .consentLocdoftTimestamp(entity.getConsentLocdoftTimestamp())
                 .createdAt(entity.getCreatedAt())
                 .updatedAt(entity.getUpdatedAt())
                 .build();

--- a/backend/src/main/java/com/tufondo/socios/infrastructure/persistence/entity/SolicitudRegistroEntity.java
+++ b/backend/src/main/java/com/tufondo/socios/infrastructure/persistence/entity/SolicitudRegistroEntity.java
@@ -121,7 +121,11 @@ public class SolicitudRegistroEntity {
     @Column(name = "acepta_lopdp", nullable = false)
     private Boolean aceptaLopdp;
 
-    // ---- Auditoría LOPDP (defensa legal Venezuela) ----
+    /** Declaración jurada LOCDOFT (origen lícito de fondos). Issue #218 PR-B. */
+    @Column(name = "acepta_locdoft", nullable = false)
+    private Boolean aceptaLocdoft;
+
+    // ---- Auditoría LOPDP / LOCDOFT (defensa legal Venezuela) ----
     @Column(name = "ip_registro", length = 45)
     private String ipRegistro;
 
@@ -130,6 +134,9 @@ public class SolicitudRegistroEntity {
 
     @Column(name = "consent_lopdp_timestamp")
     private Instant consentLopdpTimestamp;
+
+    @Column(name = "consent_locdoft_timestamp")
+    private Instant consentLocdoftTimestamp;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -200,12 +207,16 @@ public class SolicitudRegistroEntity {
     public void setAceptaTerminos(Boolean aceptaTerminos) { this.aceptaTerminos = aceptaTerminos; }
     public Boolean getAceptaLopdp() { return aceptaLopdp; }
     public void setAceptaLopdp(Boolean aceptaLopdp) { this.aceptaLopdp = aceptaLopdp; }
+    public Boolean getAceptaLocdoft() { return aceptaLocdoft; }
+    public void setAceptaLocdoft(Boolean aceptaLocdoft) { this.aceptaLocdoft = aceptaLocdoft; }
     public String getIpRegistro() { return ipRegistro; }
     public void setIpRegistro(String ipRegistro) { this.ipRegistro = ipRegistro; }
     public String getUserAgentRegistro() { return userAgentRegistro; }
     public void setUserAgentRegistro(String userAgentRegistro) { this.userAgentRegistro = userAgentRegistro; }
     public Instant getConsentLopdpTimestamp() { return consentLopdpTimestamp; }
     public void setConsentLopdpTimestamp(Instant consentLopdpTimestamp) { this.consentLopdpTimestamp = consentLopdpTimestamp; }
+    public Instant getConsentLocdoftTimestamp() { return consentLocdoftTimestamp; }
+    public void setConsentLocdoftTimestamp(Instant consentLocdoftTimestamp) { this.consentLocdoftTimestamp = consentLocdoftTimestamp; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }
@@ -244,9 +255,11 @@ public class SolicitudRegistroEntity {
         public SolicitudRegistroEntityBuilder motivoRechazo(String v) { e.motivoRechazo = v; return this; }
         public SolicitudRegistroEntityBuilder aceptaTerminos(Boolean v) { e.aceptaTerminos = v; return this; }
         public SolicitudRegistroEntityBuilder aceptaLopdp(Boolean v) { e.aceptaLopdp = v; return this; }
+        public SolicitudRegistroEntityBuilder aceptaLocdoft(Boolean v) { e.aceptaLocdoft = v; return this; }
         public SolicitudRegistroEntityBuilder ipRegistro(String v) { e.ipRegistro = v; return this; }
         public SolicitudRegistroEntityBuilder userAgentRegistro(String v) { e.userAgentRegistro = v; return this; }
         public SolicitudRegistroEntityBuilder consentLopdpTimestamp(Instant v) { e.consentLopdpTimestamp = v; return this; }
+        public SolicitudRegistroEntityBuilder consentLocdoftTimestamp(Instant v) { e.consentLocdoftTimestamp = v; return this; }
         public SolicitudRegistroEntityBuilder createdAt(LocalDateTime v) { e.createdAt = v; return this; }
         public SolicitudRegistroEntityBuilder updatedAt(LocalDateTime v) { e.updatedAt = v; return this; }
         public SolicitudRegistroEntity build() { return e; }

--- a/backend/src/main/resources/db/migration/V19__add_consent_locdoft.sql
+++ b/backend/src/main/resources/db/migration/V19__add_consent_locdoft.sql
@@ -1,0 +1,40 @@
+-- =========================================================================
+-- V19__add_consent_locdoft.sql
+--
+-- Issue #218 PR-B: añadir consentimiento LOCDOFT (Ley Orgánica contra la
+-- Delincuencia Organizada y Financiamiento al Terrorismo) al flujo de
+-- registro. Obligación legal — los sujetos obligados (Fatrans lo es como
+-- fondo de ahorro) deben recolectar declaración jurada de origen lícito
+-- de los fondos.
+--
+-- Patrón: idéntico a `acepta_lopdp` + `consent_lopdp_timestamp` que ya
+-- vive en `solicitud_registro` (V11). Por consistencia, NO creamos tabla
+-- aparte — mantenemos los 3 consentimientos del registro en la misma fila.
+-- Si en el futuro se quiere unificar todos los consentimientos en una
+-- sola tabla `consentimientos`, será un refactor independiente que
+-- migrará TODOS los flags (términos, LOPDP, LOCDOFT) a la vez.
+--
+-- Idempotente (IF NOT EXISTS) para que se pueda re-aplicar en VPS prod
+-- sin romper si por alguna razón ya existe.
+-- =========================================================================
+
+ALTER TABLE solicitud_registro
+    ADD COLUMN IF NOT EXISTS acepta_locdoft BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE solicitud_registro
+    ADD COLUMN IF NOT EXISTS consent_locdoft_timestamp TIMESTAMP NULL;
+
+-- Quitar el default después del backfill: para nuevos registros queremos
+-- que el campo sea obligatorio (la app siempre lo manda).
+-- En filas existentes (registros previos al issue), queda FALSE — esos
+-- usuarios no aceptaron LOCDOFT porque no existía la pantalla. Se les
+-- puede solicitar re-aceptar en su próximo login si se considera
+-- necesario (fuera de scope de este PR).
+ALTER TABLE solicitud_registro
+    ALTER COLUMN acepta_locdoft DROP DEFAULT;
+
+COMMENT ON COLUMN solicitud_registro.acepta_locdoft IS
+    'Declaración jurada de origen lícito de fondos (LOCDOFT). Obligatorio. Debe ser TRUE para que la solicitud sea válida.';
+
+COMMENT ON COLUMN solicitud_registro.consent_locdoft_timestamp IS
+    'Timestamp UTC sellado por el backend cuando se recibe acepta_locdoft=TRUE. Junto con ip_registro y user_agent_registro forma la traza legal para defensa en juicio.';

--- a/backend/src/test/java/com/tufondo/socios/application/dto/SolicitudRegistroRequestDTOTest.java
+++ b/backend/src/test/java/com/tufondo/socios/application/dto/SolicitudRegistroRequestDTOTest.java
@@ -53,6 +53,7 @@ class SolicitudRegistroRequestDTOTest {
                 .emergenciaParentesco("Cónyuge")
                 .aceptaTerminos(true)
                 .aceptaLopdp(true)
+                .aceptaLocdoft(true)
                 .build();
     }
 
@@ -236,16 +237,40 @@ class SolicitudRegistroRequestDTOTest {
             assertThat(violations).contains("aceptaLopdp");
         }
 
+        // Issue #218 PR-B — la declaración LOCDOFT es obligatoria
+        @Test
+        @DisplayName("AceptaLocdoft false debe fallar")
+        void aceptaLocdoftFalse_Falla() {
+            SolicitudRegistroRequestDTO request = createValidRequest();
+            request.setAceptaLocdoft(false);
+            Set<String> violations = validator.validate(request).stream()
+                    .map(v -> v.getPropertyPath().toString())
+                    .collect(java.util.stream.Collectors.toSet());
+            assertThat(violations).contains("aceptaLocdoft");
+        }
+
+        @Test
+        @DisplayName("AceptaLocdoft null debe fallar")
+        void aceptaLocdoftNull_Falla() {
+            SolicitudRegistroRequestDTO request = createValidRequest();
+            request.setAceptaLocdoft(null);
+            Set<String> violations = validator.validate(request).stream()
+                    .map(v -> v.getPropertyPath().toString())
+                    .collect(java.util.stream.Collectors.toSet());
+            assertThat(violations).contains("aceptaLocdoft");
+        }
+
         @Test
         @DisplayName("Consentimientos null deben fallar")
         void consentimientosNull_Fallan() {
             SolicitudRegistroRequestDTO request = createValidRequest();
             request.setAceptaTerminos(null);
             request.setAceptaLopdp(null);
+            request.setAceptaLocdoft(null);
             Set<String> violations = validator.validate(request).stream()
                     .map(v -> v.getPropertyPath().toString())
                     .collect(java.util.stream.Collectors.toSet());
-            assertThat(violations).contains("aceptaTerminos", "aceptaLopdp");
+            assertThat(violations).contains("aceptaTerminos", "aceptaLopdp", "aceptaLocdoft");
         }
     }
 

--- a/backend/src/test/java/com/tufondo/socios/application/usecase/SolicitudRegistroDTOMapperTest.java
+++ b/backend/src/test/java/com/tufondo/socios/application/usecase/SolicitudRegistroDTOMapperTest.java
@@ -59,6 +59,7 @@ class SolicitudRegistroDTOMapperTest {
                 .emergenciaParentesco("Cónyuge")
                 .aceptaTerminos(true)
                 .aceptaLopdp(true)
+                .aceptaLocdoft(true)
                 .estado(EstadoSolicitud.APROBADA)
                 .fechaSolicitud(fechaSolicitud)
                 .fechaRevision(fechaRevision)

--- a/backend/src/test/java/com/tufondo/socios/infrastructure/persistence/adapter/SolicitudRegistroRepositoryImplTest.java
+++ b/backend/src/test/java/com/tufondo/socios/infrastructure/persistence/adapter/SolicitudRegistroRepositoryImplTest.java
@@ -71,6 +71,7 @@ class SolicitudRegistroRepositoryImplTest {
                 .estado(EstadoSolicitud.PENDIENTE)
                 .aceptaTerminos(true)
                 .aceptaLopdp(true)
+                .aceptaLocdoft(true)
                 .fechaSolicitud(LocalDateTime.now())
                 .build();
 
@@ -105,11 +106,12 @@ class SolicitudRegistroRepositoryImplTest {
     }
 
     @Test
-    @DisplayName("Preserva aceptaTerminos y aceptaLopdp (defecto LOPDP histórico)")
+    @DisplayName("Preserva aceptaTerminos, aceptaLopdp y aceptaLocdoft (consentimientos legales)")
     void preservaConsentimientosLegales() {
         SolicitudRegistro solicitud = nuevaSolicitudMinima("V-30000001", "lopdp@test.com")
                 .aceptaTerminos(true)
                 .aceptaLopdp(true)
+                .aceptaLocdoft(true)
                 .build();
 
         SolicitudRegistro guardada = repository.guardar(solicitud);
@@ -123,6 +125,9 @@ class SolicitudRegistroRepositoryImplTest {
                 .isTrue();
         assertThat(recuperada.getAceptaLopdp())
                 .as("aceptaLopdp debe persistirse; mapping antiguo lo perdía (defecto legal LOPDP)")
+                .isTrue();
+        assertThat(recuperada.getAceptaLocdoft())
+                .as("aceptaLocdoft debe persistirse (#218 PR-B — declaración LOCDOFT)")
                 .isTrue();
     }
 
@@ -263,6 +268,10 @@ class SolicitudRegistroRepositoryImplTest {
                 .correoElectronico(correo)
                 .telefono("04121234567")
                 .empresa("Empresa Test")
+                // Consentimientos legales mínimos (#218 PR-B: locdoft también obligatorio)
+                .aceptaTerminos(true)
+                .aceptaLopdp(true)
+                .aceptaLocdoft(true)
                 .estado(EstadoSolicitud.PENDIENTE)
                 .fechaSolicitud(LocalDateTime.now());
     }

--- a/backend/src/test/java/com/tufondo/socios/presentation/controller/SolicitudRegistroControllerTest.java
+++ b/backend/src/test/java/com/tufondo/socios/presentation/controller/SolicitudRegistroControllerTest.java
@@ -165,6 +165,7 @@ class SolicitudRegistroControllerTest {
                 .salario(new BigDecimal("1500.00"))
                 .aceptaTerminos(true)
                 .aceptaLopdp(true)
+                .aceptaLocdoft(true)
                 .build();
     }
 }

--- a/frontend-web/src/app/api/auth/registro/route.test.ts
+++ b/frontend-web/src/app/api/auth/registro/route.test.ts
@@ -60,6 +60,7 @@ function buildValidPayload(overrides: Record<string, unknown> = {}): Record<stri
     emergenciaParentesco: 'Cónyuge',
     aceptaTerminos: true,
     aceptaLopdp: true,
+    aceptaLocdoft: true, // Issue #218 PR-B — declaración LOCDOFT obligatoria
     ...overrides,
   };
 }
@@ -127,6 +128,7 @@ describe('POST /api/auth/registro (BFF)', () => {
       'emergenciaParentesco',
       'aceptaTerminos',
       'aceptaLopdp',
+      'aceptaLocdoft',
     ];
     for (const key of expectedKeys) {
       expect(forwarded).toHaveProperty(key);
@@ -146,6 +148,7 @@ describe('POST /api/auth/registro (BFF)', () => {
     // Booleanos de consentimiento llegan como `true`.
     expect(forwarded.aceptaTerminos).toBe(true);
     expect(forwarded.aceptaLopdp).toBe(true);
+    expect(forwarded.aceptaLocdoft).toBe(true);
 
     // Salario normalizado a string numérico para BigDecimal.
     expect(forwarded.salario).toBe('1500.5');

--- a/frontend-web/src/app/api/auth/registro/route.ts
+++ b/frontend-web/src/app/api/auth/registro/route.ts
@@ -133,12 +133,15 @@ export async function POST(request: NextRequest) {
       // --- Consentimientos legales (booleanos, requeridos por el backend con @AssertTrue) ---
       aceptaTerminos: data.aceptaTerminos,
       aceptaLopdp: data.aceptaLopdp,
+      // Issue #218 PR-B — declaración jurada LOCDOFT (origen lícito de fondos).
+      aceptaLocdoft: data.aceptaLocdoft,
 
-      // --- Auditoría LOPDP (defensa legal Venezuela) ---
+      // --- Auditoría LOPDP / LOCDOFT (defensa legal Venezuela) ---
       // IP del cliente original (respeta x-forwarded-for; el primer hop) y user-agent.
       // El backend trunca a 45 / 500 chars y, si vienen null/vacíos, hace fallback a
-      // HttpServletRequest. El consentLopdpTimestamp lo sella el backend con Instant.now()
-      // cuando aceptaLopdp === true — NUNCA confiamos en el cliente para timestamps.
+      // HttpServletRequest. Los timestamps consentLopdpTimestamp y consentLocdoftTimestamp
+      // los sella el backend con Instant.now() cuando los flags llegan en true — NUNCA
+      // confiamos en el cliente para timestamps.
       ipRegistro: getClientIp(request),
       userAgentRegistro: request.headers.get('user-agent'),
     };

--- a/frontend-web/src/components/features/auth/registration-form.tsx
+++ b/frontend-web/src/components/features/auth/registration-form.tsx
@@ -116,7 +116,7 @@ const STEPS: StepDef[] = [
     title: 'Confirmación',
     description: 'Revisa y acepta',
     icon: ShieldCheck,
-    fields: ['aceptaTerminos', 'aceptaLopdp'],
+    fields: ['aceptaTerminos', 'aceptaLopdp', 'aceptaLocdoft'],
   },
 ];
 
@@ -723,6 +723,32 @@ export function RegistrationForm() {
                   )}
                 />
                 <FieldError message={errors.aceptaLopdp?.message} />
+
+                {/* Declaración jurada LOCDOFT (#218 PR-B). Obligación legal —
+                    los sujetos obligados deben recolectar al onboarding. */}
+                <Controller
+                  control={control}
+                  name="aceptaLocdoft"
+                  render={({ field }) => (
+                    <div className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-3">
+                      <Checkbox
+                        id="aceptaLocdoft"
+                        checked={field.value === true}
+                        onCheckedChange={(c) => field.onChange(c === true)}
+                        disabled={isLoading}
+                        aria-invalid={!!errors.aceptaLocdoft}
+                        className="mt-0.5"
+                      />
+                      <Label htmlFor="aceptaLocdoft" className="text-sm leading-relaxed text-amber-900">
+                        <strong className="block mb-1">Declaración jurada de origen lícito de fondos</strong>
+                        Declaro bajo fe de juramento que los fondos que utilizaré en esta plataforma{' '}
+                        <strong>no provienen de actividades ilícitas</strong> según la Ley Orgánica
+                        contra la Delincuencia Organizada y Financiamiento al Terrorismo (LOCDOFT).
+                      </Label>
+                    </div>
+                  )}
+                />
+                <FieldError message={errors.aceptaLocdoft?.message} />
               </div>
             </div>
           )}

--- a/frontend-web/src/lib/utils/validators.test.ts
+++ b/frontend-web/src/lib/utils/validators.test.ts
@@ -18,6 +18,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test C.A.',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -35,6 +36,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test C.A.',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(false);
     });
@@ -56,6 +58,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -73,6 +76,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -90,6 +94,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(false);
     });
@@ -111,6 +116,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -128,6 +134,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -145,6 +152,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -162,6 +170,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(false);
     });
@@ -179,6 +188,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(false);
     });
@@ -200,6 +210,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -217,6 +228,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(false);
     });
@@ -247,6 +259,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
       empresa: 'Empresa Test',
       aceptaTerminos: true as const,
       aceptaLopdp: true as const,
+      aceptaLocdoft: true as const,
     };
 
     it('Issue #204: persona con exactamente 18 años recién cumplidos pasa', () => {
@@ -303,6 +316,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -320,6 +334,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(false);
     });
@@ -341,6 +356,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -358,6 +374,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -380,6 +397,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         rifEmpresa: 'J-123456789-0',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -398,6 +416,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         rifEmpresa: 'V-12345678',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -416,6 +435,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         rifEmpresa: '',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -437,6 +457,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -454,6 +475,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(false);
     });
@@ -471,6 +493,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -488,6 +511,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -505,6 +529,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(false);
     });
@@ -526,6 +551,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -543,6 +569,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: false,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(false);
     });
@@ -560,6 +587,43 @@ describe('registroSchema - Validaciones Issue #99', () => {
         empresa: 'Empresa Test',
         aceptaTerminos: true,
         aceptaLopdp: false,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    // Issue #218 PR-B — la declaración LOCDOFT es obligatoria
+    it('aceptaLocdoft false falla', () => {
+      const result = registroSchema.safeParse({
+        nombreCompleto: 'Juan Pérez',
+        tipoDocumento: 'CEDULA',
+        cedula: 'V-12345678',
+        fechaNacimiento: '1990-01-15',
+        genero: 'MASCULINO',
+        estadoCivil: 'SOLTERO',
+        correoElectronico: 'juan@test.com',
+        telefono: '04121234567',
+        empresa: 'Empresa Test',
+        aceptaTerminos: true,
+        aceptaLopdp: true,
+        aceptaLocdoft: false,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('aceptaLocdoft omitido falla (es obligatorio)', () => {
+      const result = registroSchema.safeParse({
+        nombreCompleto: 'Juan Pérez',
+        tipoDocumento: 'CEDULA',
+        cedula: 'V-12345678',
+        fechaNacimiento: '1990-01-15',
+        genero: 'MASCULINO',
+        estadoCivil: 'SOLTERO',
+        correoElectronico: 'juan@test.com',
+        telefono: '04121234567',
+        empresa: 'Empresa Test',
+        aceptaTerminos: true,
+        aceptaLopdp: true,
+        // aceptaLocdoft: omitido
       });
       expect(result.success).toBe(false);
     });
@@ -585,6 +649,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         direccionCalle: 'Av. Principal #123',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -603,6 +668,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         direccionEstado: 'Zulia',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });
@@ -627,6 +693,7 @@ describe('registroSchema - Validaciones Issue #99', () => {
         emergenciaParentesco: 'Cónyuge',
         aceptaTerminos: true,
         aceptaLopdp: true,
+        aceptaLocdoft: true,
       });
       expect(result.success).toBe(true);
     });

--- a/frontend-web/src/lib/utils/validators.ts
+++ b/frontend-web/src/lib/utils/validators.ts
@@ -167,6 +167,13 @@ export const registroSchema = z.object({
   aceptaLopdp: z.literal(true, {
     errorMap: () => ({ message: 'Debe aceptar la política de protección de datos' }),
   }),
+  // Issue #218 PR-B — declaración jurada LOCDOFT (origen lícito de fondos).
+  // Obligación de Ley Orgánica contra la Delincuencia Organizada y
+  // Financiamiento al Terrorismo. Los sujetos obligados (Fatrans lo es como
+  // fondo de ahorro) deben recolectar esta declaración al onboarding.
+  aceptaLocdoft: z.literal(true, {
+    errorMap: () => ({ message: 'Debe declarar que los fondos provienen de actividades lícitas (LOCDOFT)' }),
+  }),
 });
 
 export type RegistroFormData = z.infer<typeof registroSchema>;


### PR DESCRIPTION
Parte de #218 (PR-B — checkbox LOCDOFT en registro). PR-A merged en #275. PR-C pendiente (modal LOCDOFT en operaciones grandes).

## Problema

Fatrans (fondo de ahorro) es **sujeto obligado** según la Ley Orgánica contra la Delincuencia Organizada y Financiamiento al Terrorismo (LOCDOFT). Debe recolectar declaración jurada de origen lícito de los fondos al onboarding del socio. Hoy el registro solo pide \`aceptaTerminos\` + \`aceptaLopdp\` — no hay nada sobre LOCDOFT.

## Cambios

### Backend
- **Migración V19** (\`V19__add_consent_locdoft.sql\`): añade columnas a \`solicitud_registro\`:
  - \`acepta_locdoft\` BOOLEAN NOT NULL — obligatorio para nuevas solicitudes
  - \`consent_locdoft_timestamp\` TIMESTAMP NULL — sellado por backend con \`Instant.now()\` cuando recibe \`true\`
  - Idempotente con IF NOT EXISTS (VPS prod-safe)
- **Decisión**: NO creo tabla separada \`consentimiento_locdoft\`. Mantengo los 3 consentimientos legales (términos, LOPDP, LOCDOFT) en \`solicitud_registro\` por consistencia con el patrón actual. Si en el futuro se quiere unificar todos los consentimientos en una sola tabla, será un refactor independiente que migre los 3 a la vez.
- **Validación**: \`@NotNull\` + \`@AssertTrue\` con mensaje específico — mismo patrón que \`aceptaLopdp\`. Si la solicitud llega sin el flag o con \`false\`, devuelve 400.
- **Flow**: entity + dominio + DTO request/response + mapper + repo adapter + use case actualizados.
- **Seguridad**: el timestamp NUNCA viaja desde el cliente — el backend lo sella server-side cuando recibe el flag en true.

### Frontend
- **\`validators.ts\`**: schema zod añade \`aceptaLocdoft: z.literal(true)\` con mensaje específico.
- **\`registration-form.tsx\`**: nuevo checkbox en el paso \"Confirmación\" con estilo **destacado** (caja amber con borde) para resaltar visualmente que es declaración jurada, no solo otra casilla. Texto exacto del issue #218:
  > \"Declaro bajo fe de juramento que los fondos que utilizaré no provienen de actividades ilícitas según la Ley Orgánica contra la Delincuencia Organizada y Financiamiento al Terrorismo (LOCDOFT).\"
- **Step \`confirmacion.fields\`** incluye \`aceptaLocdoft\` para que el trigger del paso lo valide antes de poder avanzar/enviar.
- **BFF route** (\`/api/auth/registro/route.ts\`): reenvía \`aceptaLocdoft\` al backend.

## Tests

### Backend (392 / 0 fail)
- 4 fixtures actualizados (\`aceptaLocdoft(true)\` en builders existentes)
- 2 tests nuevos en \`SolicitudRegistroRequestDTOTest\`:
  - \`aceptaLocdoftFalse_Falla\`
  - \`aceptaLocdoftNull_Falla\`
- Helper \`nuevaSolicitudMinima\` incluye el campo (sino el constraint NOT NULL de la BD rechazaba inserts)

### Frontend (517 passing / 17 preexistentes failing — sin regresión)
- \`validators.test.ts\`: 2 tests nuevos específicos del flag LOCDOFT + fixtures de \"Issue #204 mayoría de edad\" actualizadas
- \`route.test.ts\`: payload + expectedKeys + assert sobre el flag forwarded

## Verificación
- [x] \`mvn test\`: **392 passing / 0 failures** (sin cambio neto, los nuevos pasan + los viejos siguen)
- [x] \`npm run build\`: OK
- [x] \`npm test\`: 517 passing (era 515) — +2 verdes nuevos, 17 fallidos preexistentes intactos

## Test plan QA

- [ ] Ir a \`/registro\`, completar todos los pasos, llegar al paso de \"Confirmación\"
- [ ] Verificar que aparece la **caja amber** con la declaración LOCDOFT
- [ ] Intentar enviar el formulario sin tildar el checkbox LOCDOFT → debe bloquear con mensaje claro
- [ ] Tildar checkbox de LOCDOFT pero NO de términos → bloquea pidiendo aceptar términos
- [ ] Tildar los 3 checkboxes (términos + LOPDP + LOCDOFT) → envía correctamente
- [ ] Verificar en BD que \`acepta_locdoft\` quedó en TRUE y \`consent_locdoft_timestamp\` tiene la fecha exacta del envío
- [ ] Migración aplica en QA sin errores (idempotente — se puede correr varias veces)

## Scope diferido a PR-C

- Modal LOCDOFT en **operaciones grandes** (depósito > umbral configurable, ej. $1000 equivalente VES)
- Parámetro umbral en \`parametros_sistema\`
- Persistencia del consentimiento por operación

🤖 Generated with [Claude Code](https://claude.com/claude-code)