### PR TITLE
fix(deploy-prod): healthcheck con nc, command_timeout 30m, rollback condicional

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -48,7 +48,13 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
           port: 22
+          # `timeout` es solo el handshake SSH; `command_timeout` es lo que
+          # corre el script. Default es 10m — insuficiente para el primer
+          # deploy a PROD donde hay que buildear backend (4 min) + frontend
+          # (5 min) + correr 10 migrations + start de Spring + healthcheck.
+          # 30 min cubre primeros deploys cold y deja margen.
           timeout: 20m
+          command_timeout: 30m
           script: |
             chmod +x /opt/fatrans/deploy-prod.sh
             bash /opt/fatrans/deploy-prod.sh ${{ github.sha }}
@@ -67,6 +73,14 @@ jobs:
             const sha = context.sha.substring(0, 7);
             console.log('✅ Deploy producción OK — SHA ' + sha);
 
+      # Rollback condicional: solo ejecuta si el backend NO está
+      # respondiendo. La versión anterior corría en todo failure() —
+      # incluyendo timeouts SSH o errores en steps de verificación
+      # cosméticos, casos donde el backend en realidad estaba arriba.
+      # Eso causó (18-05-2026) que matáramos un deploy exitoso porque
+      # el SSH timeout de 10m disparó el rollback y el rollback re-taggeó
+      # `latest` apuntando a una imagen anterior incompatible con la BD
+      # ya migrada a V20, dejando PROD sin backend usable.
       - name: Rollback automático si falla
         if: failure()
         uses: appleboy/ssh-action@v1.0.3
@@ -76,13 +90,26 @@ jobs:
           key: ${{ secrets.VPS_SSH_KEY }}
           port: 22
           script: |
-            echo "⚠️ Deploy falló — intentando rollback..."
-            PREV=$(docker images fatrans-backend --format "{{.Tag}}" | grep -v latest | sort -r | sed -n '2p')
+            echo "⚠️ Workflow falló — evaluando si necesita rollback..."
+            sleep 5
+            # Si el backend responde en 8080, asumimos que el deploy llegó
+            # lejos y que el "failure" del workflow fue cosmético (timeout,
+            # healthcheck mal configurado, etc). No tocar nada.
+            if docker exec fatrans-backend nc -z -w 3 localhost 8080 2>/dev/null; then
+              echo "✅ Backend responde en :8080 — NO rollback. Verificar manualmente."
+              exit 0
+            fi
+            echo "❌ Backend no responde — iniciando rollback..."
+            # Buscar la imagen anterior (segunda en orden reverso, descartando :latest)
+            PREV=$(docker images fatrans-backend --format "{{.Tag}}" \
+                    | grep -v '^latest$' | grep -v '^<none>$' \
+                    | sort -r | sed -n '2p')
             if [ -n "$PREV" ]; then
-              docker tag fatrans-backend:$PREV fatrans-backend:latest
+              echo "→ Rollback a fatrans-backend:$PREV"
+              docker tag "fatrans-backend:$PREV" fatrans-backend:latest
               cd /opt/fatrans/backend/infrastructure
-              docker-compose -f docker-compose.prod.yml up -d --no-deps --force-recreate backend
-              echo "Rollback a $PREV completado"
+              docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate backend
+              echo "Rollback completado"
             else
-              echo "No hay imagen anterior para rollback"
+              echo "No hay imagen anterior para rollback — backend queda caído"
             fi

--- a/infrastructure/docker-compose.prod.yml
+++ b/infrastructure/docker-compose.prod.yml
@@ -86,8 +86,15 @@ services:
         condition: service_healthy
     ports:
       - "8080:8080"
+    # La imagen del backend NO incluye curl — el healthcheck anterior
+    # (`curl -s ... | grep`) fallaba siempre con `/bin/sh: curl: not found`
+    # y dejaba al container en `unhealthy` aunque la app respondiera OK.
+    # Usamos `nc -z` (netcat, sí está en alpine vía busybox) para verificar
+    # que Tomcat está escuchando en 8080. Es un check de "liveness" mínimo
+    # — si Spring Boot crasheó en el arranque, el puerto no escucha y nc
+    # falla; si el contexto cargó, nc pasa.
     healthcheck:
-      test: ["CMD-SHELL", "curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/api/v1/auth/login | grep -E '405|400|200' || exit 1"]
+      test: ["CMD-SHELL", "nc -z -w 3 localhost 8080 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Por qué

Hoy (18-may-2026) la primera promoción a `main` (PR #284 → #286) tropezó tres veces antes de quedar funcional:

1. PR #284: `git checkout main` fallaba en VPS (resuelto en #285)
2. PR #286 1ª: race condition con QA deploy concurrente
3. PR #286 2ª: SSH `command_timeout` 10m disparó rollback automático cuando el deploy estaba arrancando OK; el rollback mató al backend nuevo y re-taggeó `latest` a una imagen anterior incompatible con la BD ya migrada a V20.

Recuperamos manual (docker rm + compose up). PROD quedó OK pero el workflow seguirá reportando "failure" mientras el healthcheck del backend siga siendo `curl ... | grep` (curl no existe en alpine).

Este PR endurece deploy-prod para que el próximo merge a main pase limpio.

## Cambios

### 1. `infrastructure/docker-compose.prod.yml`
Healthcheck del backend: `curl -s ... | grep '405|400|200'` → `nc -z -w 3 localhost 8080`.

La imagen del backend está basada en alpine y NO incluye curl. El healthcheck anterior siempre fallaba con:
```
/bin/sh: curl: not found
```

`nc` (netcat) sí está en alpine vía busybox. Verifica que Tomcat esté escuchando en :8080 — si Spring Boot crasheó en el arranque, el puerto no escucha; si el contexto cargó, nc pasa. Suficiente para liveness check.

### 2. `.github/workflows/deploy-prod.yml` — `command_timeout: 30m`
El `command_timeout` por default de `appleboy/ssh-action` es 10m. El primer deploy de PROD necesita:
- build backend (~4 min)
- build frontend (~5 min) 
- correr 10 migrations Flyway
- arrancar Spring Boot (~30s)
- esperar healthcheck saludable

Total: ~12-15 min en cold deploy. 10m no alcanza. 30m da margen sin afectar deploys cacheados (que tardan ~3 min).

### 3. `.github/workflows/deploy-prod.yml` — rollback condicional
La versión anterior corría rollback en CUALQUIER `failure()` de los steps anteriores. El nuevo rollback hace primero:

```bash
if docker exec fatrans-backend nc -z -w 3 localhost 8080 2>/dev/null; then
  echo "✅ Backend responde — NO rollback"
  exit 0
fi
```

Solo si el backend efectivamente no responde, busca imagen anterior y la re-tagea. Esto evita el escenario de hoy donde un timeout cosmético destruyó un deploy funcional.

## Plan post-merge

1. Merge a `develop`
2. PR `develop` → `main` (será la 3ª promoción)
3. Merge → dispara Deploy → Producción con la config nueva
4. El deploy debería pasar limpio:
   - Builds cacheados (las layers ya están de los intentos anteriores)
   - Healthcheck del backend pasa con nc → no más `unhealthy` falso
   - Si todo sale bien: workflow termina success en ~3-5 min
   - Si algo falla: el rollback condicional protege el estado actual

## Test plan

- [ ] Workflow `Deploy → Producción` corre y termina `success`
- [ ] Container `fatrans-backend` queda con healthcheck `healthy` (no `unhealthy`)
- [ ] `docker inspect fatrans-backend --format '{{.State.Health.Status}}'` → `healthy`
- [ ] Smoke test: login con socio real sigue funcionando
- [ ] Logo PNG continúa sirviendo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
