### PR TITLE
fix(layouts): boton Cerrar Sesion del dropdown ahora ejecuta logout

### DIFF
--- a/frontend-web/src/components/layouts/admin/admin-shell.tsx
+++ b/frontend-web/src/components/layouts/admin/admin-shell.tsx
@@ -67,10 +67,25 @@ export function AdminShell({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
-      if (profileRef.current && !profileRef.current.contains(event.target as Node)) {
+      const target = event.target as Element | null;
+      if (!target) return;
+      // Ignorar clicks dentro de portals de Radix (Dialog/Popover/etc.).
+      // Razón: el LogoutButton abre un Dialog de confirmación que Radix
+      // renderiza vía Portal FUERA de `profileRef`. Sin esta guarda, el
+      // click en "Cerrar Sesión" del modal se interpretaba como
+      // "click afuera" → cerraba el dropdown → desmontaba el DialogTrigger
+      // → Radix cerraba el Dialog → el logout nunca se ejecutaba.
+      if (
+        target.closest('[role="dialog"]') ||
+        target.closest('[data-radix-popper-content-wrapper]') ||
+        target.closest('[data-radix-portal]')
+      ) {
+        return;
+      }
+      if (profileRef.current && !profileRef.current.contains(target as Node)) {
         setProfileOpen(false);
       }
-      if (notifRef.current && !notifRef.current.contains(event.target as Node)) {
+      if (notifRef.current && !notifRef.current.contains(target as Node)) {
         setNotificationsOpen(false);
       }
     }

--- a/frontend-web/src/components/layouts/socio/socio-shell.tsx
+++ b/frontend-web/src/components/layouts/socio/socio-shell.tsx
@@ -58,7 +58,22 @@ export function SocioShell({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
-      if (profileRef.current && !profileRef.current.contains(event.target as Node)) {
+      const target = event.target as Element | null;
+      if (!target) return;
+      // Ignorar clicks dentro de portals de Radix (Dialog/Popover/etc.).
+      // Razón: el LogoutButton abre un Dialog de confirmación que Radix
+      // renderiza vía Portal FUERA de `profileRef`. Sin esta guarda, el
+      // click en "Cerrar Sesión" del modal se interpretaba como
+      // "click afuera" → cerraba el dropdown → desmontaba el DialogTrigger
+      // → Radix cerraba el Dialog → el logout nunca se ejecutaba.
+      if (
+        target.closest('[role="dialog"]') ||
+        target.closest('[data-radix-popper-content-wrapper]') ||
+        target.closest('[data-radix-portal]')
+      ) {
+        return;
+      }
+      if (profileRef.current && !profileRef.current.contains(target as Node)) {
         setProfileOpen(false);
       }
     }


### PR DESCRIPTION
## Reemplaza #282

#282 quedó en conflicto porque incluía cambios que ya estaban en develop por el merge de #281. Este PR es limpio: branch nueva desde `origin/develop` actualizado + cherry-pick **solo del commit del logout fix**.

## Bug

En socios y admin, click en "Cerrar Sesión" del dropdown del avatar (arriba-derecha) → modal de confirmación abre → click "Cerrar Sesión" del modal → **no pasa nada**. El logout no se ejecuta.

## Causa raíz

El `LogoutButton` usa `<Dialog>` de shadcn/Radix que se renderiza vía **Portal FUERA del DOM del dropdown** (`profileRef`).

Flujo del bug:
1. Click "Cerrar Sesión" del dropdown → `DialogTrigger` abre el modal de confirmación
2. Click "Cerrar Sesión" del modal de confirmación → el evento ocurre **fuera de `profileRef`** (porque el Dialog está en Portal)
3. `handleClickOutside` se dispara → `setProfileOpen(false)`
4. El dropdown se desmonta → el `DialogTrigger` desaparece del DOM
5. Radix detecta que el trigger ya no existe → cierra el `Dialog`
6. `handleLogout` **nunca se ejecuta**

## Fix

Guarda en `handleClickOutside` que ignora clicks dentro de Radix Portals:

```ts
function handleClickOutside(event: MouseEvent) {
  const target = event.target as Element | null;
  if (!target) return;
  // Ignorar clicks dentro de portals de Radix (Dialog/Popover/etc.)
  if (
    target.closest('[role="dialog"]') ||
    target.closest('[data-radix-popper-content-wrapper]') ||
    target.closest('[data-radix-portal]')
  ) {
    return;
  }
  if (profileRef.current && !profileRef.current.contains(target as Node)) {
    setProfileOpen(false);
  }
}
```

Aplicado en:
- `socio-shell.tsx` (dropdown del avatar)
- `admin-shell.tsx` (dropdown del avatar — mismo bug)

## Mantiene el comportamiento original

El dropdown sigue cerrándose al click fuera (en el navbar, sidebar, contenido de la página, etc.). **Solo agrega la excepción para Radix portals** que es lo correcto.

## Test plan QA

- [ ] Logged como socio: click avatar arriba-derecha → dropdown abre
- [ ] Click "Cerrar Sesión" en el dropdown → modal de confirmación aparece (el dropdown queda visible debajo)
- [ ] Click "Cancelar" del modal → modal cierra, dropdown sigue abierto ✓
- [ ] Reabrir modal: click "Cerrar Sesión" del modal → toast "Sesión cerrada correctamente" + redirect a `/login` ✓
- [ ] Mismo flujo logged como admin → idem
- [ ] Click en cualquier otro lugar de la página (no el dropdown ni el modal) → dropdown se cierra normalmente ✓

## ⚠️ Al mergear

**Usá "Create a merge commit"** o **"Rebase and merge"** — NO "Squash". El squash nos comió cambios 2 veces ya (PR #279 PNG, PR #281 unoptimized+delay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)