### PR TITLE
feat(compliance): modal LOCDOFT en operaciones grandes (#218 PR-C — cierra issue)

### DIFF
--- a/backend/src/main/java/com/tufondo/ahorros/application/dto/DepositoRequest.java
+++ b/backend/src/main/java/com/tufondo/ahorros/application/dto/DepositoRequest.java
@@ -31,4 +31,16 @@ public class DepositoRequest {
     
     @NotNull(message = "canalOrigen es requerido")
     private CanalOrigen canalOrigen;
+
+    // ==== LOCDOFT — declaración jurada para operaciones grandes (#218 PR-C) ====
+    //
+    // Si el monto supera el umbral configurado en `parametros_sistema`, el
+    // backend EXIGE que `confirmaOrigenLicito=true`. El frontend muestra un
+    // modal con la pregunta y, al confirmar, reintenta el POST con este flag.
+    // Si el monto NO supera el umbral, estos campos se ignoran.
+
+    private Boolean confirmaOrigenLicito;
+
+    @Size(max = 2000, message = "origenFondos no puede exceder 2000 caracteres")
+    private String origenFondos;
 }

--- a/backend/src/main/java/com/tufondo/ahorros/application/dto/RetiroRequest.java
+++ b/backend/src/main/java/com/tufondo/ahorros/application/dto/RetiroRequest.java
@@ -25,4 +25,10 @@ public class RetiroRequest {
     
     @NotNull(message = "canalOrigen es requerido")
     private CanalOrigen canalOrigen;
+
+    // ==== LOCDOFT — declaración jurada para operaciones grandes (#218 PR-C) ====
+    private Boolean confirmaOrigenLicito;
+
+    @Size(max = 2000, message = "origenFondos no puede exceder 2000 caracteres")
+    private String origenFondos;
 }

--- a/backend/src/main/java/com/tufondo/ahorros/application/usecase/RealizarDepositoUseCase.java
+++ b/backend/src/main/java/com/tufondo/ahorros/application/usecase/RealizarDepositoUseCase.java
@@ -14,6 +14,8 @@ import com.tufondo.ahorros.domain.model.enums.EstadoCuenta;
 import com.tufondo.ahorros.domain.model.valueobjects.NumeroOperacion;
 import com.tufondo.ahorros.domain.repository.CuentaAhorroRepository;
 import com.tufondo.ahorros.domain.repository.MovimientoRepository;
+import com.tufondo.compliance.application.service.LocdoftOperacionService;
+import com.tufondo.compliance.domain.model.ConsentimientoLocdoftOperacion;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -36,6 +38,7 @@ public class RealizarDepositoUseCase {
     private final CuentaAhorroRepository cuentaRepository;
     private final MovimientoRepository movimientoRepository;
     private final AhorrosDTOMapper mapper;
+    private final LocdoftOperacionService locdoftService;
 
     @Transactional
     public MovimientoResponse ejecutar(String numeroCuenta, DepositoRequest request,
@@ -58,6 +61,20 @@ public class RealizarDepositoUseCase {
         if (request.getMonto().compareTo(LIMITE_DEPOSITO) > 0) {
             throw new MontoExcedeLimiteException(request.getMonto(), LIMITE_DEPOSITO, "depósito");
         }
+
+        // LOCDOFT (#218 PR-C): si supera el umbral, registra el consentimiento
+        // o lanza LocdoftConsentimientoRequeridoException (HTTP 422 → frontend
+        // abre modal con la pregunta de origen lícito).
+        ConsentimientoLocdoftOperacion consentimiento = locdoftService.validarYRegistrar(
+                new LocdoftOperacionService.DatosOperacion(
+                        cuenta.getSocioId(),
+                        cuenta.getId(),
+                        ConsentimientoLocdoftOperacion.TipoOperacion.DEPOSITO,
+                        request.getMonto(),
+                        cuenta.getMoneda() != null ? cuenta.getMoneda().name() : "VES",
+                        Boolean.TRUE.equals(request.getConfirmaOrigenLicito()),
+                        request.getOrigenFondos(),
+                        ipOrigen, null, sessionId, requestId));
 
         // Ejecutar depósito
         BigDecimal saldoAnterior = cuenta.getSaldoActual();
@@ -90,6 +107,12 @@ public class RealizarDepositoUseCase {
                 request.getReferencia()
         );
         movimiento = movimientoRepository.guardar(movimiento);
+
+        // Asociar consentimiento LOCDOFT con el movimiento real recién creado
+        // (resiliente: si falla, queda con movimiento_id=null, no aborta).
+        if (consentimiento != null) {
+            locdoftService.asociarConMovimiento(consentimiento.getId(), movimiento.getId());
+        }
 
         log.info("Depósito realizado: {} en cuenta {}", request.getMonto(), numeroCuenta);
         return mapper.toResponse(movimiento);

--- a/backend/src/main/java/com/tufondo/ahorros/application/usecase/RealizarRetiroUseCase.java
+++ b/backend/src/main/java/com/tufondo/ahorros/application/usecase/RealizarRetiroUseCase.java
@@ -12,6 +12,8 @@ import com.tufondo.ahorros.domain.model.enums.TipoMovimiento;
 import com.tufondo.ahorros.domain.model.valueobjects.NumeroOperacion;
 import com.tufondo.ahorros.domain.repository.CuentaAhorroRepository;
 import com.tufondo.ahorros.domain.repository.MovimientoRepository;
+import com.tufondo.compliance.application.service.LocdoftOperacionService;
+import com.tufondo.compliance.domain.model.ConsentimientoLocdoftOperacion;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,6 +37,7 @@ public class RealizarRetiroUseCase {
     private final CuentaAhorroRepository cuentaRepository;
     private final MovimientoRepository movimientoRepository;
     private final AhorrosDTOMapper mapper;
+    private final LocdoftOperacionService locdoftService;
 
     @Transactional
     public MovimientoResponse ejecutar(String numeroCuenta, RetiroRequest request,
@@ -69,6 +72,19 @@ public class RealizarRetiroUseCase {
             throw new MontoExcedeLimiteException(request.getMonto(), LIMITE_RETIRO, "retiro");
         }
 
+        // LOCDOFT (#218 PR-C): mismo patrón que en depósito — si supera el
+        // umbral, registra el consentimiento o lanza 422.
+        ConsentimientoLocdoftOperacion consentimiento = locdoftService.validarYRegistrar(
+                new LocdoftOperacionService.DatosOperacion(
+                        cuenta.getSocioId(),
+                        cuenta.getId(),
+                        ConsentimientoLocdoftOperacion.TipoOperacion.RETIRO,
+                        request.getMonto(),
+                        cuenta.getMoneda() != null ? cuenta.getMoneda().name() : "VES",
+                        Boolean.TRUE.equals(request.getConfirmaOrigenLicito()),
+                        request.getOrigenFondos(),
+                        ipOrigen, null, sessionId, requestId));
+
         // Ejecutar retiro
         BigDecimal saldoAnterior = cuenta.getSaldoActual();
         cuenta.restarSaldo(request.getMonto());
@@ -98,6 +114,11 @@ public class RealizarRetiroUseCase {
                 requestId
         );
         movimiento = movimientoRepository.guardar(movimiento);
+
+        // Asociar consentimiento LOCDOFT con el movimiento real (resiliente).
+        if (consentimiento != null) {
+            locdoftService.asociarConMovimiento(consentimiento.getId(), movimiento.getId());
+        }
 
         log.info("Retiro realizado: {} de cuenta {}", request.getMonto(), numeroCuenta);
         return mapper.toResponse(movimiento);

--- a/backend/src/main/java/com/tufondo/ahorros/infrastructure/security/AhorroExceptionHandler.java
+++ b/backend/src/main/java/com/tufondo/ahorros/infrastructure/security/AhorroExceptionHandler.java
@@ -2,6 +2,7 @@
 package com.tufondo.ahorros.infrastructure.security;
 
 import com.tufondo.ahorros.domain.exception.*;
+import com.tufondo.compliance.application.service.LocdoftConsentimientoRequeridoException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -80,6 +81,26 @@ public class AhorroExceptionHandler {
     @ExceptionHandler(TasaInvalidaException.class)
     public ResponseEntity<Map<String, Object>> handleTasaInvalida(TasaInvalidaException ex) {
         return buildErrorResponse(HttpStatus.BAD_REQUEST, "TASA_INVALIDA", ex.getMessage());
+    }
+
+    /**
+     * Issue #218 PR-C — operación supera umbral LOCDOFT y el cliente no
+     * envió declaración jurada. Devuelve HTTP 422 con el código que el
+     * frontend usa para abrir el modal de declaración.
+     */
+    @ExceptionHandler(LocdoftConsentimientoRequeridoException.class)
+    public ResponseEntity<Map<String, Object>> handleLocdoftConsent(LocdoftConsentimientoRequeridoException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("status", HttpStatus.UNPROCESSABLE_ENTITY.value());
+        body.put("error", LocdoftConsentimientoRequeridoException.CODE);
+        body.put("mensaje", ex.getMessage());
+        body.put("detalles", Map.of(
+                "montoSolicitado", ex.getMontoSolicitado(),
+                "moneda", ex.getMoneda(),
+                "umbral", ex.getUmbral()
+        ));
+        return new ResponseEntity<>(body, HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     private ResponseEntity<Map<String, Object>> buildErrorResponse(HttpStatus status, String error, String message) {

--- a/backend/src/main/java/com/tufondo/compliance/application/service/LocdoftConsentimientoRequeridoException.java
+++ b/backend/src/main/java/com/tufondo/compliance/application/service/LocdoftConsentimientoRequeridoException.java
@@ -1,0 +1,32 @@
+package com.tufondo.compliance.application.service;
+
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+/**
+ * Lanzada cuando una operación financiera (depósito/retiro) supera el
+ * umbral LOCDOFT configurado y el cliente NO envió la declaración
+ * jurada {@code confirmaOrigenLicito=true}.
+ *
+ * <p>Mapea a HTTP 422 (Unprocessable Entity) con código de error
+ * {@code LOCDOFT_CONSENT_REQUIRED}. El frontend usa este código para
+ * abrir el modal de declaración y reintentar con el flag.</p>
+ */
+@Getter
+public class LocdoftConsentimientoRequeridoException extends RuntimeException {
+
+    public static final String CODE = "LOCDOFT_CONSENT_REQUIRED";
+
+    private final BigDecimal montoSolicitado;
+    private final String moneda;
+    private final BigDecimal umbral;
+
+    public LocdoftConsentimientoRequeridoException(BigDecimal montoSolicitado, String moneda, BigDecimal umbral) {
+        super("La operación supera el umbral LOCDOFT (" + umbral + " " + moneda
+                + "). Se requiere declaración jurada de origen lícito de los fondos.");
+        this.montoSolicitado = montoSolicitado;
+        this.moneda = moneda;
+        this.umbral = umbral;
+    }
+}

--- a/backend/src/main/java/com/tufondo/compliance/application/service/LocdoftOperacionService.java
+++ b/backend/src/main/java/com/tufondo/compliance/application/service/LocdoftOperacionService.java
@@ -1,0 +1,134 @@
+package com.tufondo.compliance.application.service;
+
+import com.tufondo.compliance.domain.model.ConsentimientoLocdoftOperacion;
+import com.tufondo.compliance.domain.model.ConsentimientoLocdoftOperacion.TipoOperacion;
+import com.tufondo.compliance.domain.repository.ConsentimientoLocdoftRepository;
+import com.tufondo.parametros.domain.repository.ParametroRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Servicio compartido para validar y registrar declaraciones LOCDOFT en
+ * operaciones financieras grandes (#218 PR-C).
+ *
+ * <p>Lo invocan {@code RealizarDepositoUseCase} y {@code RealizarRetiroUseCase}
+ * antes de ejecutar la operación. Si el monto NO supera el umbral, devuelve
+ * {@code null} (operación normal sin declaración). Si SÍ supera el umbral y
+ * el flag {@code confirmaOrigenLicito} no es {@code true}, lanza
+ * {@link LocdoftConsentimientoRequeridoException}. Si el flag es true,
+ * persiste el consentimiento y devuelve el registro.</p>
+ *
+ * <p><strong>Resiliencia:</strong> si lectura del parámetro falla por
+ * cualquier razón transient, NO se bloquea la operación — se loguea y
+ * se asume "sin umbral" (fail-open). Razón: el umbral es defensa
+ * adicional, no la única protección; impedir todas las operaciones por
+ * un bug del módulo de parámetros sería peor que dejar pasar
+ * operaciones grandes durante el bug.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LocdoftOperacionService {
+
+    private static final String KEY_UMBRAL_VES = "LOCDOFT_UMBRAL_VES";
+    private static final String KEY_UMBRAL_USD = "LOCDOFT_UMBRAL_USD";
+
+    private final ParametroRepository parametroRepository;
+    private final ConsentimientoLocdoftRepository consentimientoRepository;
+
+    public record DatosOperacion(
+            UUID socioId,
+            UUID cuentaAhorroId,
+            TipoOperacion tipoOperacion,
+            BigDecimal monto,
+            String moneda,
+            boolean confirmaOrigenLicito,
+            String origenFondos,
+            String ipOrigen,
+            String userAgent,
+            String sessionId,
+            String requestId
+    ) {}
+
+    /**
+     * Valida el umbral y persiste el consentimiento si aplica.
+     *
+     * @return el consentimiento persistido (con id) si la operación supera
+     *         el umbral, o {@code null} si no lo supera (operación normal).
+     * @throws LocdoftConsentimientoRequeridoException si supera el umbral y
+     *         el cliente no envió {@code confirmaOrigenLicito=true}.
+     */
+    @Transactional
+    public ConsentimientoLocdoftOperacion validarYRegistrar(DatosOperacion datos) {
+        BigDecimal umbral = obtenerUmbral(datos.moneda());
+        if (umbral == null || datos.monto().compareTo(umbral) <= 0) {
+            return null; // operación normal — no requiere declaración
+        }
+
+        // Supera el umbral → requiere confirmación
+        if (!datos.confirmaOrigenLicito()) {
+            throw new LocdoftConsentimientoRequeridoException(datos.monto(), datos.moneda(), umbral);
+        }
+
+        // Persistir como evidencia (movimientoId queda null hasta que la
+        // operación principal lo asocie con `asociarConMovimiento`).
+        return consentimientoRepository.guardar(ConsentimientoLocdoftOperacion.builder()
+                .socioId(datos.socioId())
+                .cuentaAhorroId(datos.cuentaAhorroId())
+                .movimientoId(null)
+                .tipoOperacion(datos.tipoOperacion())
+                .monto(datos.monto())
+                .moneda(datos.moneda())
+                .umbralAplicado(umbral)
+                .aceptaOrigenLicito(true)
+                .origenFondos(datos.origenFondos())
+                .ipOrigen(datos.ipOrigen())
+                .userAgent(datos.userAgent())
+                .sessionId(datos.sessionId())
+                .requestId(datos.requestId())
+                .build());
+    }
+
+    /** Lee el umbral vigente. Fail-open: si no se puede leer, devuelve null. */
+    public BigDecimal obtenerUmbral(String moneda) {
+        String key = "USD".equalsIgnoreCase(moneda) ? KEY_UMBRAL_USD : KEY_UMBRAL_VES;
+        try {
+            return parametroRepository.buscarPorKey(key)
+                    .map(p -> {
+                        try {
+                            return new BigDecimal(p.valor());
+                        } catch (NumberFormatException nfe) {
+                            log.warn("Parámetro {} tiene valor inválido '{}' — fail-open",
+                                    key, p.valor());
+                            return null;
+                        }
+                    })
+                    .orElse(null);
+        } catch (Throwable t) {
+            log.warn("No se pudo leer parámetro {} ({}) — fail-open en LOCDOFT umbral",
+                    key, t.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Asocia el consentimiento ya persistido con el movimiento real
+     * que se acaba de crear. Resiliente: si falla, log y skip — el
+     * consentimiento queda con movimientoId=null pero igual sirve como
+     * evidencia. La operación principal NO se aborta por esto.
+     */
+    public void asociarConMovimiento(UUID consentimientoId, UUID movimientoId) {
+        if (consentimientoId == null || movimientoId == null) return;
+        try {
+            consentimientoRepository.asociarConMovimiento(consentimientoId, movimientoId);
+        } catch (Throwable t) {
+            log.error("No se pudo asociar consentimiento {} con movimiento {}: {}",
+                    consentimientoId, movimientoId, t.getMessage(), t);
+        }
+    }
+}

--- a/backend/src/main/java/com/tufondo/compliance/domain/model/ConsentimientoLocdoftOperacion.java
+++ b/backend/src/main/java/com/tufondo/compliance/domain/model/ConsentimientoLocdoftOperacion.java
@@ -1,0 +1,49 @@
+package com.tufondo.compliance.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Declaración jurada LOCDOFT capturada al momento de una operación grande
+ * (#218 PR-C).
+ *
+ * <p>Se registra cuando el socio confirma origen lícito de los fondos en
+ * una operación que supera el umbral configurado en
+ * {@code parametros_sistema.LOCDOFT_UMBRAL_*}. Se persiste ANTES de
+ * intentar la operación — si la operación falla por otra razón (saldo
+ * insuficiente, límite excedido), el consentimiento queda igual como
+ * evidencia del intento + declaración.</p>
+ *
+ * <p>Conservación: mínimo 5 años (Art. 9 LOCDOFT).</p>
+ */
+@Getter
+@Builder
+public class ConsentimientoLocdoftOperacion {
+
+    private final UUID id;
+    private final UUID socioId;
+    private final UUID cuentaAhorroId;
+    /** Null si el consentimiento se persistió pero la operación falló después. */
+    private final UUID movimientoId;
+    private final TipoOperacion tipoOperacion;
+    private final BigDecimal monto;
+    private final String moneda;
+    /** Snapshot del umbral vigente al momento — no se recalcula a posteriori. */
+    private final BigDecimal umbralAplicado;
+    private final boolean aceptaOrigenLicito;
+    /** Texto libre del socio. Útil para PEPs o casos con justificación específica. */
+    private final String origenFondos;
+    private final String ipOrigen;
+    private final String userAgent;
+    private final String sessionId;
+    private final String requestId;
+    private final Instant createdAt;
+
+    public enum TipoOperacion {
+        DEPOSITO, RETIRO
+    }
+}

--- a/backend/src/main/java/com/tufondo/compliance/domain/repository/ConsentimientoLocdoftRepository.java
+++ b/backend/src/main/java/com/tufondo/compliance/domain/repository/ConsentimientoLocdoftRepository.java
@@ -1,0 +1,21 @@
+package com.tufondo.compliance.domain.repository;
+
+import com.tufondo.compliance.domain.model.ConsentimientoLocdoftOperacion;
+
+import java.util.UUID;
+
+/**
+ * Port para persistencia de consentimientos LOCDOFT de operación (#218 PR-C).
+ */
+public interface ConsentimientoLocdoftRepository {
+
+    ConsentimientoLocdoftOperacion guardar(ConsentimientoLocdoftOperacion consentimiento);
+
+    /**
+     * Asocia el consentimiento con el movimiento real una vez que la
+     * operación se completó exitosamente. Si la operación falla, NO se
+     * llama y el registro queda con {@code movimientoId=null} (deseable
+     * como evidencia del intento).
+     */
+    void asociarConMovimiento(UUID consentimientoId, UUID movimientoId);
+}

--- a/backend/src/main/java/com/tufondo/compliance/infrastructure/persistence/adapter/ConsentimientoLocdoftRepositoryImpl.java
+++ b/backend/src/main/java/com/tufondo/compliance/infrastructure/persistence/adapter/ConsentimientoLocdoftRepositoryImpl.java
@@ -1,0 +1,66 @@
+package com.tufondo.compliance.infrastructure.persistence.adapter;
+
+import com.tufondo.compliance.domain.model.ConsentimientoLocdoftOperacion;
+import com.tufondo.compliance.domain.repository.ConsentimientoLocdoftRepository;
+import com.tufondo.compliance.infrastructure.persistence.entity.ConsentimientoLocdoftEntity;
+import com.tufondo.compliance.infrastructure.persistence.jpa.ConsentimientoLocdoftJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class ConsentimientoLocdoftRepositoryImpl implements ConsentimientoLocdoftRepository {
+
+    private final ConsentimientoLocdoftJpaRepository jpa;
+
+    @Override
+    @Transactional
+    public ConsentimientoLocdoftOperacion guardar(ConsentimientoLocdoftOperacion c) {
+        ConsentimientoLocdoftEntity e = new ConsentimientoLocdoftEntity();
+        e.setId(c.getId() != null ? c.getId() : UUID.randomUUID());
+        e.setSocioId(c.getSocioId());
+        e.setCuentaAhorroId(c.getCuentaAhorroId());
+        e.setMovimientoId(c.getMovimientoId());
+        e.setTipoOperacion(c.getTipoOperacion().name());
+        e.setMonto(c.getMonto());
+        e.setMoneda(c.getMoneda());
+        e.setUmbralAplicado(c.getUmbralAplicado());
+        e.setAceptaOrigenLicito(c.isAceptaOrigenLicito());
+        e.setOrigenFondos(c.getOrigenFondos());
+        e.setIpOrigen(c.getIpOrigen());
+        e.setUserAgent(c.getUserAgent());
+        e.setSessionId(c.getSessionId());
+        e.setRequestId(c.getRequestId());
+        e.setCreatedAt(c.getCreatedAt() != null ? c.getCreatedAt() : Instant.now());
+
+        ConsentimientoLocdoftEntity saved = jpa.save(e);
+
+        return ConsentimientoLocdoftOperacion.builder()
+                .id(saved.getId())
+                .socioId(saved.getSocioId())
+                .cuentaAhorroId(saved.getCuentaAhorroId())
+                .movimientoId(saved.getMovimientoId())
+                .tipoOperacion(ConsentimientoLocdoftOperacion.TipoOperacion.valueOf(saved.getTipoOperacion()))
+                .monto(saved.getMonto())
+                .moneda(saved.getMoneda())
+                .umbralAplicado(saved.getUmbralAplicado())
+                .aceptaOrigenLicito(saved.isAceptaOrigenLicito())
+                .origenFondos(saved.getOrigenFondos())
+                .ipOrigen(saved.getIpOrigen())
+                .userAgent(saved.getUserAgent())
+                .sessionId(saved.getSessionId())
+                .requestId(saved.getRequestId())
+                .createdAt(saved.getCreatedAt())
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public void asociarConMovimiento(UUID consentimientoId, UUID movimientoId) {
+        jpa.actualizarMovimientoId(consentimientoId, movimientoId);
+    }
+}

--- a/backend/src/main/java/com/tufondo/compliance/infrastructure/persistence/entity/ConsentimientoLocdoftEntity.java
+++ b/backend/src/main/java/com/tufondo/compliance/infrastructure/persistence/entity/ConsentimientoLocdoftEntity.java
@@ -1,0 +1,99 @@
+package com.tufondo.compliance.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * JPA entity para `consentimiento_locdoft_operacion` (#218 PR-C).
+ * Schema en V20__locdoft_operacion_grande.sql.
+ */
+@Entity
+@Table(name = "consentimiento_locdoft_operacion",
+    indexes = {
+        @Index(name = "idx_locdoft_op_socio_fecha", columnList = "socio_id, created_at DESC"),
+        @Index(name = "idx_locdoft_op_movimiento", columnList = "movimiento_id")
+    })
+public class ConsentimientoLocdoftEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "socio_id", nullable = false)
+    private UUID socioId;
+
+    @Column(name = "cuenta_ahorro_id", nullable = false)
+    private UUID cuentaAhorroId;
+
+    @Column(name = "movimiento_id")
+    private UUID movimientoId;
+
+    @Column(name = "tipo_operacion", nullable = false, length = 20)
+    private String tipoOperacion;
+
+    @Column(name = "monto", nullable = false, precision = 18, scale = 2)
+    private BigDecimal monto;
+
+    @Column(name = "moneda", nullable = false, length = 3)
+    private String moneda;
+
+    @Column(name = "umbral_aplicado", nullable = false, precision = 18, scale = 2)
+    private BigDecimal umbralAplicado;
+
+    @Column(name = "acepta_origen_licito", nullable = false)
+    private boolean aceptaOrigenLicito;
+
+    @Column(name = "origen_fondos", columnDefinition = "TEXT")
+    private String origenFondos;
+
+    @Column(name = "ip_origen", length = 45)
+    private String ipOrigen;
+
+    @Column(name = "user_agent", columnDefinition = "TEXT")
+    private String userAgent;
+
+    @Column(name = "session_id", length = 64)
+    private String sessionId;
+
+    @Column(name = "request_id", length = 64)
+    private String requestId;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    public ConsentimientoLocdoftEntity() {}
+
+    // Getters / setters
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+    public UUID getSocioId() { return socioId; }
+    public void setSocioId(UUID v) { this.socioId = v; }
+    public UUID getCuentaAhorroId() { return cuentaAhorroId; }
+    public void setCuentaAhorroId(UUID v) { this.cuentaAhorroId = v; }
+    public UUID getMovimientoId() { return movimientoId; }
+    public void setMovimientoId(UUID v) { this.movimientoId = v; }
+    public String getTipoOperacion() { return tipoOperacion; }
+    public void setTipoOperacion(String v) { this.tipoOperacion = v; }
+    public BigDecimal getMonto() { return monto; }
+    public void setMonto(BigDecimal v) { this.monto = v; }
+    public String getMoneda() { return moneda; }
+    public void setMoneda(String v) { this.moneda = v; }
+    public BigDecimal getUmbralAplicado() { return umbralAplicado; }
+    public void setUmbralAplicado(BigDecimal v) { this.umbralAplicado = v; }
+    public boolean isAceptaOrigenLicito() { return aceptaOrigenLicito; }
+    public void setAceptaOrigenLicito(boolean v) { this.aceptaOrigenLicito = v; }
+    public String getOrigenFondos() { return origenFondos; }
+    public void setOrigenFondos(String v) { this.origenFondos = v; }
+    public String getIpOrigen() { return ipOrigen; }
+    public void setIpOrigen(String v) { this.ipOrigen = v; }
+    public String getUserAgent() { return userAgent; }
+    public void setUserAgent(String v) { this.userAgent = v; }
+    public String getSessionId() { return sessionId; }
+    public void setSessionId(String v) { this.sessionId = v; }
+    public String getRequestId() { return requestId; }
+    public void setRequestId(String v) { this.requestId = v; }
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant v) { this.createdAt = v; }
+}

--- a/backend/src/main/java/com/tufondo/compliance/infrastructure/persistence/jpa/ConsentimientoLocdoftJpaRepository.java
+++ b/backend/src/main/java/com/tufondo/compliance/infrastructure/persistence/jpa/ConsentimientoLocdoftJpaRepository.java
@@ -1,0 +1,16 @@
+package com.tufondo.compliance.infrastructure.persistence.jpa;
+
+import com.tufondo.compliance.infrastructure.persistence.entity.ConsentimientoLocdoftEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.UUID;
+
+public interface ConsentimientoLocdoftJpaRepository extends JpaRepository<ConsentimientoLocdoftEntity, UUID> {
+
+    @Modifying
+    @Query("UPDATE ConsentimientoLocdoftEntity c SET c.movimientoId = :movimientoId WHERE c.id = :id")
+    int actualizarMovimientoId(@Param("id") UUID id, @Param("movimientoId") UUID movimientoId);
+}

--- a/backend/src/main/java/com/tufondo/compliance/presentation/controller/LocdoftUmbralController.java
+++ b/backend/src/main/java/com/tufondo/compliance/presentation/controller/LocdoftUmbralController.java
@@ -1,0 +1,46 @@
+package com.tufondo.compliance.presentation.controller;
+
+import com.tufondo.compliance.application.service.LocdoftOperacionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Endpoint público (autenticado) para consultar el umbral LOCDOFT vigente
+ * (#218 PR-C). El frontend lo llama antes de mostrar el modal o
+ * pre-validar si el monto de la operación lo excede.
+ *
+ * <p>Solo lectura — el endpoint de modificación vive en el módulo
+ * `parametros` con permisos de admin.</p>
+ */
+@RestController
+@RequestMapping("/api/v1/compliance/locdoft")
+@RequiredArgsConstructor
+@Tag(name = "Compliance", description = "Umbrales y consentimientos LOCDOFT")
+public class LocdoftUmbralController {
+
+    private final LocdoftOperacionService service;
+
+    @GetMapping("/umbral")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Consulta el umbral LOCDOFT vigente por moneda")
+    public ResponseEntity<Map<String, Object>> obtenerUmbral(
+            @RequestParam(defaultValue = "VES") String moneda
+    ) {
+        BigDecimal umbral = service.obtenerUmbral(moneda);
+        Map<String, Object> body = new HashMap<>();
+        body.put("moneda", moneda.toUpperCase());
+        body.put("umbral", umbral);  // puede ser null (fail-open) → frontend trata como "sin umbral"
+        return ResponseEntity.ok(body);
+    }
+}

--- a/backend/src/main/resources/db/migration/V20__locdoft_operacion_grande.sql
+++ b/backend/src/main/resources/db/migration/V20__locdoft_operacion_grande.sql
@@ -1,0 +1,82 @@
+-- =========================================================================
+-- V20__locdoft_operacion_grande.sql
+--
+-- Issue #218 PR-C: declaración jurada LOCDOFT en operaciones grandes
+-- (depósito o retiro > umbral configurable).
+--
+-- Cuando un socio realiza una operación cuyo monto supera el umbral
+-- LOCDOFT configurado en `parametros_sistema`, el frontend muestra un
+-- modal con la pregunta "¿Confirmas el origen lícito de los fondos?"
+-- y un campo opcional "Origen de los fondos". La aceptación se registra
+-- por operación en la tabla `consentimiento_locdoft_operacion` para
+-- trazabilidad legal (Art. 9 LOCDOFT — los sujetos obligados deben
+-- conservar declaraciones por al menos 5 años).
+-- =========================================================================
+
+-- 1. Seeds de los umbrales (idempotente — sólo inserta si la clave no existe)
+INSERT INTO parametros_sistema (clave, valor, tipo, descripcion, categoria, editable)
+SELECT 'LOCDOFT_UMBRAL_VES', '10000.00', 'CURRENCY',
+       'Umbral en bolívares para exigir declaración jurada LOCDOFT en operaciones (depósito/retiro). Por defecto Bs 10.000 (aprox equivalente a USD 1.000 con tasa BCV media histórica).',
+       'compliance', TRUE
+WHERE NOT EXISTS (SELECT 1 FROM parametros_sistema WHERE clave = 'LOCDOFT_UMBRAL_VES');
+
+INSERT INTO parametros_sistema (clave, valor, tipo, descripcion, categoria, editable)
+SELECT 'LOCDOFT_UMBRAL_USD', '1000.00', 'CURRENCY',
+       'Umbral en USD para exigir declaración jurada LOCDOFT en operaciones (depósito/retiro). Recomendación FATF: USD 1.000 para reporting de operaciones.',
+       'compliance', TRUE
+WHERE NOT EXISTS (SELECT 1 FROM parametros_sistema WHERE clave = 'LOCDOFT_UMBRAL_USD');
+
+-- 2. Tabla de consentimientos por operación
+--
+-- Diseño: una fila por operación que requirió declaración. NO se sobreescribe
+-- ni se borra (append-only conceptual, enforcement formal en EPIC #251 con
+-- audit_log central). El movimiento_id queda nullable porque el consentimiento
+-- se valida ANTES de crear el movimiento — si la operación falla por otra razón
+-- (saldo insuficiente en retiro, validación de límite, etc.) el consentimiento
+-- igual queda registrado como evidencia del intento + declaración del socio.
+CREATE TABLE IF NOT EXISTS consentimiento_locdoft_operacion (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+
+    socio_id UUID NOT NULL,
+    cuenta_ahorro_id UUID NOT NULL,
+    movimiento_id UUID NULL,                       -- FK soft a movimientos.id
+
+    tipo_operacion VARCHAR(20) NOT NULL,           -- 'DEPOSITO' | 'RETIRO'
+    monto NUMERIC(18, 2) NOT NULL,
+    moneda VARCHAR(3) NOT NULL,                    -- 'VES' | 'USD'
+    umbral_aplicado NUMERIC(18, 2) NOT NULL,       -- snapshot del umbral vigente al momento
+
+    acepta_origen_licito BOOLEAN NOT NULL,         -- declaración jurada del socio
+    origen_fondos TEXT NULL,                       -- texto libre opcional (PEP, etc.)
+
+    -- Trazabilidad legal (defensa para auditorías SUDECA/UNIF)
+    ip_origen VARCHAR(45) NULL,
+    user_agent TEXT NULL,
+    session_id VARCHAR(64) NULL,
+    request_id VARCHAR(64) NULL,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT chk_locdoft_tipo CHECK (tipo_operacion IN ('DEPOSITO', 'RETIRO')),
+    CONSTRAINT chk_locdoft_moneda CHECK (moneda IN ('VES', 'USD'))
+);
+
+-- Índices para consultas comunes (admin/cumplimiento)
+CREATE INDEX IF NOT EXISTS idx_locdoft_op_socio_fecha
+    ON consentimiento_locdoft_operacion (socio_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_locdoft_op_movimiento
+    ON consentimiento_locdoft_operacion (movimiento_id)
+    WHERE movimiento_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_locdoft_op_monto_fecha
+    ON consentimiento_locdoft_operacion (created_at DESC, monto DESC);
+
+COMMENT ON TABLE consentimiento_locdoft_operacion IS
+    'Declaraciones juradas LOCDOFT por operación financiera grande (#218 PR-C). Append-only conceptual — la evidencia debe conservarse mínimo 5 años (Art. 9 LOCDOFT).';
+
+COMMENT ON COLUMN consentimiento_locdoft_operacion.movimiento_id IS
+    'NULL si el consentimiento se registró pero la operación falló después por otra razón. Esto es deseable para la auditoría: queda evidencia del intento y la declaración del socio.';
+
+COMMENT ON COLUMN consentimiento_locdoft_operacion.umbral_aplicado IS
+    'Snapshot del umbral vigente en parametros_sistema al momento de la operación. Si el umbral cambia después, no afecta el registro histórico.';

--- a/backend/src/test/java/com/tufondo/compliance/application/service/LocdoftOperacionServiceTest.java
+++ b/backend/src/test/java/com/tufondo/compliance/application/service/LocdoftOperacionServiceTest.java
@@ -1,0 +1,231 @@
+package com.tufondo.compliance.application.service;
+
+import com.tufondo.compliance.domain.model.ConsentimientoLocdoftOperacion;
+import com.tufondo.compliance.domain.model.ConsentimientoLocdoftOperacion.TipoOperacion;
+import com.tufondo.compliance.domain.repository.ConsentimientoLocdoftRepository;
+import com.tufondo.parametros.domain.model.ParametroSistema;
+import com.tufondo.parametros.domain.repository.ParametroRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests del servicio LOCDOFT (#218 PR-C).
+ *
+ * <p>Cubre los 3 flujos críticos:
+ * (1) monto bajo umbral → no requiere consentimiento, devuelve null
+ * (2) monto sobre umbral SIN flag → lanza LocdoftConsentimientoRequeridoException
+ * (3) monto sobre umbral CON flag → persiste consentimiento y devuelve registro
+ *
+ * Plus: fail-open si el parámetro no se puede leer o tiene valor inválido.
+ */
+@ExtendWith(MockitoExtension.class)
+class LocdoftOperacionServiceTest {
+
+    @Mock private ParametroRepository parametroRepository;
+    @Mock private ConsentimientoLocdoftRepository consentimientoRepository;
+
+    @InjectMocks
+    private LocdoftOperacionService service;
+
+    private UUID socioId;
+    private UUID cuentaId;
+
+    @BeforeEach
+    void setUp() {
+        socioId = UUID.randomUUID();
+        cuentaId = UUID.randomUUID();
+    }
+
+    private LocdoftOperacionService.DatosOperacion datos(BigDecimal monto, String moneda, boolean confirma, String origen) {
+        return new LocdoftOperacionService.DatosOperacion(
+                socioId, cuentaId, TipoOperacion.DEPOSITO,
+                monto, moneda, confirma, origen,
+                "10.0.0.1", "Mozilla/5.0", "sess-1", "req-1"
+        );
+    }
+
+    private void stubUmbral(String key, String valor) {
+        when(parametroRepository.buscarPorKey(key)).thenReturn(Optional.of(
+                ParametroSistema.desdeParametros(key, valor,
+                        ParametroSistema.TipoParametro.CURRENCY,
+                        "test", "compliance", true, Instant.now(), null)));
+    }
+
+    @Test
+    @DisplayName("Monto bajo umbral VES → devuelve null sin tocar el repo de consentimientos")
+    void monto_bajo_umbral_no_requiere_consentimiento() {
+        stubUmbral("LOCDOFT_UMBRAL_VES", "10000.00");
+
+        ConsentimientoLocdoftOperacion resultado = service.validarYRegistrar(
+                datos(new BigDecimal("500.00"), "VES", false, null));
+
+        assertThat(resultado).isNull();
+        verify(consentimientoRepository, never()).guardar(any());
+    }
+
+    @Test
+    @DisplayName("Monto IGUAL al umbral → no lo supera, devuelve null (boundary)")
+    void monto_igual_umbral_no_requiere() {
+        stubUmbral("LOCDOFT_UMBRAL_VES", "10000.00");
+
+        ConsentimientoLocdoftOperacion resultado = service.validarYRegistrar(
+                datos(new BigDecimal("10000.00"), "VES", false, null));
+
+        assertThat(resultado).isNull();
+        verify(consentimientoRepository, never()).guardar(any());
+    }
+
+    @Test
+    @DisplayName("Monto SOBRE umbral SIN flag → lanza LocdoftConsentimientoRequeridoException con detalles")
+    void monto_sobre_umbral_sin_flag_lanza_exception() {
+        stubUmbral("LOCDOFT_UMBRAL_VES", "10000.00");
+
+        assertThatThrownBy(() -> service.validarYRegistrar(
+                datos(new BigDecimal("15000.00"), "VES", false, null)))
+                .isInstanceOf(LocdoftConsentimientoRequeridoException.class)
+                .satisfies(t -> {
+                    LocdoftConsentimientoRequeridoException e = (LocdoftConsentimientoRequeridoException) t;
+                    assertThat(e.getMontoSolicitado()).isEqualByComparingTo("15000.00");
+                    assertThat(e.getMoneda()).isEqualTo("VES");
+                    assertThat(e.getUmbral()).isEqualByComparingTo("10000.00");
+                });
+
+        verify(consentimientoRepository, never()).guardar(any());
+    }
+
+    @Test
+    @DisplayName("Monto SOBRE umbral CON flag → persiste consentimiento con snapshot del umbral + origenFondos")
+    void monto_sobre_umbral_con_flag_persiste() {
+        stubUmbral("LOCDOFT_UMBRAL_VES", "10000.00");
+        when(consentimientoRepository.guardar(any())).thenAnswer(inv -> {
+            ConsentimientoLocdoftOperacion c = inv.getArgument(0);
+            // simula que el repo asigna id
+            return ConsentimientoLocdoftOperacion.builder()
+                    .id(UUID.randomUUID())
+                    .socioId(c.getSocioId())
+                    .cuentaAhorroId(c.getCuentaAhorroId())
+                    .tipoOperacion(c.getTipoOperacion())
+                    .monto(c.getMonto())
+                    .moneda(c.getMoneda())
+                    .umbralAplicado(c.getUmbralAplicado())
+                    .aceptaOrigenLicito(c.isAceptaOrigenLicito())
+                    .origenFondos(c.getOrigenFondos())
+                    .createdAt(Instant.now())
+                    .build();
+        });
+
+        ConsentimientoLocdoftOperacion resultado = service.validarYRegistrar(
+                datos(new BigDecimal("15000.00"), "VES", true, "Venta de vehículo"));
+
+        assertThat(resultado).isNotNull();
+        assertThat(resultado.getId()).isNotNull();
+
+        ArgumentCaptor<ConsentimientoLocdoftOperacion> captor =
+                ArgumentCaptor.forClass(ConsentimientoLocdoftOperacion.class);
+        verify(consentimientoRepository).guardar(captor.capture());
+        ConsentimientoLocdoftOperacion guardado = captor.getValue();
+        assertThat(guardado.getSocioId()).isEqualTo(socioId);
+        assertThat(guardado.getCuentaAhorroId()).isEqualTo(cuentaId);
+        assertThat(guardado.getTipoOperacion()).isEqualTo(TipoOperacion.DEPOSITO);
+        assertThat(guardado.getMonto()).isEqualByComparingTo("15000.00");
+        assertThat(guardado.getUmbralAplicado()).isEqualByComparingTo("10000.00");
+        assertThat(guardado.isAceptaOrigenLicito()).isTrue();
+        assertThat(guardado.getOrigenFondos()).isEqualTo("Venta de vehículo");
+        assertThat(guardado.getMovimientoId()).isNull(); // se asocia después
+    }
+
+    @Test
+    @DisplayName("Moneda USD usa LOCDOFT_UMBRAL_USD, no el de VES")
+    void moneda_usd_lee_parametro_correcto() {
+        stubUmbral("LOCDOFT_UMBRAL_USD", "1000.00");
+
+        // 500 USD bajo umbral → null
+        assertThat(service.validarYRegistrar(datos(new BigDecimal("500.00"), "USD", false, null))).isNull();
+
+        verify(parametroRepository).buscarPorKey("LOCDOFT_UMBRAL_USD");
+        verify(parametroRepository, never()).buscarPorKey("LOCDOFT_UMBRAL_VES");
+    }
+
+    @Test
+    @DisplayName("Fail-open: si el parámetro no existe, NO bloquea la operación (devuelve null)")
+    void parametro_inexistente_fail_open() {
+        when(parametroRepository.buscarPorKey("LOCDOFT_UMBRAL_VES")).thenReturn(Optional.empty());
+
+        // Monto grande, sin flag — no lanza porque no hay umbral configurado
+        ConsentimientoLocdoftOperacion resultado = service.validarYRegistrar(
+                datos(new BigDecimal("9999999.00"), "VES", false, null));
+
+        assertThat(resultado).isNull();
+        verify(consentimientoRepository, never()).guardar(any());
+    }
+
+    @Test
+    @DisplayName("Fail-open: si el parámetro tiene valor no-numérico, NO bloquea (loguea + devuelve null)")
+    void parametro_valor_invalido_fail_open() {
+        stubUmbral("LOCDOFT_UMBRAL_VES", "esto-no-es-numero");
+
+        ConsentimientoLocdoftOperacion resultado = service.validarYRegistrar(
+                datos(new BigDecimal("99999.00"), "VES", false, null));
+
+        assertThat(resultado).isNull();
+    }
+
+    @Test
+    @DisplayName("Fail-open: si el repo lanza al leer el parámetro, NO bloquea")
+    void repo_lanza_fail_open() {
+        when(parametroRepository.buscarPorKey(any()))
+                .thenThrow(new RuntimeException("DB caída"));
+
+        ConsentimientoLocdoftOperacion resultado = service.validarYRegistrar(
+                datos(new BigDecimal("99999.00"), "VES", false, null));
+
+        assertThat(resultado).isNull();
+    }
+
+    @Test
+    @DisplayName("asociarConMovimiento: invoca al repo cuando ambos ids son no-null")
+    void asociar_con_movimiento_ok() {
+        UUID consentId = UUID.randomUUID();
+        UUID movId = UUID.randomUUID();
+
+        service.asociarConMovimiento(consentId, movId);
+
+        verify(consentimientoRepository).asociarConMovimiento(consentId, movId);
+    }
+
+    @Test
+    @DisplayName("asociarConMovimiento: con ids null hace no-op (resiliente)")
+    void asociar_con_movimiento_null_noop() {
+        service.asociarConMovimiento(null, UUID.randomUUID());
+        service.asociarConMovimiento(UUID.randomUUID(), null);
+        service.asociarConMovimiento(null, null);
+
+        verify(consentimientoRepository, never()).asociarConMovimiento(any(), any());
+    }
+
+    @Test
+    @DisplayName("asociarConMovimiento: si el repo lanza, NO propaga (la operación principal no debe abortar)")
+    void asociar_con_movimiento_falla_no_propaga() {
+        doThrow(new RuntimeException("DB caída"))
+                .when(consentimientoRepository).asociarConMovimiento(any(), any());
+
+        // NO debe lanzar
+        service.asociarConMovimiento(UUID.randomUUID(), UUID.randomUUID());
+    }
+}

--- a/frontend-web/src/app/(dashboard)/dashboard/cuentas/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/cuentas/page.tsx
@@ -12,6 +12,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Loader2 } from 'lucide-react';
 import { toastSuccess, toastError } from '@/components/ui/toast-helpers';
 import { useTipoCambio, convertirABolivares, convertirADolares } from '@/hooks/useTipoCambio';
+import { LocdoftOperacionModal } from '@/components/legal/locdoft-operacion-modal';
 
 interface Cuenta {
   id: string;
@@ -48,6 +49,13 @@ export default function CuentasPage() {
   const [loadingOperacion, setLoadingOperacion] = useState(false);
   const [operacion, setOperacion] = useState<'deposito' | 'retiro' | null>(null);
   const [openConfirm, setOpenConfirm] = useState(false);
+
+  // Issue #218 PR-C — modal LOCDOFT cuando el backend devuelve 422
+  // LOCDOFT_CONSENT_REQUIRED tras un primer intento sin el flag.
+  const [locdoftModal, setLocdoftModal] = useState<{
+    open: boolean;
+    umbral: number | null;
+  }>({ open: false, umbral: null });
   const [cuentaSeleccionada, setCuentaSeleccionada] = useState<Cuenta | null>(null);
 
   const [errores, setErrores] = useState<{ monto?: string }>({});
@@ -113,25 +121,23 @@ export default function CuentasPage() {
     setOpenConfirm(true);
   }
 
-  async function confirmarOperacion() {
+  // Ejecuta la operación. Si `extras` viene con `confirmaOrigenLicito=true`,
+  // significa que se está reintentando tras el modal LOCDOFT.
+  async function ejecutarOperacion(
+    extras?: { confirmaOrigenLicito: true; origenFondos: string }
+  ) {
     if (!cuentaSeleccionada || !operacion) return;
-
-    const error = validarMonto(monto, operacion);
-    if (error) {
-      setErrores({ monto: error });
-      return;
-    }
 
     setLoadingOperacion(true);
     try {
       const numMonto = parseFloat(monto);
       let nuevoSaldo: number;
       if (operacion === 'deposito') {
-        const res = await cuentasApi.deposito(cuentaSeleccionada.numeroCuenta, numMonto);
+        const res = await cuentasApi.deposito(cuentaSeleccionada.numeroCuenta, numMonto, extras);
         nuevoSaldo = res.data.saldoPosterior;
         toastSuccess('Depósito realizado', `Se depositaron $${numMonto.toFixed(2)} a la cuenta ${cuentaSeleccionada.numeroCuenta}`);
       } else {
-        const res = await cuentasApi.retiro(cuentaSeleccionada.numeroCuenta, numMonto);
+        const res = await cuentasApi.retiro(cuentaSeleccionada.numeroCuenta, numMonto, extras);
         nuevoSaldo = res.data.saldoPosterior;
         toastSuccess('Retiro realizado', `Se retiraron $${numMonto.toFixed(2)} de la cuenta ${cuentaSeleccionada.numeroCuenta}`);
       }
@@ -141,12 +147,36 @@ export default function CuentasPage() {
         )
       );
       setOpenConfirm(false);
+      setLocdoftModal({ open: false, umbral: null });
     } catch (err: unknown) {
-      const message = (err as { response?: { data?: { message?: string } } })?.response?.data?.message || 'Error en la operación';
+      const errResp = err as { response?: { status?: number; data?: { message?: string; error?: string; detalles?: { umbral?: number | string } } } };
+      // Issue #218 PR-C — backend pide declaración LOCDOFT (HTTP 422)
+      if (
+        errResp?.response?.status === 422 &&
+        errResp?.response?.data?.error === 'LOCDOFT_CONSENT_REQUIRED'
+      ) {
+        const umbralRaw = errResp.response.data.detalles?.umbral;
+        const umbral = umbralRaw != null ? Number(umbralRaw) : null;
+        setLocdoftModal({ open: true, umbral: Number.isFinite(umbral as number) ? (umbral as number) : null });
+        return; // NO mostrar toast de error — el modal se encarga
+      }
+      const message = errResp?.response?.data?.message || 'Error en la operación';
       toastError('Operación fallida', message);
     } finally {
       setLoadingOperacion(false);
     }
+  }
+
+  async function confirmarOperacion() {
+    if (!cuentaSeleccionada || !operacion) return;
+
+    const error = validarMonto(monto, operacion);
+    if (error) {
+      setErrores({ monto: error });
+      return;
+    }
+
+    await ejecutarOperacion();
   }
 
   return (
@@ -341,6 +371,18 @@ export default function CuentasPage() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Issue #218 PR-C — modal LOCDOFT cuando backend devuelve 422 */}
+      <LocdoftOperacionModal
+        open={locdoftModal.open}
+        tipoOperacion={operacion === 'retiro' ? 'retiro' : 'deposito'}
+        monto={parseFloat(monto) || 0}
+        moneda={(cuentaSeleccionada?.moneda as 'VES' | 'USD') || 'VES'}
+        umbral={locdoftModal.umbral}
+        procesando={loadingOperacion}
+        onCancelar={() => setLocdoftModal({ open: false, umbral: null })}
+        onConfirmar={(datos) => ejecutarOperacion(datos)}
+      />
     </div>
   );
 }

--- a/frontend-web/src/app/api/compliance/locdoft/umbral/route.ts
+++ b/frontend-web/src/app/api/compliance/locdoft/umbral/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+/**
+ * BFF read-only para consultar el umbral LOCDOFT vigente (#218 PR-C).
+ *
+ * GET /api/compliance/locdoft/umbral?moneda=VES|USD
+ * → { moneda: "VES", umbral: 10000.00 | null }
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const accessToken = request.cookies.get('access_token')?.value;
+    if (!accessToken) {
+      return NextResponse.json({ message: 'No autenticado' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const moneda = (searchParams.get('moneda') || 'VES').toUpperCase();
+    if (!['VES', 'USD'].includes(moneda)) {
+      return NextResponse.json(
+        { message: 'moneda inválida (se acepta VES o USD)' },
+        { status: 400 },
+      );
+    }
+
+    const backendResponse = await fetch(
+      `${BACKEND_URL}/api/v1/compliance/locdoft/umbral?moneda=${moneda}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    if (!backendResponse.ok) {
+      // fail-open: si el backend devuelve error, el frontend trata como
+      // "sin umbral" y deja que el backend decida en el POST de operación.
+      return NextResponse.json({ moneda, umbral: null }, { status: 200 });
+    }
+
+    const data = await backendResponse.json();
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    console.error('Locdoft umbral error:', error);
+    return NextResponse.json({ moneda: 'VES', umbral: null }, { status: 200 });
+  }
+}

--- a/frontend-web/src/components/legal/locdoft-operacion-modal.test.tsx
+++ b/frontend-web/src/components/legal/locdoft-operacion-modal.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LocdoftOperacionModal } from '@/components/legal/locdoft-operacion-modal';
+
+/**
+ * Tests del modal LOCDOFT para operaciones grandes (#218 PR-C).
+ */
+
+describe('LocdoftOperacionModal', () => {
+  const baseProps = {
+    open: true,
+    tipoOperacion: 'deposito' as const,
+    monto: 15000,
+    moneda: 'VES' as const,
+    umbral: 10000,
+    onCancelar: vi.fn(),
+    onConfirmar: vi.fn(),
+  };
+
+  it('no renderiza cuando open=false', () => {
+    render(<LocdoftOperacionModal {...baseProps} open={false} />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renderiza título, descripción LOCDOFT y monto', () => {
+    render(<LocdoftOperacionModal {...baseProps} />);
+    expect(screen.getByText(/Declaración jurada requerida \(LOCDOFT\)/i)).toBeTruthy();
+    // El texto LOCDOFT aparece en 2 lugares (descripción + checkbox), basta con
+    // verificar que aparece al menos una vez.
+    expect(screen.getAllByText(/Ley Orgánica contra la Delincuencia Organizada/i).length).toBeGreaterThan(0);
+    // El monto se muestra formateado con Bs
+    expect(screen.getByText(/15\.000,00/)).toBeTruthy();
+  });
+
+  it('muestra el umbral vigente cuando se pasa', () => {
+    render(<LocdoftOperacionModal {...baseProps} umbral={10000} />);
+    expect(screen.getByText(/umbral vigente/i)).toBeTruthy();
+  });
+
+  it('omite el umbral cuando es null (fail-open)', () => {
+    render(<LocdoftOperacionModal {...baseProps} umbral={null} />);
+    expect(screen.queryByText(/umbral vigente/i)).toBeNull();
+  });
+
+  it('botón "Confirmar y continuar" está deshabilitado sin tildar la declaración', () => {
+    render(<LocdoftOperacionModal {...baseProps} />);
+    const btn = screen.getByRole('button', { name: /confirmar y continuar/i });
+    expect(btn.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('al tildar la declaración, el botón se habilita', () => {
+    render(<LocdoftOperacionModal {...baseProps} />);
+    const checkbox = screen.getByRole('checkbox', {
+      name: /declaro que los fondos provienen de actividades l[íi]citas/i,
+    });
+    fireEvent.click(checkbox);
+    const btn = screen.getByRole('button', { name: /confirmar y continuar/i });
+    expect(btn.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('click en Confirmar invoca onConfirmar con confirmaOrigenLicito=true y origenFondos', () => {
+    const onConfirmar = vi.fn();
+    render(<LocdoftOperacionModal {...baseProps} onConfirmar={onConfirmar} />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /declaro/i }));
+    fireEvent.change(screen.getByLabelText(/origen de los fondos/i), {
+      target: { value: 'Venta de vehículo' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /confirmar y continuar/i }));
+
+    expect(onConfirmar).toHaveBeenCalledWith({
+      confirmaOrigenLicito: true,
+      origenFondos: 'Venta de vehículo',
+    });
+  });
+
+  it('click en Cancelar invoca onCancelar', () => {
+    const onCancelar = vi.fn();
+    render(<LocdoftOperacionModal {...baseProps} onCancelar={onCancelar} />);
+    fireEvent.click(screen.getByRole('button', { name: /cancelar/i }));
+    expect(onCancelar).toHaveBeenCalled();
+  });
+
+  it('verbo cambia según tipoOperacion (deposito → "depositar", retiro → "retirar")', () => {
+    const { unmount } = render(<LocdoftOperacionModal {...baseProps} tipoOperacion="deposito" />);
+    expect(screen.getByText(/depositar/i)).toBeTruthy();
+    unmount();
+
+    render(<LocdoftOperacionModal {...baseProps} tipoOperacion="retiro" />);
+    expect(screen.getByText(/retirar/i)).toBeTruthy();
+  });
+
+  it('moneda USD muestra "$" en lugar de "Bs"', () => {
+    render(<LocdoftOperacionModal {...baseProps} moneda="USD" monto={1500} />);
+    expect(screen.getByText(/\$ 1\.500,00/)).toBeTruthy();
+  });
+
+  it('procesando=true deshabilita Cancelar y Confirmar', () => {
+    render(<LocdoftOperacionModal {...baseProps} procesando />);
+    expect(screen.getByRole('button', { name: /cancelar/i }).hasAttribute('disabled')).toBe(true);
+    // Confirmar está disabled por checkbox no marcado + por procesando
+    expect(screen.getByRole('button', { name: /procesando/i }).hasAttribute('disabled')).toBe(true);
+  });
+});

--- a/frontend-web/src/components/legal/locdoft-operacion-modal.tsx
+++ b/frontend-web/src/components/legal/locdoft-operacion-modal.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { AlertTriangle, ShieldCheck } from 'lucide-react';
+
+/**
+ * Modal de declaración jurada LOCDOFT para operaciones grandes (#218 PR-C).
+ *
+ * Aparece cuando el monto de un depósito o retiro supera el umbral
+ * configurado. El usuario debe:
+ *   1. Marcar el checkbox de declaración jurada (obligatorio)
+ *   2. Opcionalmente describir el origen de los fondos
+ *   3. Confirmar — el form padre vuelve a hacer la operación con
+ *      `confirmaOrigenLicito=true` + `origenFondos` en el payload.
+ *
+ * Si el socio cierra el modal sin confirmar, la operación se cancela.
+ */
+
+export interface LocdoftOperacionModalProps {
+  /** Si el modal está abierto. */
+  open: boolean;
+  /** Tipo de operación (afecta solo el texto). */
+  tipoOperacion: 'deposito' | 'retiro';
+  /** Monto que el usuario quiso operar (para mostrarlo en el modal). */
+  monto: number;
+  /** Moneda — solo para formatear (VES → Bs, USD → $). */
+  moneda: 'VES' | 'USD';
+  /** Umbral vigente, para mostrar al usuario por qué se le pide. */
+  umbral: number | null;
+  /** Si la operación está en curso (deshabilita botones). */
+  procesando?: boolean;
+  /** Cierre sin confirmar. */
+  onCancelar: () => void;
+  /** Confirmación: el padre debe relanzar la operación con estos datos. */
+  onConfirmar: (datos: { confirmaOrigenLicito: true; origenFondos: string }) => void;
+}
+
+const formatMonto = (monto: number, moneda: 'VES' | 'USD') => {
+  const simbolo = moneda === 'VES' ? 'Bs' : '$';
+  return `${simbolo} ${monto.toLocaleString('es-VE', { minimumFractionDigits: 2 })}`;
+};
+
+export function LocdoftOperacionModal({
+  open,
+  tipoOperacion,
+  monto,
+  moneda,
+  umbral,
+  procesando = false,
+  onCancelar,
+  onConfirmar,
+}: LocdoftOperacionModalProps) {
+  const [aceptaOrigenLicito, setAceptaOrigenLicito] = useState(false);
+  const [origenFondos, setOrigenFondos] = useState('');
+
+  // Reset cuando se abre/cierra el modal
+  useEffect(() => {
+    if (open) {
+      setAceptaOrigenLicito(false);
+      setOrigenFondos('');
+    }
+  }, [open]);
+
+  const verbo = tipoOperacion === 'deposito' ? 'depositar' : 'retirar';
+
+  const handleConfirmar = () => {
+    if (!aceptaOrigenLicito || procesando) return;
+    onConfirmar({ confirmaOrigenLicito: true, origenFondos: origenFondos.trim() });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o && !procesando) onCancelar(); }}>
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-amber-900">
+            <AlertTriangle className="w-5 h-5 text-amber-600" aria-hidden="true" />
+            Declaración jurada requerida (LOCDOFT)
+          </DialogTitle>
+          <DialogDescription>
+            Esta operación supera el umbral de monitoreo establecido por la
+            Ley Orgánica contra la Delincuencia Organizada y Financiamiento al
+            Terrorismo (LOCDOFT). Necesitamos tu declaración jurada antes de
+            continuar.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Resumen de la operación */}
+          <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm">
+            <p className="text-amber-900">
+              Estás por <strong>{verbo}</strong>{' '}
+              <strong className="text-base">{formatMonto(monto, moneda)}</strong>
+              {umbral !== null && (
+                <>
+                  {' '}— umbral vigente:{' '}
+                  <span className="font-mono">{formatMonto(umbral, moneda)}</span>
+                </>
+              )}
+              .
+            </p>
+          </div>
+
+          {/* Checkbox obligatorio */}
+          <label className="flex items-start gap-3 rounded-lg border border-slate-200 p-3 hover:bg-slate-50 cursor-pointer">
+            <Checkbox
+              id="acepta-origen-licito"
+              checked={aceptaOrigenLicito}
+              onCheckedChange={(c) => setAceptaOrigenLicito(c === true)}
+              disabled={procesando}
+              className="mt-1"
+              aria-label="Declaro que los fondos provienen de actividades lícitas"
+            />
+            <Label htmlFor="acepta-origen-licito" className="text-sm leading-relaxed text-slate-800 cursor-pointer">
+              <strong className="block mb-1 text-[#0F2744]">Declaración jurada</strong>
+              Declaro bajo fe de juramento que los fondos involucrados en esta
+              operación <strong>no provienen de actividades ilícitas</strong>,
+              de acuerdo con la Ley Orgánica contra la Delincuencia Organizada
+              y Financiamiento al Terrorismo (LOCDOFT).
+            </Label>
+          </label>
+
+          {/* Campo opcional */}
+          <div className="space-y-2">
+            <Label htmlFor="origen-fondos" className="text-sm font-medium text-slate-700">
+              Origen de los fondos <span className="text-xs font-normal text-slate-500">(opcional)</span>
+            </Label>
+            <Textarea
+              id="origen-fondos"
+              value={origenFondos}
+              onChange={(e) => setOrigenFondos(e.target.value)}
+              disabled={procesando}
+              maxLength={2000}
+              placeholder="Ej: ahorros personales, venta de vehículo, herencia..."
+              className="min-h-[80px] resize-y"
+              aria-describedby="origen-fondos-help"
+            />
+            <p id="origen-fondos-help" className="text-xs text-slate-500">
+              Información que ayuda al departamento de cumplimiento. Útil si
+              estás registrado como PEP (Persona Expuesta Políticamente) o
+              quieres justificar voluntariamente el origen.
+            </p>
+          </div>
+
+          {/* Acciones */}
+          <div className="flex flex-col sm:flex-row gap-2 sm:justify-end pt-2 border-t border-slate-100">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onCancelar}
+              disabled={procesando}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="button"
+              onClick={handleConfirmar}
+              disabled={!aceptaOrigenLicito || procesando}
+              className="bg-[#16A34A] hover:bg-green-700 gap-2"
+            >
+              <ShieldCheck className="w-4 h-4" aria-hidden="true" />
+              {procesando ? 'Procesando...' : 'Confirmar y continuar'}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend-web/src/lib/api/client.ts
+++ b/frontend-web/src/lib/api/client.ts
@@ -79,17 +79,28 @@ export const cuentasApi = {
     if (tipoFiltro) url += `&tipo=${tipoFiltro}`;
     return apiClient.get(url);
   },
-  deposito: (numeroCuenta: string, monto: number) =>
+  // Issue #218 PR-C — `extras` permite enviar la declaración LOCDOFT
+  // cuando el backend responde 422 LOCDOFT_CONSENT_REQUIRED y el usuario
+  // confirma en el modal. Para operaciones normales, no se pasa.
+  deposito: (numeroCuenta: string, monto: number, extras?: { confirmaOrigenLicito?: boolean; origenFondos?: string }) =>
     apiClient.post(`/v1/cuentas/${numeroCuenta}/depositos`, {
       monto,
       canalOrigen: 'WEB',
-      descripcion: 'Depósito en línea'
+      descripcion: 'Depósito en línea',
+      ...(extras?.confirmaOrigenLicito ? {
+        confirmaOrigenLicito: true,
+        origenFondos: extras.origenFondos || null,
+      } : {}),
     }),
-  retiro: (numeroCuenta: string, monto: number) =>
+  retiro: (numeroCuenta: string, monto: number, extras?: { confirmaOrigenLicito?: boolean; origenFondos?: string }) =>
     apiClient.post(`/v1/cuentas/${numeroCuenta}/retiros`, {
       monto,
       canalOrigen: 'WEB',
-      descripcion: 'Retiro en línea'
+      descripcion: 'Retiro en línea',
+      ...(extras?.confirmaOrigenLicito ? {
+        confirmaOrigenLicito: true,
+        origenFondos: extras.origenFondos || null,
+      } : {}),
     }),
 };
 

--- a/frontend-web/src/lib/hooks/use-locdoft-umbral.ts
+++ b/frontend-web/src/lib/hooks/use-locdoft-umbral.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Lee el umbral LOCDOFT vigente desde el backend (#218 PR-C).
+ *
+ * Pre-validación: el form puede preguntar "¿este monto supera el umbral?"
+ * antes de mostrar el modal, para mejor UX. Si el endpoint falla o devuelve
+ * null (fail-open en backend), el hook devuelve `null` y el frontend
+ * trata como "sin umbral" — el backend igualmente devolverá 422 si la
+ * operación lo requiere, así que es defensa en profundidad.
+ *
+ * Se cachea en memoria del componente (se vuelve a pedir en cada mount).
+ * Si en el futuro queremos cachear entre sesiones, se mueve a SWR/React
+ * Query con su propio storage.
+ */
+export function useLocdoftUmbral(moneda: 'VES' | 'USD' = 'VES') {
+  const [umbral, setUmbral] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelado = false;
+    setLoading(true);
+    fetch(`/api/compliance/locdoft/umbral?moneda=${encodeURIComponent(moneda)}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelado) return;
+        // backend devuelve { moneda, umbral }. Si umbral viene null, fail-open.
+        const valor = data?.umbral != null ? Number(data.umbral) : null;
+        setUmbral(Number.isFinite(valor as number) ? (valor as number) : null);
+      })
+      .catch(() => {
+        if (!cancelado) setUmbral(null); // fail-open
+      })
+      .finally(() => {
+        if (!cancelado) setLoading(false);
+      });
+    return () => {
+      cancelado = true;
+    };
+  }, [moneda]);
+
+  return { umbral, loading };
+}


### PR DESCRIPTION
Closes #218 (último PR de la serie). PR-A merged en #275 (banner cookies), PR-B merged en #276 (LOCDOFT en registro), este es el PR-C (modal LOCDOFT en operaciones grandes).

## Flujo end-to-end

1. Socio intenta depositar Bs 15.000 (umbral configurado: Bs 10.000)
2. Frontend hace POST normal sin flag LOCDOFT
3. Backend valida: monto > umbral + no hay confirmaOrigenLicito → HTTP 422 con \`{ error: \"LOCDOFT_CONSENT_REQUIRED\", detalles: { umbral, montoSolicitado, moneda } }\`
4. Frontend detecta el código, abre **modal de declaración jurada**
5. Socio marca el checkbox \"Declaro que los fondos provienen de actividades lícitas...\" (obligatorio) + opcionalmente describe el origen
6. Frontend reintenta POST con \`{ ..., confirmaOrigenLicito: true, origenFondos: \"...\" }\`
7. Backend valida + persiste el consentimiento en \`consentimiento_locdoft_operacion\` (snapshot del umbral + ip + user-agent + session) + ejecuta el movimiento + asocia el consentimiento con el \`movimientoId\`

## Backend — nuevo módulo \`compliance\`

| Pieza | Descripción |
|---|---|
| Migración V20 | Seeds \`LOCDOFT_UMBRAL_VES=10000.00\` + \`LOCDOFT_UMBRAL_USD=1000.00\` (editables por admin) + tabla \`consentimiento_locdoft_operacion\` |
| \`ConsentimientoLocdoftOperacion\` | Domain con campos legales (ip, user-agent, session, request, umbral_aplicado snapshot, origen_fondos) |
| Entity + repo + impl | JPA con índices para queries comunes (socio+fecha, movimiento, monto+fecha) |
| \`LocdoftOperacionService\` | Lee umbral, valida monto, persiste consentimiento o lanza excepción 422. FAIL-OPEN si el parámetro falla |
| \`LocdoftConsentimientoRequeridoException\` | HTTP 422 con código \`LOCDOFT_CONSENT_REQUIRED\` + detalles estructurados |
| \`LocdoftUmbralController\` | \`GET /api/v1/compliance/locdoft/umbral?moneda=\` para pre-validación frontend |
| \`AhorroExceptionHandler\` | Mapea la excepción al 422 |

## Backend — ahorros extendido

- \`DepositoRequest\` + \`RetiroRequest\` con campos opcionales \`confirmaOrigenLicito\` + \`origenFondos\`
- \`RealizarDepositoUseCase\` + \`RealizarRetiroUseCase\` invocan al \`LocdoftOperacionService\` antes de ejecutar
- Tras crear el movimiento, asocian el consentimiento con su id (resiliente: si falla, log + skip)

## Frontend

| Pieza | Descripción |
|---|---|
| \`LocdoftOperacionModal\` | Modal accesible: resumen operación + checkbox obligatorio + textarea opcional. Mobile-friendly |
| \`useLocdoftUmbral\` | Hook que lee el umbral vigente (cliente) |
| BFF \`/api/compliance/locdoft/umbral\` | Proxy al backend |
| \`cuentasApi.deposito/retiro\` | Acepta \`extras\` opcional con los flags LOCDOFT |
| \`cuentas/page.tsx\` | Refactor: detecta 422 LOCDOFT_CONSENT_REQUIRED → abre modal → reintenta |

## Decisiones de diseño

| Decisión | Por qué |
|---|---|
| Tabla aparte (no columnas en \`movimientos\`) | \`movimientos\` es inmutable (RN-006); el consentimiento tiene campos legales propios que rompen la unidad semántica |
| \`movimiento_id\` nullable | Si la operación falla DESPUÉS por otra razón (saldo, límite), el consentimiento queda como evidencia del intento + declaración |
| \`umbral_aplicado\` snapshot | Si el admin cambia el umbral después, el registro histórico mantiene el valor original |
| Fail-open en lectura del parámetro | Si \`parametros_sistema\` falla, se loguea WARN y NO se bloquea la operación — el umbral es defensa adicional, no la única protección |
| Umbrales editables por admin | Cumplimiento puede ajustarlos sin redeploy |

## Tests

**Backend** (`LocdoftOperacionServiceTest` — 11 tests):
- Boundary del umbral (igual, sobre, bajo)
- Flag faltante → lanza con detalles correctos
- Flag presente → persiste con snapshot + origen
- USD usa parámetro correcto (no VES)
- Fail-open en 3 escenarios (param inexistente, valor inválido, repo lanza)
- \`asociarConMovimiento\` resiliente (null + repo lanza)

**Frontend** (`locdoft-operacion-modal.test.tsx` — 11 tests):
- Render condicional, contenido (título, descripción LOCDOFT, monto, umbral)
- Botón Confirmar deshabilitado sin tildar
- Cancelar invoca callback
- Confirmar pasa \`{ confirmaOrigenLicito: true, origenFondos }\`
- Verbo cambia por tipoOperacion
- Moneda USD vs VES
- procesando=true deshabilita botones

## Verificación

- [x] \`mvn test\`: **403 passing / 0 failures** (+11 nuevos del LocdoftService)
- [x] \`npm run build\`: OK
- [x] \`npm test\`: **537 passing / 17 preexistentes failing (554 total)**. +11 nuevos verdes del modal; los 17 failing son preexistentes en \`develop\` — no regresión.

## Test plan QA

- [ ] Login como socio → Cuentas → cualquier cuenta → \"Depósito\"
- [ ] Ingresar monto **bajo umbral** (ej. Bs 5.000) → opera normal, no aparece modal
- [ ] Ingresar monto **sobre umbral** (ej. Bs 15.000) → aparece **modal amarillo \"Declaración jurada requerida (LOCDOFT)\"** con resumen de operación + umbral
- [ ] Intentar confirmar sin tildar la declaración → botón está deshabilitado
- [ ] Tildar la declaración → botón se habilita
- [ ] Llenar opcionalmente \"Origen de los fondos\" (ej. \"Venta de vehículo\")
- [ ] Click \"Confirmar y continuar\" → la operación se realiza, modal cierra
- [ ] Verificar en BD: existe fila en \`consentimiento_locdoft_operacion\` con socio, monto, umbral snapshot, origen_fondos, ip, user_agent, movimiento_id asociado
- [ ] Mismo flujo para **retiro** sobre umbral
- [ ] Cancelar el modal → operación se aborta (no genera movimiento)
- [ ] Admin: cambiar el parámetro \`LOCDOFT_UMBRAL_VES\` a otro valor → siguiente operación usa el nuevo umbral

🤖 Generated with [Claude Code](https://claude.com/claude-code)