### PR TITLE
fix(auth): registro no permite www + cedula auto-prefix V-/E-

### DIFF
--- a/frontend-web/src/app/api/admin/solicitudes/[id]/aprobar/route.ts
+++ b/frontend-web/src/app/api/admin/solicitudes/[id]/aprobar/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
+import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
@@ -7,18 +8,8 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const origin = request.headers.get('origin');
-    const allowedOrigins = [
-    'http://localhost:3000',
-    'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL,
-    process.env.NEXT_PUBLIC_ADMIN_URL,
-    process.env.NEXT_PUBLIC_AUTH_URL,
-  ].filter(Boolean);
-
-  if (origin && !allowedOrigins.includes(origin)) {
-    return NextResponse.json({ message: 'Origen no permitido' }, { status: 403 });
-  }
+  const blocked = enforceOriginPolicy(request);
+  if (blocked) return blocked;
 
   try {
     const accessToken = request.cookies.get('access_token');

--- a/frontend-web/src/app/api/admin/solicitudes/[id]/rechazar/route.ts
+++ b/frontend-web/src/app/api/admin/solicitudes/[id]/rechazar/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
+import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
@@ -7,18 +8,8 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const origin = request.headers.get('origin');
-    const allowedOrigins = [
-    'http://localhost:3000',
-    'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL,
-    process.env.NEXT_PUBLIC_ADMIN_URL,
-    process.env.NEXT_PUBLIC_AUTH_URL,
-  ].filter(Boolean);
-
-  if (origin && !allowedOrigins.includes(origin)) {
-    return NextResponse.json({ message: 'Origen no permitido' }, { status: 403 });
-  }
+  const blocked = enforceOriginPolicy(request);
+  if (blocked) return blocked;
 
   try {
     const accessToken = request.cookies.get('access_token');

--- a/frontend-web/src/app/api/admin/solicitudes/route.ts
+++ b/frontend-web/src/app/api/admin/solicitudes/route.ts
@@ -1,21 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
+import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {
-  const origin = request.headers.get('origin');
-    const allowedOrigins = [
-    'http://localhost:3000',
-    'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL,
-    process.env.NEXT_PUBLIC_ADMIN_URL,
-    process.env.NEXT_PUBLIC_AUTH_URL,
-  ].filter(Boolean);
-
-  if (origin && !allowedOrigins.includes(origin)) {
-    return NextResponse.json({ message: 'Origen no permitido' }, { status: 403 });
-  }
+  const blocked = enforceOriginPolicy(request);
+  if (blocked) return blocked;
 
   try {
     const accessToken = request.cookies.get('access_token');

--- a/frontend-web/src/app/api/auth/cambiar-password/route.ts
+++ b/frontend-web/src/app/api/auth/cambiar-password/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
+import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
@@ -16,18 +17,8 @@ const changePasswordRequestSchema = z.object({
 });
 
 export async function POST(request: NextRequest) {
-  const origin = request.headers.get('origin');
-    const allowedOrigins = [
-    'http://localhost:3000',
-    'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL,
-    process.env.NEXT_PUBLIC_ADMIN_URL,
-    process.env.NEXT_PUBLIC_AUTH_URL,
-  ].filter(Boolean);
-
-  if (origin && !allowedOrigins.includes(origin)) {
-    return NextResponse.json({ message: 'Origen no permitido' }, { status: 403 });
-  }
+  const blocked = enforceOriginPolicy(request);
+  if (blocked) return blocked;
 
   try {
     const body = await request.json();

--- a/frontend-web/src/app/api/auth/login/route.ts
+++ b/frontend-web/src/app/api/auth/login/route.ts
@@ -1,21 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { loginSchema } from '@/lib/utils/validators';
+import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(request: NextRequest) {
-  const origin = request.headers.get('origin');
-    const allowedOrigins = [
-    'http://localhost:3000',
-    'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL,
-    process.env.NEXT_PUBLIC_ADMIN_URL,
-    process.env.NEXT_PUBLIC_AUTH_URL,
-  ].filter(Boolean);
-
-  if (origin && !allowedOrigins.includes(origin)) {
-    return NextResponse.json({ message: 'Origen no permitido' }, { status: 403 });
-  }
+  const blocked = enforceOriginPolicy(request);
+  if (blocked) return blocked;
 
   try {
     const body = await request.json();

--- a/frontend-web/src/app/api/auth/registro/route.ts
+++ b/frontend-web/src/app/api/auth/registro/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { registroSchema } from '@/lib/utils/validators';
+import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
@@ -49,36 +50,14 @@ function getClientIp(request: NextRequest): string | null {
 }
 
 export async function POST(request: NextRequest) {
-  const origin = request.headers.get('origin');
-  const referer = request.headers.get('referer');
-  const allowedOrigins = [
-    'http://localhost:3000',
-    'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL,
-    process.env.NEXT_PUBLIC_ADMIN_URL,
-    process.env.NEXT_PUBLIC_AUTH_URL,
-  ].filter(Boolean);
-
-  // El referer llega como "https://qa-auth.fatrans.com.ve/registro". Parseamos su origin
-  // y lo comparamos con la misma whitelist de allowedOrigins (evita drift entre listas).
-  // OJO con startsWith: "https://auth.fatrans.com.ve.evil.com" también empezaría con
-  // "https://auth.fatrans.com.ve" — por eso usamos URL.origin que extrae esquema+host+puerto.
-  function refererOriginAllowed(headerValue: string): boolean {
-    try {
-      const refOrigin = new URL(headerValue).origin;
-      return allowedOrigins.includes(refOrigin);
-    } catch {
-      return false;
-    }
-  }
-
-  if (origin && !allowedOrigins.includes(origin)) {
-    return NextResponse.json({ message: 'Origen no permitido' }, { status: 403 });
-  }
-
-  if (referer && !refererOriginAllowed(referer)) {
-    return NextResponse.json({ message: 'Referer no permitido' }, { status: 403 });
-  }
+  // Whitelist centralizada en `lib/security/origin-check`. Antes vivía
+  // inline en cada route, derivada de `NEXT_PUBLIC_*_URL` — y como esos
+  // env vars se inlinen al BUILD (no runtime), bastaba con que el deploy
+  // no pasara un build-arg para que el bundle quedara con la lista mal.
+  // El 18-may-2026 los usuarios que entraban por `www.fatrans.com.ve` no
+  // podían registrarse por eso.
+  const blocked = enforceOriginPolicy(request);
+  if (blocked) return blocked;
 
   try {
     const body = await request.json();

--- a/frontend-web/src/components/features/auth/registration-form.tsx
+++ b/frontend-web/src/components/features/auth/registration-form.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
-import { useForm, Controller, type Path } from 'react-hook-form';
+import { useEffect, useMemo, useState } from 'react';
+import { useForm, useWatch, Controller, type Path } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
 import {
@@ -152,11 +152,40 @@ export function RegistrationForm() {
     trigger,
     control,
     getValues,
+    setValue,
   } = useForm<RegistroFormData>({
     resolver: zodResolver(registroSchema),
     mode: 'onBlur',
     reValidateMode: 'onChange',
   });
+
+  // Auto-prefix de cédula según tipoDocumento. El usuario seleccionó
+  // "Cédula de Identidad (V-)" → mostramos un "V-" fijo a la izquierda
+  // del input y el usuario solo escribe los dígitos. Idem "E-" para
+  // extranjeros. Para RIF/Pasaporte dejamos el input plano (formato
+  // libre: RIF es V/E/J/G-XXXXXXX-Y y Pasaporte es alfanumérico).
+  const tipoDocumento = useWatch({ control, name: 'tipoDocumento' });
+  const cedulaPrefix = useMemo<'V-' | 'E-' | ''>(() => {
+    if (tipoDocumento === 'CEDULA') return 'V-';
+    if (tipoDocumento === 'CEDULA_EXTRANJERO') return 'E-';
+    return '';
+  }, [tipoDocumento]);
+
+  // Cuando cambia el tipo, re-prefijar los dígitos existentes para que
+  // pasar de Cédula → Extranjero (o viceversa) no obligue al usuario
+  // a retipear. Si pasa a RIF/Pasaporte, dejamos el valor sin prefijo.
+  useEffect(() => {
+    const current = getValues('cedula') || '';
+    const digits = current.replace(/^[VEJG]-?/, '');
+    if (cedulaPrefix) {
+      setValue('cedula', `${cedulaPrefix}${digits}`, { shouldValidate: false });
+    } else if (current && current !== digits) {
+      // Estábamos en CEDULA/EXTRANJERO y ahora es RIF/Pasaporte: limpiar
+      // prefijo automático para que el usuario lo escriba libremente.
+      setValue('cedula', digits, { shouldValidate: false });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cedulaPrefix]);
 
   const currentStep = STEPS[stepIndex];
   const isLastStep = stepIndex === STEPS.length - 1;
@@ -305,16 +334,71 @@ export function RegistrationForm() {
                 </div>
 
                 <div className="space-y-2">
-                  <FieldLabel htmlFor="cedula">Cédula</FieldLabel>
-                  <Input
-                    id="cedula"
-                    type="text"
-                    placeholder="V-12345678"
-                    autoComplete="off"
-                    disabled={isLoading}
-                    aria-invalid={!!errors.cedula}
-                    {...register('cedula')}
-                  />
+                  <FieldLabel htmlFor="cedula">
+                    {tipoDocumento === 'RIF' ? 'RIF' : 'Cédula'}
+                  </FieldLabel>
+                  {cedulaPrefix ? (
+                    // Cédula nacional o extranjera — prefijo V-/E- fijo a la izquierda.
+                    // El input solo acepta dígitos; almacenamos `<prefix><digits>`
+                    // en el form state para que pase el regex /^(V|E)-\d{7,8}$/.
+                    <Controller
+                      control={control}
+                      name="cedula"
+                      render={({ field }) => {
+                        const digitsOnly = (field.value || '').replace(/^[VE]-?/, '');
+                        return (
+                          <div
+                            className={`flex items-stretch rounded-md border bg-background overflow-hidden focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 ${
+                              errors.cedula ? 'border-destructive' : 'border-input'
+                            }`}
+                          >
+                            <span
+                              className="flex items-center px-3 bg-muted/50 text-sm font-semibold border-r border-input select-none text-foreground/80"
+                              aria-hidden="true"
+                            >
+                              {cedulaPrefix}
+                            </span>
+                            <Input
+                              id="cedula"
+                              type="text"
+                              inputMode="numeric"
+                              pattern="[0-9]*"
+                              placeholder="12345678"
+                              autoComplete="off"
+                              maxLength={8}
+                              disabled={isLoading}
+                              aria-invalid={!!errors.cedula}
+                              value={digitsOnly}
+                              onChange={(e) => {
+                                const onlyDigits = e.target.value.replace(/\D/g, '').slice(0, 8);
+                                field.onChange(`${cedulaPrefix}${onlyDigits}`);
+                              }}
+                              onBlur={field.onBlur}
+                              className="border-0 focus-visible:ring-0 focus-visible:ring-offset-0 shadow-none"
+                            />
+                          </div>
+                        );
+                      }}
+                    />
+                  ) : (
+                    // RIF / Pasaporte — formato libre.
+                    <Input
+                      id="cedula"
+                      type="text"
+                      placeholder={
+                        tipoDocumento === 'RIF' ? 'J-123456789-0' : 'Documento'
+                      }
+                      autoComplete="off"
+                      disabled={isLoading || !tipoDocumento}
+                      aria-invalid={!!errors.cedula}
+                      {...register('cedula')}
+                    />
+                  )}
+                  {!tipoDocumento && (
+                    <p className="text-xs text-muted-foreground">
+                      Primero seleccioná el tipo de documento.
+                    </p>
+                  )}
                   <FieldError message={errors.cedula?.message} />
                 </div>
 

--- a/frontend-web/src/lib/security/origin-check.ts
+++ b/frontend-web/src/lib/security/origin-check.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Whitelist de Origins permitidos para las API routes del BFF (Next.js).
+ *
+ * Por qué un módulo compartido en vez de duplicar `allowedOrigins` en cada
+ * route handler:
+ *
+ *  1. **Inlining de NEXT_PUBLIC_* al BUILD**: Next.js sustituye
+ *     `process.env.NEXT_PUBLIC_X` por la literal en build-time, no en
+ *     runtime. Si el build no recibió un `--build-arg`, el bundle queda
+ *     con el default del Dockerfile o con `undefined`, y el `process.env`
+ *     del runtime ya no lo alcanza. Eso causó el bug del 18-may-2026:
+ *     `NEXT_PUBLIC_AUTH_URL` no se pasó como build-arg → quedó horneado
+ *     con el default `https://fatrans.com.ve` en vez de
+ *     `https://auth.fatrans.com.ve` → usuarios entrando por
+ *     `www.fatrans.com.ve/registro` recibían 403 "Origen no permitido".
+ *
+ *  2. **www y root variantes**: los usuarios escriben `www.` o no,
+ *     entran por subdominio público o protegido. Hay que aceptar TODOS
+ *     los hosts canónicos donde puede vivir un form, no solo los que
+ *     coincidan con un env var puntual.
+ *
+ *  3. **PROD + QA en mismo bundle no aplica** pero por defensa-en-
+ *     profundidad y por DX (corre QA local apuntando a PROD si quisiera),
+ *     incluimos ambos sets explícitos.
+ *
+ * El check sigue siendo opt-in: la API route llama a `enforceOriginPolicy`
+ * al inicio del handler y, si devuelve un NextResponse, lo retorna tal cual.
+ */
+
+const STATIC_ALLOWED_ORIGINS = [
+  // Local development
+  'http://localhost:3000',
+  'http://localhost:3001',
+  'http://localhost:13000',
+
+  // Producción — todos los hosts canónicos
+  'https://fatrans.com.ve',
+  'https://www.fatrans.com.ve',
+  'https://app.fatrans.com.ve',
+  'https://admin.fatrans.com.ve',
+  'https://auth.fatrans.com.ve',
+  'https://api.fatrans.com.ve',
+
+  // QA — todos los hosts canónicos
+  'https://qa.fatrans.com.ve',
+  'https://www.qa.fatrans.com.ve',
+  'https://qa-app.fatrans.com.ve',
+  'https://qa-admin.fatrans.com.ve',
+  'https://qa-auth.fatrans.com.ve',
+  'https://qa-api.fatrans.com.ve',
+] as const;
+
+/**
+ * Devuelve la lista efectiva de origins permitidos:
+ * la estática + lo que indiquen los env vars (por si en QA/PROD
+ * apunta a un dominio nuevo que aún no está en STATIC).
+ */
+export function getAllowedOrigins(): string[] {
+  const envOrigins = [
+    process.env.NEXT_PUBLIC_APP_URL,
+    process.env.NEXT_PUBLIC_ADMIN_URL,
+    process.env.NEXT_PUBLIC_AUTH_URL,
+  ].filter((v): v is string => typeof v === 'string' && v.length > 0);
+
+  return Array.from(new Set<string>([...STATIC_ALLOWED_ORIGINS, ...envOrigins]));
+}
+
+export function isOriginAllowed(origin: string): boolean {
+  return getAllowedOrigins().includes(origin);
+}
+
+/**
+ * Para Referer no hacemos startsWith (vulnerable a
+ * `https://app.fatrans.com.ve.evil.com`); parseamos con `new URL().origin`
+ * y comparamos contra la misma lista.
+ */
+export function isRefererAllowed(referer: string): boolean {
+  try {
+    return isOriginAllowed(new URL(referer).origin);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verifica Origin + Referer de la request. Devuelve un NextResponse listo
+ * para retornar si la request está bloqueada, o `null` si pasa el check.
+ *
+ *     export async function POST(request: NextRequest) {
+ *       const blocked = enforceOriginPolicy(request);
+ *       if (blocked) return blocked;
+ *       // ... rest of handler
+ *     }
+ */
+export function enforceOriginPolicy(request: Request): NextResponse | null {
+  const origin = request.headers.get('origin');
+  const referer = request.headers.get('referer');
+
+  if (origin && !isOriginAllowed(origin)) {
+    return NextResponse.json({ message: 'Origen no permitido' }, { status: 403 });
+  }
+  if (referer && !isRefererAllowed(referer)) {
+    return NextResponse.json({ message: 'Referer no permitido' }, { status: 403 });
+  }
+  return null;
+}

--- a/infrastructure/scripts/deploy-prod.sh
+++ b/infrastructure/scripts/deploy-prod.sh
@@ -44,12 +44,24 @@ docker build \
 log "   Backend build OK"
 
 # 3. Build del Frontend
+# IMPORTANTE: pasar los CUATRO build-args de NEXT_PUBLIC_*. Los valores
+# se inlinean al BUILD (no a runtime), así que si falta alguno acá, el
+# bundle queda con el default del Dockerfile y los env vars del
+# `docker-compose.prod.yml` no lo cambian en producción.
+#
+# El 18-may-2026 omitir ADMIN_URL y AUTH_URL hizo que el bundle quedara
+# con `NEXT_PUBLIC_AUTH_URL=https://fatrans.com.ve` (default del
+# Dockerfile) en vez de `auth.fatrans.com.ve` (compose). Los usuarios
+# que entraban por `www.fatrans.com.ve/registro` recibían 403
+# "Origen no permitido" porque la whitelist del BFF no incluía `www`.
 log "→ Construyendo imagen frontend (prod)..."
 docker build \
   -t fatrans-frontend:latest \
   -t "fatrans-frontend:$GIT_SHA" \
   --build-arg NEXT_PUBLIC_API_URL=https://api.fatrans.com.ve/api \
   --build-arg NEXT_PUBLIC_APP_URL=https://app.fatrans.com.ve \
+  --build-arg NEXT_PUBLIC_ADMIN_URL=https://admin.fatrans.com.ve \
+  --build-arg NEXT_PUBLIC_AUTH_URL=https://fatrans.com.ve \
   "$REPO_DIR/frontend-web/"
 
 docker tag fatrans-frontend:latest fatrans-frontend-public:latest


### PR DESCRIPTION
## Reportado en PROD (18-may-2026)

> "Se están intentando registrar y cuando le dan a enviar solicitud dice **origen no permitido** y en la cédula hay que hacer como un autocompletado que en vez de escribir V- salga automático."

## Bug #1 — "Origen no permitido" al enviar registro

**Repro**: usuario entra a `https://www.fatrans.com.ve/registro`, llena form, click "Enviar" → 403 `{"message":"Origen no permitido"}`.

**Causa raíz doble** (verificado en vivo en PROD con curl):

```
Origin: https://fatrans.com.ve       → 400 (datos inválidos) ✅ pasa
Origin: https://app.fatrans.com.ve   → 400 (datos inválidos) ✅ pasa
Origin: https://www.fatrans.com.ve   → 403 "Origen no permitido" ❌
Origin: https://auth.fatrans.com.ve  → 403 "Origen no permitido" ❌
```

**(a)** Los 6 handlers BFF (`/api/auth/registro`, `/api/auth/login`, `/api/auth/cambiar-password`, `/api/admin/solicitudes` y sus aprobar/rechazar) construían `allowedOrigins` desde `process.env.NEXT_PUBLIC_*_URL`. Esos vars en Next.js se **inlinean al BUILD**, no a runtime. El `deploy-prod.sh` solo pasaba 2 de los 4 build-args (`NEXT_PUBLIC_API_URL` y `NEXT_PUBLIC_APP_URL`); los otros caían al default del Dockerfile. En PROD eso dejó `NEXT_PUBLIC_AUTH_URL=https://fatrans.com.ve` horneado en el bundle, contradiciendo lo que dice el `docker-compose.prod.yml` a runtime (`https://auth.fatrans.com.ve`).

**(b)** La whitelist nunca incluyó `https://www.fatrans.com.ve` (el variant que el usuario escribe).

## Bug #2 — Cédula UX

Antes:
```
Tipo: Cédula de Identidad (V-)
Cédula: [V-12345678         ]  ← usuario tipea V- y -
```

Después:
```
Tipo: Cédula de Identidad (V-)
Cédula: [ V- ][12345678         ]  ← prefijo fijo, input numérico
```

Cambiar a "Cédula Extranjero (E-)" re-prefija automáticamente. Cambiar a RIF/Pasaporte limpia el prefijo (formato libre).

## Cambios

### Nuevo: `frontend-web/src/lib/security/origin-check.ts`
- `STATIC_ALLOWED_ORIGINS` con TODOS los hosts canónicos PROD+QA (raíz, www, app, admin, auth, api) más localhost.
- `enforceOriginPolicy(request)` reemplaza la duplicación inline.
- Mantiene la defensa anti-spoof (parse con `new URL().origin`, no `startsWith`).

### Modificado: 6 BFF routes
Sustituyen `const allowedOrigins = [...].filter(Boolean); if (origin && !allowedOrigins.includes(origin)) return 403; ...` (15 líneas) por `const blocked = enforceOriginPolicy(request); if (blocked) return blocked;` (2 líneas).

### Modificado: `frontend-web/src/components/features/auth/registration-form.tsx`
- `useWatch` sobre `tipoDocumento` para reaccionar al cambio.
- `Controller` para el campo `cedula` que renderiza prefix (`V-`/`E-`) como span no-editable + Input numérico de 8 dígitos.
- `useEffect` re-prefija dígitos existentes cuando cambia el tipo.

### Modificado: `infrastructure/scripts/deploy-prod.sh`
Pasa los 4 `--build-arg NEXT_PUBLIC_*_URL` en vez de solo 2, para que el bundle de PROD no quede con valores del default del Dockerfile.

## Tests

- `registro/route.test.ts` — 16 casos pasan sin modificar. La whitelist nueva es estrictamente más permisiva para hosts canónicos y mantiene los rechazos anti-spoof.

## Test plan post-deploy

- [ ] `https://www.fatrans.com.ve/registro` → enviar form → backend recibe el POST (no 403)
- [ ] `https://fatrans.com.ve/registro` → idem
- [ ] `https://app.fatrans.com.ve/registro` → idem
- [ ] Seleccionar "Cédula de Identidad (V-)" → input muestra "V-" fijo → tipear digits → form state guarda `V-12345678`
- [ ] Cambiar tipo a "Cédula Extranjero (E-)" → prefijo se actualiza a "E-", dígitos se mantienen
- [ ] Cambiar a "RIF" → input plano sin prefijo, dígitos existentes preservados
- [ ] Cambiar a "Pasaporte" → idem RIF

🤖 Generated with [Claude Code](https://claude.com/claude-code)
