### PR TITLE
feat(login): rediseño desktop con layout 2-cols + logo PNG real

### DIFF
--- a/frontend-web/public/logo-fatrans.svg
+++ b/frontend-web/public/logo-fatrans.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  PLACEHOLDER SVG del logo de Fatrans.
-  Reemplazar este archivo por el PNG real (rendido del logo institucional
-  con la mascota digital y el círculo metálico) en `public/logo-fatrans.png`,
-  y actualizar `frontend-web/src/components/branding/logo.tsx` para usar `.png`.
+  PLACEHOLDER SVG del logo de Fatrans (sin RIF).
+  El archivo real institucional vive en `public/logo-fatrans.png` y es
+  el que la app realmente carga. Este SVG queda como fallback de
+  desarrollo o si el PNG no se encuentra (cambiar el src en
+  `components/branding/logo.tsx` si se quiere usar).
 
-  Mientras tanto este placeholder mantiene la identidad visual:
-  - Anillo metálico (gradient gris) — base del logo
-  - Insecto/mascota digital en verde Fatrans (#16A34A) — silueta simplificada
-  - Texto FATRANS en azul institucional (#0F2744)
+  Identidad visual: anillo metálico con texto curvado + mascota digital
+  verde con ojos de circuito + texto FATRANS abajo. Versión simplificada
+  del logo real (sin todo el detalle del render).
 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Fatrans">
   <defs>
@@ -25,6 +25,8 @@
       <stop offset="0%" stop-color="#0f2744"/>
       <stop offset="100%" stop-color="#1e40af"/>
     </linearGradient>
+    <path id="circle-top" d="M 28 128 A 100 100 0 0 1 228 128" fill="none"/>
+    <path id="circle-bot" d="M 228 128 A 100 100 0 0 1 28 128" fill="none"/>
   </defs>
 
   <!-- Anillo metálico exterior -->
@@ -32,26 +34,34 @@
   <!-- Anillo decorativo interior -->
   <circle cx="128" cy="128" r="100" fill="none" stroke="#94a3b8" stroke-width="1" opacity="0.5"/>
 
+  <!-- Texto curvado superior "ASOCIACIÓN DE AHORRO Y CRÉDITO" -->
+  <text font-family="ui-sans-serif, system-ui, -apple-system, sans-serif"
+        font-size="13" font-weight="700" fill="#0f2744" letter-spacing="1">
+    <textPath href="#circle-top" startOffset="50%" text-anchor="middle">
+      ASOCIACIÓN DE AHORRO Y CRÉDITO
+    </textPath>
+  </text>
+
   <!-- Mascota: silueta de "alien" digital simplificada -->
-  <g transform="translate(128 116)">
+  <g transform="translate(128 124)">
     <!-- Antenas -->
-    <line x1="-22" y1="-45" x2="-32" y2="-65" stroke="#0f2744" stroke-width="4" stroke-linecap="round"/>
-    <line x1="22"  y1="-45" x2="32"  y2="-65" stroke="#0f2744" stroke-width="4" stroke-linecap="round"/>
+    <line x1="-22" y1="-40" x2="-32" y2="-60" stroke="#0f2744" stroke-width="4" stroke-linecap="round"/>
+    <line x1="22"  y1="-40" x2="32"  y2="-60" stroke="#0f2744" stroke-width="4" stroke-linecap="round"/>
     <!-- Cabeza/cuerpo (forma ovalada) -->
-    <ellipse cx="0" cy="0" rx="42" ry="48" fill="#0f2744"/>
+    <ellipse cx="0" cy="0" rx="40" ry="44" fill="#0f2744"/>
     <!-- Ojos grandes de "circuito" verde -->
-    <ellipse cx="-15" cy="-8" rx="13" ry="17" fill="url(#alien)"/>
-    <ellipse cx="15"  cy="-8" rx="13" ry="17" fill="url(#alien)"/>
+    <ellipse cx="-14" cy="-6" rx="12" ry="16" fill="url(#alien)"/>
+    <ellipse cx="14"  cy="-6" rx="12" ry="16" fill="url(#alien)"/>
     <!-- Brillo en los ojos -->
-    <ellipse cx="-17" cy="-13" rx="3" ry="4" fill="#bbf7d0" opacity="0.8"/>
-    <ellipse cx="13"  cy="-13" rx="3" ry="4" fill="#bbf7d0" opacity="0.8"/>
+    <ellipse cx="-16" cy="-11" rx="3" ry="4" fill="#bbf7d0" opacity="0.8"/>
+    <ellipse cx="12"  cy="-11" rx="3" ry="4" fill="#bbf7d0" opacity="0.8"/>
     <!-- Boca pequeña -->
-    <path d="M -10 22 Q 0 30, 10 22" stroke="#94a3b8" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <path d="M -9 20 Q 0 27, 9 20" stroke="#94a3b8" stroke-width="2.5" fill="none" stroke-linecap="round"/>
   </g>
 
-  <!-- Texto FATRANS -->
-  <text x="128" y="222" text-anchor="middle"
+  <!-- Texto FATRANS abajo -->
+  <text x="128" y="228" text-anchor="middle"
         font-family="ui-sans-serif, system-ui, -apple-system, Inter, sans-serif"
-        font-size="32" font-weight="800" fill="#0f2744"
+        font-size="30" font-weight="800" fill="#0f2744"
         letter-spacing="3">FATRANS</text>
 </svg>

--- a/frontend-web/src/app/layout.tsx
+++ b/frontend-web/src/app/layout.tsx
@@ -18,16 +18,16 @@ export const metadata: Metadata = {
   applicationName: 'Fatrans',
   // Iconos servidos desde frontend-web/src/app/ (Next.js 14 los detecta
   // automáticamente: icon.png → favicon, apple-icon.png → iOS).
-  // Fallback explícito a /logo-fatrans.svg por si el navegador no lee
+  // Fallback explícito a /logo-fatrans.png por si el navegador no lee
   // los conventional icons.
   icons: {
     icon: [
-      { url: '/logo-fatrans.svg', type: 'image/png' },
+      { url: '/logo-fatrans.png', type: 'image/png' },
     ],
     apple: [
-      { url: '/logo-fatrans.svg', type: 'image/png' },
+      { url: '/logo-fatrans.png', type: 'image/png' },
     ],
-    shortcut: '/logo-fatrans.svg',
+    shortcut: '/logo-fatrans.png',
   },
   openGraph: {
     title: 'Fatrans · Asociación de Ahorro y Crédito',

--- a/frontend-web/src/components/branding/logo.tsx
+++ b/frontend-web/src/components/branding/logo.tsx
@@ -6,16 +6,14 @@ import Image from 'next/image';
  * Logo institucional de Fatrans.
  *
  * Usa `next/image` para optimización automática (resize, lazy, formatos
- * modernos). El archivo fuente vive en `frontend-web/public/logo-fatrans.svg`
- * (placeholder).
+ * modernos). El archivo fuente vive en `frontend-web/public/logo-fatrans.png`
+ * — debe ser el logo institucional real (PNG render del logo metálico con
+ * la mascota digital, sin RIF embebido). Idealmente 1024×1024 con fondo
+ * transparente.
  *
- * Para reemplazar por el logo institucional real (PNG render del logo
- * metálico con la mascota digital):
- *   1. Guardar el archivo en `frontend-web/public/logo-fatrans.png`
- *      (PNG con fondo transparente, idealmente 1024×1024).
- *   2. Cambiar el `src` abajo de `.svg` a `.png` (Next.js detecta el
- *      formato automáticamente).
- *   3. Opcional: eliminar `logo-fatrans.svg` si ya no se necesita.
+ * Si el PNG no existe, el browser muestra el alt text. Para tener un
+ * fallback visual, se mantiene `logo-fatrans.svg` (placeholder estilizado)
+ * — el dev puede cambiar el `src` temporalmente si quiere ver el placeholder.
  */
 
 export interface LogoProps {
@@ -41,7 +39,7 @@ export function Logo({ size = 96, className = '', soloImagen = false, priority =
         aria-label="Fatrans — Asociación de Ahorro y Crédito"
       >
         <Image
-          src="/logo-fatrans.svg"
+          src="/logo-fatrans.png"
           alt="Fatrans"
           fill
           sizes={`${size}px`}

--- a/frontend-web/src/components/features/auth/login-form-neobank.tsx
+++ b/frontend-web/src/components/features/auth/login-form-neobank.tsx
@@ -149,24 +149,51 @@ export function LoginFormNeobank() {
           procesando, no congelada. */}
       {isLoading && <LoadingLogo variante="overlay" mensaje="Iniciando sesión..." />}
 
-      {/* Login Card */}
-      <div className="relative z-10 w-full max-w-md">
-        <div className="bg-white rounded-2xl shadow-2xl shadow-blue-950/50 overflow-hidden">
-          {/* Card Header con logo institucional */}
-          <div className="px-8 pt-8 pb-6 text-center border-b border-slate-100">
-            <div className="flex justify-center mb-4">
-              <Logo size={88} priority />
+      {/* Container responsivo: 2 columnas en desktop (logo institucional
+          a la izquierda + card del form a la derecha), stack vertical en
+          mobile (logo dentro del card como antes). */}
+      <div className="relative z-10 w-full max-w-5xl">
+        <div className="grid lg:grid-cols-[1.1fr_1fr] gap-8 lg:gap-12 items-center">
+          {/* === COLUMNA IZQUIERDA: Branding institucional (solo desktop) === */}
+          <aside className="hidden lg:flex flex-col items-center text-center text-white px-4">
+            <Logo size={220} soloImagen priority />
+            <h1 className="mt-6 text-5xl font-bold tracking-tight">Fatrans</h1>
+            <p className="mt-2 text-base uppercase tracking-[0.2em] text-blue-200/90">
+              Asociación de Ahorro y Crédito
+            </p>
+            <p className="mt-8 text-sm text-white/80 max-w-md leading-relaxed">
+              El respaldo financiero del sector transporte venezolano.
+              Ahorro, crédito y servicios diseñados para socios del transporte.
+            </p>
+            <div className="mt-8 flex flex-wrap gap-2 justify-center">
+              <TrustChip icon={Lock} label="Cifrado de grado bancario" />
+              <TrustChip icon={ShieldCheck} label="Auditoría LOCDOFT" />
             </div>
-            <h1 className="text-xl font-bold text-slate-900">
+            <p className="mt-10 text-xs text-white/40">
+              RIF J-50516835-5 · © {new Date().getFullYear()} Fatrans
+            </p>
+          </aside>
+
+          {/* === COLUMNA DERECHA: Card del formulario === */}
+          <div className="w-full max-w-md mx-auto lg:mx-0">
+        <div className="bg-white rounded-2xl shadow-2xl shadow-blue-950/50 overflow-hidden">
+          {/* Card Header — logo solo visible en mobile (en desktop ya
+              está en la columna izquierda). En desktop, el header queda
+              más compacto y limpio. */}
+          <div className="px-7 pt-6 pb-5 text-center border-b border-slate-100">
+            <div className="flex justify-center mb-3 lg:hidden">
+              <Logo size={72} priority />
+            </div>
+            <h2 className="text-lg lg:text-xl font-bold text-slate-900">
               Acceso Seguro al Fondo
-            </h1>
-            <p className="text-sm text-slate-500 mt-1">
+            </h2>
+            <p className="text-xs lg:text-sm text-slate-500 mt-1">
               Ingresa tus credenciales para continuar
             </p>
           </div>
 
-          {/* Card Body */}
-          <div className="px-8 py-8">
+          {/* Card Body — padding compactado para que el card no se infle */}
+          <div className="px-7 py-6">
             {/* Lockout Warning */}
             {lockoutRemaining > 0 && (
               <div className="mb-6 p-4 rounded-xl bg-red-50 border border-red-200 flex items-center gap-3">
@@ -205,7 +232,7 @@ export function LoginFormNeobank() {
                   placeholder="Ej: V-12345678"
                   autoComplete="username"
                   disabled={isLoading || lockoutRemaining > 0}
-                  className="h-14 px-4 rounded-xl border-slate-300 bg-slate-50 text-base placeholder:text-slate-400 focus:bg-white focus:border-[#16A34A] focus:ring-2 focus:ring-[#16A34A]/20 transition-all"
+                  className="h-12 px-4 rounded-xl border-slate-300 bg-slate-50 text-base placeholder:text-slate-400 focus:bg-white focus:border-[#16A34A] focus:ring-2 focus:ring-[#16A34A]/20 transition-all"
                   {...register('identificador')}
                   aria-invalid={!!errors.identificador}
                   aria-describedby={errors.identificador ? 'identificador-error' : undefined}
@@ -236,7 +263,7 @@ export function LoginFormNeobank() {
                     placeholder="Ingresa tu contraseña"
                     autoComplete="current-password"
                     disabled={isLoading || lockoutRemaining > 0}
-                    className="h-14 px-4 pr-12 rounded-xl border-slate-300 bg-slate-50 text-base placeholder:text-slate-400 focus:bg-white focus:border-[#16A34A] focus:ring-2 focus:ring-[#16A34A]/20 transition-all"
+                    className="h-12 px-4 pr-12 rounded-xl border-slate-300 bg-slate-50 text-base placeholder:text-slate-400 focus:bg-white focus:border-[#16A34A] focus:ring-2 focus:ring-[#16A34A]/20 transition-all"
                     {...register('password')}
                     aria-invalid={!!errors.password}
                     aria-describedby={errors.password ? 'password-error' : undefined}
@@ -306,7 +333,7 @@ export function LoginFormNeobank() {
               {/* Submit Button */}
               <Button
                 type="submit"
-                className="w-full h-14 bg-[#16A34A] hover:bg-[#15803D] text-white font-semibold text-base rounded-xl transition-all shadow-lg shadow-[#16A34A]/25 hover:shadow-[#16A34A]/40 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="w-full h-12 bg-[#16A34A] hover:bg-[#15803D] text-white font-semibold text-base rounded-xl transition-all shadow-lg shadow-[#16A34A]/25 hover:shadow-[#16A34A]/40 disabled:opacity-50 disabled:cursor-not-allowed"
                 disabled={isLoading || lockoutRemaining > 0}
               >
                 {isLoading ? (
@@ -334,24 +361,41 @@ export function LoginFormNeobank() {
             </p>
           </div>
 
-          {/* Card Footer - Trust Badges */}
-          <div className="px-8 py-5 bg-slate-50 border-t border-slate-100">
-            <div className="flex items-center justify-center gap-1 text-xs text-slate-400">
+          {/* Card Footer - Trust Badges (siempre visible) */}
+          <div className="px-7 py-4 bg-slate-50 border-t border-slate-100">
+            <div className="flex flex-wrap items-center justify-center gap-x-1 gap-y-1 text-xs text-slate-400">
               <Lock className="w-3 h-3" />
               <span>Cifrado de grado bancario.</span>
-              <span className="mx-1.5 text-slate-300">•</span>
-              <span>Auditoría en tiempo real.</span>
-              <span className="mx-1.5 text-slate-300">•</span>
+              <span className="mx-1 text-slate-300">•</span>
               <span className="font-medium text-slate-500">v2.1.0</span>
             </div>
           </div>
         </div>
 
-        {/* Copyright */}
-        <p className="mt-6 text-center text-xs text-white/40">
-          © {new Date().getFullYear()} Fatrans. Todos los derechos reservados.
+        {/* Copyright — solo visible en mobile (en desktop ya está en la
+            columna izquierda con el RIF). */}
+        <p className="mt-6 text-center text-xs text-white/40 lg:hidden">
+          © {new Date().getFullYear()} Fatrans · RIF J-50516835-5
         </p>
+          </div>
+          {/* === FIN columna derecha === */}
+        </div>
+        {/* === FIN grid 2-cols === */}
       </div>
     </div>
+  );
+}
+
+/**
+ * Chip de confianza institucional (solo visible en desktop).
+ * Muestra una característica de seguridad/cumplimiento con ícono +
+ * label sobre fondo glassmorphism.
+ */
+function TrustChip({ icon: Icon, label }: { icon: React.ComponentType<{ className?: string }>; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-white/10 backdrop-blur-sm border border-white/15 px-3 py-1.5 text-xs font-medium text-white/90">
+      <Icon className="w-3.5 h-3.5 text-emerald-400" />
+      {label}
+    </span>
   );
 }


### PR DESCRIPTION
## Problema

En desktop el card del login se ve **estirado verticalmente**, dominando toda la pantalla:

- Card max-w-md (~448px) ocupando 700px+ de alto en una pantalla de 1000px
- Logo dentro del card → en mobile se ve bien, en desktop el espacio horizontal disponible se desperdicia
- UX poco profesional para una página de acceso a una asociación de ahorro institucional

## Rediseño

Layout responsivo en **dos modos**:

### Desktop (lg ≥ 1024px) — Layout 2 columnas
```
┌──────────────────────────────┬─────────────────────┐
│                              │                     │
│        [LOGO 220px]          │   ┌─────────────┐   │
│                              │   │  Acceso     │   │
│       Fatrans                │   │  Seguro     │   │
│ ASOCIACIÓN DE AHORRO Y CRÉDITO│   ├─────────────┤   │
│                              │   │ Cédula:     │   │
│  El respaldo financiero del  │   │ ▢▢▢▢▢▢▢▢▢▢ │   │
│  sector transporte venezolano│   │ Contraseña: │   │
│                              │   │ ▢▢▢▢▢▢▢▢▢▢ │   │
│  🔒 Cifrado bancario         │   │             │   │
│  🛡  Auditoría LOCDOFT       │   │ [Iniciar]   │   │
│                              │   └─────────────┘   │
│  RIF J-50516835-5 · © 2026   │                     │
└──────────────────────────────┴─────────────────────┘
```

- **Izquierda**: branding institucional grande (logo 220px + título + chips de seguridad + RIF)
- **Derecha**: card compacto con form (inputs `h-12`, padding reducido)

### Mobile (< lg)
Stack vertical igual al actual: logo dentro del card + form abajo. La columna izquierda se oculta con `lg:flex` / `lg:hidden`.

## Cambios técnicos

| Pieza | Cambio |
|---|---|
| `login-form-neobank.tsx` | Wrapper grid 2-cols con `lg:grid-cols-[1.1fr_1fr]`. Card pasa de `max-w-md` global a `max-w-md` solo en su columna |
| Inputs altura | `h-14` → `h-12` (cards menos altos, menos scroll en mobile) |
| Padding card body | `px-8 py-8` → `px-7 py-6` |
| Padding card header | `pt-8 pb-6` → `pt-6 pb-5` |
| Logo en header del card | Solo visible en mobile (`lg:hidden`) — en desktop ya está en la columna izquierda |
| Nuevo `TrustChip` | Chip glassmorphism con ícono + label sobre `bg-white/10 backdrop-blur-sm` (solo desktop) |
| Footer del card | Compactado: solo "Cifrado de grado bancario · v2.1.0" |
| Copyright | Solo visible en mobile (`lg:hidden`) — en desktop el RIF + copyright están en col izquierda |

## Logo PNG real

⚠️ **Acción requerida tuya**:

El componente `Logo` ahora apunta a `/logo-fatrans.png` (antes `.svg`). Guarda el logo institucional real (el que me pasaste sin RIF) en:

```
frontend-web/public/logo-fatrans.png
```

- Tamaño recomendado: **cuadrado 1024×1024 px**
- Fondo **transparente** (el logo se renderiza sobre fondos oscuros y claros)
- Sin RIF embebido en la imagen

Si el archivo no está, el navegador muestra el alt text "Fatrans" (no rompe la app). El SVG placeholder (`logo-fatrans.svg`) sigue en `public/` por si alguna vez quieres usarlo de fallback de dev.

## Mantenido

- Animación `LoadingLogo` overlay cuando `isLoading=true` — sigue funcionando, no se tocó.
- Toda la lógica de validación, lockout, attempts warning, rememberMe, etc. — intacta.
- Background con gradient + dots pattern — intacto.

## Verificación

- [x] `npm run build`: OK
- [x] `npm test`: **537 passing / 17 preexistentes failing (554 total)** — sin cambio neto (no se rompió ningún test existente, no se agregaron nuevos porque el redesign es visual).

## Test plan QA

- [ ] **Desktop** (≥ 1024px de ancho de viewport):
  - Logo grande a la izquierda con título "Fatrans" + subtítulo + chips de seguridad
  - Card del form a la derecha (sin logo en el header — ya está al lado)
  - Card NO se ve inflado verticalmente — ocupa solo lo necesario
- [ ] **Mobile** (< 1024px, o resize del browser): columna izquierda desaparece, el card del form muestra el logo arriba (mobile-first como antes)
- [ ] Hacer login con credenciales válidas → overlay de carga con logo "respirando" aparece → redirige al dashboard
- [ ] Pestaña del navegador muestra el favicon (logo PNG si lo subiste, alt text si no)
- [ ] `prefers-reduced-motion: reduce`: animaciones del LoadingLogo se desactivan

🤖 Generated with [Claude Code](https://claude.com/claude-code)