### PR TITLE
fix(deploy-prod): script versionado en repo + defensa contra containers no-compose

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Shell scripts must use LF line endings (sino bash en Linux falla).
+*.sh text eol=lf

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -26,6 +26,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Copia el script de deploy del repo al VPS antes de ejecutarlo.
+      # Así el repo es la fuente de verdad: cualquier cambio en
+      # `infrastructure/scripts/deploy-prod.sh` se aplica en el
+      # siguiente deploy automáticamente, sin tocar el VPS a mano.
+      - name: Subir script de deploy al VPS
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          port: 22
+          source: "infrastructure/scripts/deploy-prod.sh"
+          target: "/opt/fatrans/"
+          strip_components: 2
+
       - name: Deploy vía SSH al VPS
         uses: appleboy/ssh-action@v1.0.3
         with:
@@ -35,6 +50,7 @@ jobs:
           port: 22
           timeout: 20m
           script: |
+            chmod +x /opt/fatrans/deploy-prod.sh
             bash /opt/fatrans/deploy-prod.sh ${{ github.sha }}
 
       - name: Verificar Producción

--- a/infrastructure/scripts/deploy-prod.sh
+++ b/infrastructure/scripts/deploy-prod.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# ============================================================
+#  deploy-prod.sh  —  Script de deploy para Producción
+#
+#  El workflow `.github/workflows/deploy-prod.yml` copia este
+#  archivo del repo al VPS en /opt/fatrans/deploy-prod.sh y lo
+#  ejecuta vía SSH. **El repo es la fuente de verdad** — cualquier
+#  cambio acá se aplica al próximo deploy automáticamente.
+#
+#  Uso: bash /opt/fatrans/deploy-prod.sh <GIT_SHA>
+# ============================================================
+set -euo pipefail
+
+GIT_SHA=${1:-"latest"}
+REPO_DIR="/opt/fatrans/backend"
+INFRA_DIR="/opt/fatrans/backend/infrastructure"
+LOG_FILE="/var/log/fatrans-prod-deploy.log"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"; }
+
+log "======================================================"
+log " Iniciando deploy PRODUCCIÓN  —  SHA: $GIT_SHA"
+log "======================================================"
+
+# 1. Actualizar código
+log "→ Actualizando repositorio..."
+cd "$REPO_DIR"
+git fetch origin
+# `-B` crea la rama local si no existe, o la resetea si existe.
+# Necesario para clones que históricamente vinieron con refspec
+# restringido a develop (la primera promoción a main falla con
+# `git checkout main` plain porque la rama local no existe aún).
+git checkout -B main origin/main
+git reset --hard origin/main
+log "   Código actualizado: $(git log --oneline -1)"
+
+# 2. Build del Backend
+log "→ Construyendo imagen backend (prod)..."
+docker build \
+  -t fatrans-backend:latest \
+  -t "fatrans-backend:$GIT_SHA" \
+  -f "$REPO_DIR/backend/Dockerfile" \
+  "$REPO_DIR/backend/"
+log "   Backend build OK"
+
+# 3. Build del Frontend
+log "→ Construyendo imagen frontend (prod)..."
+docker build \
+  -t fatrans-frontend:latest \
+  -t "fatrans-frontend:$GIT_SHA" \
+  --build-arg NEXT_PUBLIC_API_URL=https://api.fatrans.com.ve/api \
+  --build-arg NEXT_PUBLIC_APP_URL=https://app.fatrans.com.ve \
+  "$REPO_DIR/frontend-web/"
+
+docker tag fatrans-frontend:latest fatrans-frontend-public:latest
+docker tag fatrans-frontend:latest fatrans-frontend-protected:latest
+log "   Frontend build OK"
+
+# 4. Defensa contra containers pre-existentes creados fuera de compose.
+#    Si en algún momento se levantaron containers a mano (sin labels
+#    `com.docker.compose.project`), `docker compose --force-recreate`
+#    no los reconoce como propios y choca contra el `container_name`.
+#    Removerlos acá es idempotente — si ya son compose-managed,
+#    `compose up` los recrea normalmente; si no existen, no hace nada.
+log "→ Limpiando containers PROD pre-existentes (si los hay)..."
+for c in fatrans-backend fatrans-frontend-public fatrans-frontend-protected; do
+  if docker inspect "$c" >/dev/null 2>&1; then
+    LABEL=$(docker inspect --format='{{ index .Config.Labels "com.docker.compose.project" }}' "$c" 2>/dev/null || echo "")
+    if [ -z "$LABEL" ]; then
+      log "   $c existe sin labels de compose — removiendo para que compose lo cree fresco"
+      docker rm -f "$c" >/dev/null
+    else
+      log "   $c ya es compose-managed (proyecto=$LABEL) — compose se encargará"
+    fi
+  fi
+done
+
+# 5. Restart con zero-downtime (recrear uno a uno)
+log "→ Actualizando backend..."
+cd "$INFRA_DIR"
+docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate backend
+
+log "→ Esperando backend saludable..."
+for i in $(seq 1 18); do
+  STATUS=$(docker inspect --format='{{.State.Health.Status}}' fatrans-backend 2>/dev/null || echo "starting")
+  if [ "$STATUS" = "healthy" ]; then
+    log "   Backend saludable ✓"
+    break
+  fi
+  log "   Intento $i/18 — $STATUS"
+  sleep 10
+done
+
+log "→ Actualizando frontends..."
+docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate frontend_public frontend_protected
+
+# 6. Verificación
+log "→ Verificación final..."
+SERVICES=("fatrans-backend" "fatrans-frontend-public" "fatrans-frontend-protected")
+ALL_OK=true
+for svc in "${SERVICES[@]}"; do
+  STATUS=$(docker inspect --format='{{.State.Status}}' "$svc" 2>/dev/null || echo "missing")
+  if [ "$STATUS" != "running" ]; then
+    log "   ❌ $svc — $STATUS"
+    ALL_OK=false
+  else
+    log "   ✅ $svc — running"
+  fi
+done
+
+# 7. Limpieza
+docker image prune -f --filter "until=72h" 2>/dev/null || true
+
+if $ALL_OK; then
+  log "======================================================"
+  log " ✅ Deploy PRODUCCIÓN completado — SHA: $GIT_SHA"
+  log " 🌐 https://fatrans.com.ve"
+  log "======================================================"
+  exit 0
+else
+  log "======================================================"
+  log " ❌ Deploy PRODUCCIÓN FALLÓ"
+  log "======================================================"
+  exit 1
+fi


### PR DESCRIPTION
## Por qué

PR #284 mergeó develop → main por primera vez. El Deploy → Producción falló dos veces:

1. **Primera vez**: `git checkout main` fallaba porque el repo del VPS tenía refspec restringido a `develop` (legacy de `--single-branch`). Local `main` no existía.
2. **Segunda vez** (tras parchar el git checkout en el VPS): la build de backend y frontend completó OK, pero `docker compose up --force-recreate backend` chocó con el container existente (`fatrans-backend`) que estaba corriendo creado a mano (sin labels de compose), entonces compose no lo reconocía como propio.

PROD siguió corriendo la versión vieja todo el tiempo — no llegó a tocarse, los dos fallos fueron antes de cualquier `docker stop`.

## Qué hace este PR

1. **`infrastructure/scripts/deploy-prod.sh`** (nuevo) — Antes vivía solo en el VPS bajo `/opt/fatrans/deploy-prod.sh` sin version control. Ahora el repo es la fuente de verdad. Incluye los dos fixes:
   - `git checkout -B main origin/main` en lugar de `git checkout main` (crea la rama local si no existe — idempotente)
   - Loop defensivo que detecta containers PROD pre-existentes SIN labels de compose y los `docker rm -f` antes del `compose up`. Si ya son compose-managed (como sucederá después de este primer deploy), no hace nada.

2. **`.github/workflows/deploy-prod.yml`** — Agrega un step previo con `appleboy/scp-action` que copia el script del repo al VPS antes de ejecutarlo. Así cualquier cambio futuro al script entra automáticamente en el próximo deploy, sin SSH manual.

3. **`.gitattributes`** — Fuerza LF en `.sh` para que Git no rompa los scripts cuando se commitea desde Windows.

## Flujo después del merge

1. Merge este PR a `develop`
2. PR `develop` → `main` (la 2ª promoción a main; ya tiene PR #284 también)
3. Merge → triggerea Deploy → Producción
4. El workflow: scp del script ↓ build backend ↓ build frontend ↓ `docker rm -f` containers viejos ↓ `compose up` ↓ healthcheck ↓ verify

Si el deploy vuelve a fallar, el step 7 (Rollback automático) re-tagga la imagen anterior del backend y la levanta — el frontend habría que volver atrás manualmente.

## Test plan

- [ ] Action `Deploy → Producción` corre con conclusión `success`
- [ ] Step "Subir script de deploy al VPS" sube `/opt/fatrans/deploy-prod.sh`
- [ ] Container `fatrans-backend` queda `healthy`
- [ ] Container `fatrans-frontend-public` y `fatrans-frontend-protected` `running`
- [ ] BD `fondo` migrations V11..V20 con `success=true` en `flyway_schema_history`
- [ ] `https://fatrans.com.ve` 200
- [ ] `https://app.fatrans.com.ve` 200
- [ ] Login funciona con usuario real
- [ ] Logo PNG aparece (no 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
