### PR TITLE
fix: bug V20 (login QA) + logo fondo transparente + animación login + sharp

### DIFF
--- a/backend/src/main/resources/db/migration/V20__locdoft_operacion_grande.sql
+++ b/backend/src/main/resources/db/migration/V20__locdoft_operacion_grande.sql
@@ -14,14 +14,21 @@
 -- =========================================================================
 
 -- 1. Seeds de los umbrales (idempotente — sólo inserta si la clave no existe)
-INSERT INTO parametros_sistema (clave, valor, tipo, descripcion, categoria, editable)
-SELECT 'LOCDOFT_UMBRAL_VES', '10000.00', 'CURRENCY',
+--
+-- NOTA HISTÓRICA: la tabla `parametros_sistema` tiene DOS columnas NOT NULL
+-- duplicadas (`clave` de la migración V8 + `param_key` agregada por
+-- Hibernate `ddl-auto: update` desde el campo `key` de la entidad JPA).
+-- Cualquier INSERT directo desde SQL debe llenar AMBAS, sino viola el
+-- NOT NULL constraint de `param_key`. (Pendiente: unificar esto en una
+-- migración futura que dropee `clave` y deje solo `param_key`.)
+INSERT INTO parametros_sistema (clave, param_key, valor, tipo, descripcion, categoria, editable)
+SELECT 'LOCDOFT_UMBRAL_VES', 'LOCDOFT_UMBRAL_VES', '10000.00', 'CURRENCY',
        'Umbral en bolívares para exigir declaración jurada LOCDOFT en operaciones (depósito/retiro). Por defecto Bs 10.000 (aprox equivalente a USD 1.000 con tasa BCV media histórica).',
        'compliance', TRUE
 WHERE NOT EXISTS (SELECT 1 FROM parametros_sistema WHERE clave = 'LOCDOFT_UMBRAL_VES');
 
-INSERT INTO parametros_sistema (clave, valor, tipo, descripcion, categoria, editable)
-SELECT 'LOCDOFT_UMBRAL_USD', '1000.00', 'CURRENCY',
+INSERT INTO parametros_sistema (clave, param_key, valor, tipo, descripcion, categoria, editable)
+SELECT 'LOCDOFT_UMBRAL_USD', 'LOCDOFT_UMBRAL_USD', '1000.00', 'CURRENCY',
        'Umbral en USD para exigir declaración jurada LOCDOFT en operaciones (depósito/retiro). Recomendación FATF: USD 1.000 para reporting de operaciones.',
        'compliance', TRUE
 WHERE NOT EXISTS (SELECT 1 FROM parametros_sistema WHERE clave = 'LOCDOFT_UMBRAL_USD');

--- a/frontend-web/src/components/branding/logo.tsx
+++ b/frontend-web/src/components/branding/logo.tsx
@@ -44,6 +44,12 @@ export function Logo({ size = 96, className = '', soloImagen = false, priority =
           fill
           sizes={`${size}px`}
           priority={priority}
+          // `unoptimized` evita que Next.js intente procesar el PNG con
+          // `sharp` (no instalado en el container standalone). Para un logo
+          // estático servido como PNG con fondo transparente ya optimizado,
+          // no necesitamos la pipeline de webp/avif resampling. Bonus:
+          // evita el log spam "'sharp' is required" en producción.
+          unoptimized
           className="object-contain drop-shadow-md"
         />
       </div>

--- a/frontend-web/src/components/features/auth/login-form-neobank.tsx
+++ b/frontend-web/src/components/features/auth/login-form-neobank.tsx
@@ -74,6 +74,19 @@ export function LoginFormNeobank() {
     if (lockoutRemaining > 0) return;
 
     setIsLoading(true);
+    // Mínimo visual de la animación de "Iniciando sesión..." — si el backend
+    // responde en <1500ms el overlay del logo animado apenas se ve y el
+    // usuario percibe el login como "no hizo nada". Forzamos un piso de
+    // 1.5s para que el feedback sea claro (patrón estándar de banca digital
+    // que prioriza confianza sobre microsegundos de latencia percibida).
+    const ANIM_MIN_MS = 1500;
+    const animStart = Date.now();
+    const waitMinDelay = async () => {
+      const elapsed = Date.now() - animStart;
+      if (elapsed < ANIM_MIN_MS) {
+        await new Promise((r) => setTimeout(r, ANIM_MIN_MS - elapsed));
+      }
+    };
 
     try {
       const response = await fetch('/api/auth/login', {
@@ -111,6 +124,9 @@ export function LoginFormNeobank() {
         const appUrl = process.env.NEXT_PUBLIC_APP_URL || '';
         const adminUrl = process.env.NEXT_PUBLIC_ADMIN_URL || '';
 
+        // Esperar mínimo 1.5s para que la animación se vea (UX bancario)
+        await waitMinDelay();
+
         if (rol === 'SOCIO') {
           window.location.href = `${appUrl}/dashboard`;
         } else {
@@ -119,6 +135,11 @@ export function LoginFormNeobank() {
       }
     } catch (error) {
       setLoading(false);
+      // También respetar el mínimo en errores: si el backend rebota en 200ms
+      // con "credenciales inválidas", queremos que la animación se vea al
+      // menos un segundo antes de mostrar el toast (sino el usuario duda si
+      // siquiera intentó loguearse).
+      await waitMinDelay();
       console.error('Login error:', error);
       const message = error instanceof Error ? sanitizeHTML(error.message) : 'Error de conexión';
       toast.error(message);


### PR DESCRIPTION
## Contexto

Tras el deploy del PR #279 (rediseño login + logo PNG), aparecieron 3 problemas en QA al mismo tiempo + un detalle del logging:

1. ❌ **No se podía loguear** (HTTP 500)
2. 🟡 **Logo con fondo blanco** desencajaba en la columna izquierda oscura del nuevo layout
3. 🟡 **Animación de "Iniciando sesión..." apenas perceptible** (parpadeo de ms cuando el backend responde rápido)
4. ⚠️ Logs del frontend: error de `sharp` missing al optimizar imágenes

Este PR cierra los 4 con un solo commit.

## Fix 1 — Migración V20 `param_key NOT NULL` violation

**Root cause**: la tabla `parametros_sistema` tiene DOS columnas NOT NULL duplicadas:
- `clave` (creada por migración V8)
- `param_key` (agregada por Hibernate `ddl-auto: update` desde el campo `key` de la entidad)

Mi migración V20 (`#218 PR-C — LOCDOFT`) hacía `INSERT (clave, valor, ...)` y violaba el NOT NULL de `param_key`. Flyway abortaba → backend QA crasheaba en bucle → login → HTTP 500.

**Fix**: llenar AMBAS columnas en los INSERTs:
```sql
INSERT INTO parametros_sistema (clave, param_key, valor, tipo, descripcion, categoria, editable)
SELECT 'LOCDOFT_UMBRAL_VES', 'LOCDOFT_UMBRAL_VES', '10000.00', ...
```

**Comentario agregado** en V20 documentando el schema sucio (cleanup pendiente para una migración futura que dropee `clave` y deje solo `param_key`).

**Aplicado en QA**: borré la fila V20 fallida del `flyway_schema_history`, re-inserté con checksum del archivo, reinicié backend QA. Login responde 401 a credenciales inválidas (esperado, no más 500).

## Fix 2 — Logo con fondo transparente

PNG original tenía fondo blanco que se veía mal en columna izquierda oscura del nuevo login 2-cols. **Procesado con Pillow**:
- Pixeles con R,G,B ≥ 245 → alpha 0 (transparente)
- 22.3% del área total (toda la máscara blanca alrededor del logo metálico)
- Peso bajó de 7.0MB → **4.86MB**

Pillow NO se agrega al `package.json` — fue procesamiento one-shot local. El PNG procesado se commite al repo.

## Fix 3 — `unoptimized` en componente Logo

Sin `sharp` instalado en el container standalone, `next/image` lanzaba `Error: 'sharp' is required to be installed in standalone mode...` al optimizar imágenes locales.

**Fix quirúrgico**: `<Image unoptimized />` solo en el `<Logo>` (no a nivel global). Como el PNG ya está optimizado y es estático, no necesitamos la pipeline webp/avif. Bonus: elimina el log spam en producción.

Alternativa más invasiva (NO aplicada): agregar `sharp` como dep — ~50MB extra en el bundle del server, innecesario para nuestro único asset estático.

## Fix 4 — Delay mínimo 1.5s en animación de login

Si el backend responde en 200ms, el overlay del logo animado apenas se ve. Patrón de banca digital: priorizar feedback de confianza sobre latencia percibida.

```tsx
const ANIM_MIN_MS = 1500;
// ... await waitMinDelay() antes de router.push(redirect) o toast.error
```

Aplica tanto al éxito como al error (si las credenciales son inválidas, el usuario igual ve la animación 1.5s antes del toast).

## Verificación QA

| Check | Resultado |
|---|---|
| `POST /api/v1/auth/login` con creds inválidas | HTTP 401 ✓ (era 500 antes) |
| `GET /logo-fatrans.png` Content-Length | 4,986,588 ✓ (PNG transparente nuevo) |
| `fatrans-qa-backend` | healthy ✓ |
| `fatrans-qa-frontend-public/protected` | up ✓ |

## ⚠️ PROD intacto

NO se tocó la BD `fondo` ni el container `fatrans-backend` de PROD. El bug de V20 solo se manifestó en QA porque QA fue el primero en aplicar V20. Cuando se mergee este PR a `develop` y eventualmente promote a `main`, PROD aplicará V20 con la versión arreglada.

## Estado del checksum de V20 en QA

Tras el merge de este PR:
- Frontend Docker image se rebuilds con `unoptimized` + PNG transparente
- Backend Docker image se rebuilds con V20 corregido
- En QA: el checksum del nuevo V20 será distinto al que insertó mi hotfix manual (1739259598). Flyway va a fallar por validation mismatch.
- **Acción post-merge**: ejecutar `DELETE FROM flyway_schema_history WHERE version = '20'` en `fondo_qa` ANTES del próximo deploy, o usar `mvn flyway:repair` si está disponible. Yo lo puedo hacer vía SSH al VPS si me dejás.

## Tests / cambios mínimos

- Solo 4 archivos modificados
- Sin cambios en tests existentes (los 537 passing siguen pasando)
- Build OK localmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)