### PR TITLE
release: 2ª promoción — hardening del deploy-prod (fix containers no-compose)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Shell scripts must use LF line endings (sino bash en Linux falla).
+*.sh text eol=lf

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -26,6 +26,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Copia el script de deploy del repo al VPS antes de ejecutarlo.
+      # Así el repo es la fuente de verdad: cualquier cambio en
+      # `infrastructure/scripts/deploy-prod.sh` se aplica en el
+      # siguiente deploy automáticamente, sin tocar el VPS a mano.
+      - name: Subir script de deploy al VPS
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          port: 22
+          source: "infrastructure/scripts/deploy-prod.sh"
+          target: "/opt/fatrans/"
+          strip_components: 2
+
       - name: Deploy vía SSH al VPS
         uses: appleboy/ssh-action@v1.0.3
         with:
@@ -35,6 +50,7 @@ jobs:
           port: 22
           timeout: 20m
           script: |
+            chmod +x /opt/fatrans/deploy-prod.sh
             bash /opt/fatrans/deploy-prod.sh ${{ github.sha }}
 
       - name: Verificar Producción

--- a/infrastructure/scripts/deploy-prod.sh
+++ b/infrastructure/scripts/deploy-prod.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# ============================================================
+#  deploy-prod.sh  —  Script de deploy para Producción
+#
+#  El workflow `.github/workflows/deploy-prod.yml` copia este
+#  archivo del repo al VPS en /opt/fatrans/deploy-prod.sh y lo
+#  ejecuta vía SSH. **El repo es la fuente de verdad** — cualquier
+#  cambio acá se aplica al próximo deploy automáticamente.
+#
+#  Uso: bash /opt/fatrans/deploy-prod.sh <GIT_SHA>
+# ============================================================
+set -euo pipefail
+
+GIT_SHA=${1:-"latest"}
+REPO_DIR="/opt/fatrans/backend"
+INFRA_DIR="/opt/fatrans/backend/infrastructure"
+LOG_FILE="/var/log/fatrans-prod-deploy.log"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"; }
+
+log "======================================================"
+log " Iniciando deploy PRODUCCIÓN  —  SHA: $GIT_SHA"
+log "======================================================"
+
+# 1. Actualizar código
+log "→ Actualizando repositorio..."
+cd "$REPO_DIR"
+git fetch origin
+# `-B` crea la rama local si no existe, o la resetea si existe.
+# Necesario para clones que históricamente vinieron con refspec
+# restringido a develop (la primera promoción a main falla con
+# `git checkout main` plain porque la rama local no existe aún).
+git checkout -B main origin/main
+git reset --hard origin/main
+log "   Código actualizado: $(git log --oneline -1)"
+
+# 2. Build del Backend
+log "→ Construyendo imagen backend (prod)..."
+docker build \
+  -t fatrans-backend:latest \
+  -t "fatrans-backend:$GIT_SHA" \
+  -f "$REPO_DIR/backend/Dockerfile" \
+  "$REPO_DIR/backend/"
+log "   Backend build OK"
+
+# 3. Build del Frontend
+log "→ Construyendo imagen frontend (prod)..."
+docker build \
+  -t fatrans-frontend:latest \
+  -t "fatrans-frontend:$GIT_SHA" \
+  --build-arg NEXT_PUBLIC_API_URL=https://api.fatrans.com.ve/api \
+  --build-arg NEXT_PUBLIC_APP_URL=https://app.fatrans.com.ve \
+  "$REPO_DIR/frontend-web/"
+
+docker tag fatrans-frontend:latest fatrans-frontend-public:latest
+docker tag fatrans-frontend:latest fatrans-frontend-protected:latest
+log "   Frontend build OK"
+
+# 4. Defensa contra containers pre-existentes creados fuera de compose.
+#    Si en algún momento se levantaron containers a mano (sin labels
+#    `com.docker.compose.project`), `docker compose --force-recreate`
+#    no los reconoce como propios y choca contra el `container_name`.
+#    Removerlos acá es idempotente — si ya son compose-managed,
+#    `compose up` los recrea normalmente; si no existen, no hace nada.
+log "→ Limpiando containers PROD pre-existentes (si los hay)..."
+for c in fatrans-backend fatrans-frontend-public fatrans-frontend-protected; do
+  if docker inspect "$c" >/dev/null 2>&1; then
+    LABEL=$(docker inspect --format='{{ index .Config.Labels "com.docker.compose.project" }}' "$c" 2>/dev/null || echo "")
+    if [ -z "$LABEL" ]; then
+      log "   $c existe sin labels de compose — removiendo para que compose lo cree fresco"
+      docker rm -f "$c" >/dev/null
+    else
+      log "   $c ya es compose-managed (proyecto=$LABEL) — compose se encargará"
+    fi
+  fi
+done
+
+# 5. Restart con zero-downtime (recrear uno a uno)
+log "→ Actualizando backend..."
+cd "$INFRA_DIR"
+docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate backend
+
+log "→ Esperando backend saludable..."
+for i in $(seq 1 18); do
+  STATUS=$(docker inspect --format='{{.State.Health.Status}}' fatrans-backend 2>/dev/null || echo "starting")
+  if [ "$STATUS" = "healthy" ]; then
+    log "   Backend saludable ✓"
+    break
+  fi
+  log "   Intento $i/18 — $STATUS"
+  sleep 10
+done
+
+log "→ Actualizando frontends..."
+docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate frontend_public frontend_protected
+
+# 6. Verificación
+log "→ Verificación final..."
+SERVICES=("fatrans-backend" "fatrans-frontend-public" "fatrans-frontend-protected")
+ALL_OK=true
+for svc in "${SERVICES[@]}"; do
+  STATUS=$(docker inspect --format='{{.State.Status}}' "$svc" 2>/dev/null || echo "missing")
+  if [ "$STATUS" != "running" ]; then
+    log "   ❌ $svc — $STATUS"
+    ALL_OK=false
+  else
+    log "   ✅ $svc — running"
+  fi
+done
+
+# 7. Limpieza
+docker image prune -f --filter "until=72h" 2>/dev/null || true
+
+if $ALL_OK; then
+  log "======================================================"
+  log " ✅ Deploy PRODUCCIÓN completado — SHA: $GIT_SHA"
+  log " 🌐 https://fatrans.com.ve"
+  log "======================================================"
+  exit 0
+else
+  log "======================================================"
+  log " ❌ Deploy PRODUCCIÓN FALLÓ"
+  log "======================================================"
+  exit 1
+fi


### PR DESCRIPTION
## 2ª promoción a main — solo el hardening del deploy

Trae a `main` el fix de `deploy-prod.sh` que se commiteó en PR #285. La 1ª promoción (PR #284) falló dos veces por dos bugs en el script de deploy que vivían solo en el VPS; este PR pone el script en el repo con los fixes aplicados.

## Qué entra (vs `main` actual)

```
0d29a77e Merge pull request #285 from gamijoam/fix/deploy-prod-script-in-repo
8e40e458 fix(deploy-prod): script versionado en repo + defensa contra containers no-compose
```

- `infrastructure/scripts/deploy-prod.sh` (nuevo, source of truth)
- `.github/workflows/deploy-prod.yml` (agrega step `appleboy/scp-action` que sube el script al VPS antes de ejecutarlo)
- `.gitattributes` (LF en .sh)

## Qué hace el deploy automático al mergear esto

1. Workflow `Deploy → Producción` arranca en push a `main`
2. Step "Subir script de deploy al VPS" → scp `infrastructure/scripts/deploy-prod.sh` → `/opt/fatrans/deploy-prod.sh` (sobrescribe el del VPS)
3. SSH al VPS → corre el script nuevo
4. Script: `git fetch && git checkout -B main origin/main && git reset --hard origin/main`
5. Build backend (probablemente cacheado, fue la build exitosa del intento anterior)
6. Build frontend (idem cacheado)
7. **`docker rm -f`** `fatrans-backend`, `fatrans-frontend-public`, `fatrans-frontend-protected` (porque hoy están creados a mano sin labels de compose)
8. `docker compose up -d --force-recreate backend` → arranca con la imagen `2fab8516...`
9. Spring Boot arranca → **Flyway corre V11..V20** en BD `fondo`
10. Healthcheck del backend (max 3 min)
11. `docker compose up -d --force-recreate frontend_public frontend_protected`
12. Verify final + cleanup imágenes >72h

## Riesgo

- Downtime estimado de PROD: ~2–3 min (entre el `docker rm -f` y los containers nuevos saludables)
- Si V11..V20 falla en PROD postgres por algún drift de schema vs QA, el backend no llega a `healthy` y el rollback automático (step 7 del workflow) re-taggea la imagen anterior y la levanta. El frontend habría que volver atrás manualmente.
- Las imágenes nuevas ya están construidas y pasaron build en el VPS — riesgo de build = 0.

## ⚠️ Al mergear

**Usá "Create a merge commit"**, NO Squash. La protection ya está configurada para no exigir reviewer.

## Test plan post-merge

- [ ] `Deploy → Producción` aprobás el environment gate en GitHub
- [ ] Action termina en verde
- [ ] `docker ps` muestra los 3 containers de PROD con uptime nuevo y compose labels
- [ ] `https://fatrans.com.ve` → 200
- [ ] `https://app.fatrans.com.ve` → 200 con logo PNG visible
- [ ] `flyway_schema_history` en `fondo` muestra V11..V20 success=true
- [ ] Login con un socio real funciona
- [ ] Logout desde dropdown ejecuta el logout (fix #283 en PROD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
