### PR TITLE
fix(nginx): versionar config + agregar qa.fatrans.com.ve a server_name

### DIFF
--- a/infrastructure/nginx/fatrans.conf
+++ b/infrastructure/nginx/fatrans.conf
@@ -1,0 +1,279 @@
+# ============================================================
+#  /etc/nginx/sites-enabled/fatrans  —  fuente de verdad
+#
+#  Este archivo es la fuente de verdad del nginx config de la
+#  plataforma Fatrans (PROD + QA en el mismo VPS). El deploy a
+#  producción (`infrastructure/scripts/deploy-prod.sh`) lo copia a
+#  `/etc/nginx/sites-enabled/fatrans` en el VPS y ejecuta `nginx -t`
+#  + `nginx -s reload` — si la sintaxis falla, ABORTA el deploy sin
+#  tocar nginx para no dejar PROD sin servicio.
+#
+#  Hosts cubiertos:
+#   - fatrans.com.ve / www / auth  → frontend público :3000
+#   - app / admin                  → frontend protegido :3001
+#   - api                          → backend Spring Boot :8080
+#   - qa / qa-auth                 → frontend público QA :4000
+#   - qa-app / qa-admin            → frontend protegido QA :4001
+#   - qa-api                       → backend Spring Boot QA :8081
+#
+#  Bug histórico (18-may-2026): el config en el VPS NO incluía
+#  `qa.fatrans.com.ve` en ningún server_name. Cuando un usuario
+#  navegaba a `https://qa.fatrans.com.ve/` nginx no encontraba match
+#  y caía al default server (PROD landing). El HTML servido era el
+#  de PROD con sus URLs hardcodeadas (`href=https://fatrans.com.ve/
+#  registro`). Resultado: usuarios "registrándose en QA" terminaban
+#  enviando su solicitud a PROD. Fix: agregar `qa.fatrans.com.ve` al
+#  bloque qa-auth (sirven el mismo frontend público QA).
+# ============================================================
+
+upstream frontend_public {
+    server localhost:3000;
+}
+
+upstream frontend_protected {
+    server localhost:3001;
+}
+
+upstream backend_srv {
+    server 127.0.0.1:8080;
+}
+
+# === Stack QA (puertos 4000/4001/8081) ===
+upstream frontend_public_qa {
+    server localhost:4000;
+}
+
+upstream frontend_protected_qa {
+    server localhost:4001;
+}
+
+upstream backend_qa_srv {
+    server 127.0.0.1:8081;
+}
+
+proxy_buffer_size   128k;
+proxy_buffers       4 256k;
+proxy_busy_buffers_size 256k;
+
+server {
+    listen 80;
+    server_name fatrans.com.ve www.fatrans.com.ve auth.fatrans.com.ve app.fatrans.com.ve admin.fatrans.com.ve api.fatrans.com.ve
+                qa.fatrans.com.ve qa-auth.fatrans.com.ve qa-app.fatrans.com.ve qa-admin.fatrans.com.ve qa-api.fatrans.com.ve;
+    return 301 https://$host$request_uri;
+}
+
+# www + auth → frontend publico (:3000)
+server {
+    listen 443 ssl http2;
+    server_name fatrans.com.ve www.fatrans.com.ve auth.fatrans.com.ve;
+
+    ssl_certificate     /opt/fatrans/ssl/certificate.pem;
+    ssl_certificate_key /opt/fatrans/ssl/private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:50m;
+
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header CF-Connecting-IP;
+
+    location / {
+        proxy_pass http://frontend_public;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+
+# app + admin → frontend protegido (:3001)
+server {
+    listen 443 ssl http2;
+    server_name app.fatrans.com.ve admin.fatrans.com.ve;
+
+    ssl_certificate     /opt/fatrans/ssl/certificate.pem;
+    ssl_certificate_key /opt/fatrans/ssl/private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:50m;
+
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header CF-Connecting-IP;
+
+    location / {
+        proxy_pass http://frontend_protected;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+
+# api.fatrans.com.ve → backend Spring Boot (:8080)
+# Spring Boot maneja CORS — nginx NO duplica headers
+server {
+    listen 443 ssl http2;
+    server_name api.fatrans.com.ve;
+
+    ssl_certificate     /opt/fatrans/ssl/certificate.pem;
+    ssl_certificate_key /opt/fatrans/ssl/private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:50m;
+
+    # MCP server para Claude.ai connector (StreamableHTTP + SSE)
+    location /mcp {
+        proxy_pass http://127.0.0.1:3010;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+        chunked_transfer_encoding on;
+        add_header X-Accel-Buffering "no" always;
+    }
+
+    location / {
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin $http_origin always;
+            add_header Access-Control-Allow-Credentials true always;
+            add_header Access-Control-Allow-Methods "GET, POST, OPTIONS, PUT, DELETE, PATCH" always;
+            add_header Access-Control-Allow-Headers "Authorization,Content-Type,Accept,Origin,User-Agent,DNT,Cache-Control,X-Mx-ReqToken,Keep-Alive,X-Requested-With,If-Modified-Since,X-CSRF-Token" always;
+            add_header Access-Control-Max-Age 1728000;
+            add_header Content-Type "text/plain charset=UTF-8";
+            add_header Content-Length 0;
+            return 204;
+        }
+
+        proxy_pass http://backend_srv;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Authorization $http_authorization;
+        proxy_pass_header Authorization;
+    }
+}
+
+# =====================================================================
+#  STACK QA — develop branch → containers fatrans-qa-* en puertos 4000/4001/8081
+#  Mismo patrón que prod; cert wildcard *.fatrans.com.ve cubre los QA subdomains.
+# =====================================================================
+
+# qa + qa-auth → frontend público QA (:4000)
+#
+# `qa.fatrans.com.ve` es el equivalente QA de `fatrans.com.ve` (landing público).
+# `qa-auth.fatrans.com.ve` es el equivalente QA de `auth.fatrans.com.ve`. Ambos
+# sirven el mismo Next.js (frontend_public_qa) y el middleware decide qué
+# rutas habilitar por host. SIN `qa.fatrans.com.ve` acá, nginx caía al
+# default_server (PROD) y los usuarios veían HTML de PROD con URLs
+# hardcodeadas a fatrans.com.ve.
+server {
+    listen 443 ssl http2;
+    server_name qa.fatrans.com.ve qa-auth.fatrans.com.ve;
+
+    ssl_certificate     /opt/fatrans/ssl/certificate.pem;
+    ssl_certificate_key /opt/fatrans/ssl/private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:50m;
+
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header CF-Connecting-IP;
+
+    location / {
+        proxy_pass http://frontend_public_qa;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+
+# qa-app + qa-admin → frontend protegido QA (:4001)
+server {
+    listen 443 ssl http2;
+    server_name qa-app.fatrans.com.ve qa-admin.fatrans.com.ve;
+
+    ssl_certificate     /opt/fatrans/ssl/certificate.pem;
+    ssl_certificate_key /opt/fatrans/ssl/private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:50m;
+
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header CF-Connecting-IP;
+
+    location / {
+        proxy_pass http://frontend_protected_qa;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+
+# qa-api → backend Spring Boot QA (:8081)
+# Spring Boot maneja CORS — nginx NO duplica headers
+server {
+    listen 443 ssl http2;
+    server_name qa-api.fatrans.com.ve;
+
+    ssl_certificate     /opt/fatrans/ssl/certificate.pem;
+    ssl_certificate_key /opt/fatrans/ssl/private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:50m;
+
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header CF-Connecting-IP;
+
+    location / {
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin $http_origin always;
+            add_header Access-Control-Allow-Credentials true always;
+            add_header Access-Control-Allow-Methods "GET, POST, OPTIONS, PUT, DELETE, PATCH" always;
+            add_header Access-Control-Allow-Headers "Authorization,Content-Type,Accept,Origin,User-Agent,DNT,Cache-Control,X-Mx-ReqToken,Keep-Alive,X-Requested-With,If-Modified-Since,X-CSRF-Token" always;
+            add_header Access-Control-Max-Age 1728000;
+            add_header Content-Type "text/plain charset=UTF-8";
+            add_header Content-Length 0;
+            return 204;
+        }
+
+        proxy_pass http://backend_qa_srv;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Authorization $http_authorization;
+        proxy_pass_header Authorization;
+    }
+}

--- a/infrastructure/scripts/deploy-prod.sh
+++ b/infrastructure/scripts/deploy-prod.sh
@@ -18,6 +18,9 @@ LOG_FILE="/var/log/fatrans-prod-deploy.log"
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"; }
 
+NGINX_CONF_SRC="$REPO_DIR/infrastructure/nginx/fatrans.conf"
+NGINX_CONF_DST="/etc/nginx/sites-enabled/fatrans"
+
 log "======================================================"
 log " Iniciando deploy PRODUCCIÓN  —  SHA: $GIT_SHA"
 log "======================================================"
@@ -86,6 +89,37 @@ for c in fatrans-backend fatrans-frontend-public fatrans-frontend-protected; do
     fi
   fi
 done
+
+# 4.b. Actualizar config nginx desde el repo (fuente de verdad).
+#      Histórico: el config solo vivía en `/etc/nginx/sites-enabled/fatrans`
+#      sin version control. El 18-may-2026 le faltaba `qa.fatrans.com.ve`
+#      en server_name y nginx mandaba ese host al default_server (PROD
+#      landing), provocando que el botón "Registrarse" de QA llevara a
+#      PROD. Ahora el repo es la fuente de verdad y este deploy lo
+#      sincroniza. Si `nginx -t` falla, ABORTAMOS sin reload — nginx
+#      sigue sirviendo el config anterior. Backup previo a cada cambio.
+if [ -f "$NGINX_CONF_SRC" ]; then
+  log "→ Actualizando nginx config desde el repo..."
+  if ! diff -q "$NGINX_CONF_SRC" "$NGINX_CONF_DST" >/dev/null 2>&1; then
+    BAK="/root/fatrans.nginx.bak_$(date +%Y%m%d_%H%M%S)"
+    cp "$NGINX_CONF_DST" "$BAK"
+    log "   Backup del config previo: $BAK"
+    cp "$NGINX_CONF_SRC" "$NGINX_CONF_DST"
+    if nginx -t 2>>"$LOG_FILE"; then
+      nginx -s reload
+      log "   ✅ nginx config recargado"
+    else
+      log "   ❌ nginx -t FALLÓ — restaurando backup"
+      cp "$BAK" "$NGINX_CONF_DST"
+      nginx -t 2>>"$LOG_FILE"
+      exit 1
+    fi
+  else
+    log "   Config nginx sin cambios — skip"
+  fi
+else
+  log "   ⚠️ $NGINX_CONF_SRC no existe en el repo — skip nginx update"
+fi
 
 # 5. Restart con zero-downtime (recrear uno a uno)
 log "→ Actualizando backend..."


### PR DESCRIPTION
## Por qué

El 18-may-2026 destapamos que `https://qa.fatrans.com.ve/registro` mandaba a PROD (el botón "Registrarse" en la landing QA tenía `href="https://fatrans.com.ve/registro"`).

Causa raíz: el config nginx en el VPS (`/etc/nginx/sites-enabled/fatrans`) NO tenía `qa.fatrans.com.ve` en NINGÚN `server_name` específico. nginx no encontraba match → caía al **default_server** (PROD landing) → servía el HTML de PROD con URLs hardcodeadas.

Riesgo adicional: el config solo vivía en el VPS sin version control. Cualquier rebuild del servidor o intervención manual perdería el fix.

## Cambios

### Nuevo: `infrastructure/nginx/fatrans.conf`
Copia del config activo del VPS (snapshot del estado actual, post-fix in-place que ya hice hoy):
- `server_name qa.fatrans.com.ve qa-auth.fatrans.com.ve;` en el bloque de QA público (antes era solo qa-auth)
- `qa.fatrans.com.ve` agregado al HTTP→HTTPS redirect inicial

### Modificado: `infrastructure/scripts/deploy-prod.sh`
Nuevo paso 4.b en el flow de deploy:
1. `diff` entre el archivo del repo y el del VPS — si son iguales, skip
2. Backup del config previo a `/root/fatrans.nginx.bak_<timestamp>`
3. Copiar el nuevo
4. `nginx -t` (validación de sintaxis)
5. Si OK: `nginx -s reload`
6. Si falla: RESTAURAR el backup, abortar el deploy

nginx queda sirviendo el config anterior si algo sale mal — cero downtime para usuarios.

## Estado actual de PROD

El fix de nginx **ya está aplicado** in-place en el VPS desde hace ~5 min. Este PR solamente:
- Versiona el config en el repo (single source of truth de aquí en adelante)
- Automatiza el deploy del config

Cuando este PR + merge a develop + promoción a main → ejecute Deploy → Producción:
- El nuevo `deploy-prod.sh` hará `diff` y verá que el archivo del repo coincide con el del VPS → skip (no toca nginx)
- Cero impacto operacional

Pero si en el futuro alguien cambia el config nginx (agregar un subdominio nuevo, ajustar SSL, etc), basta con commitear a este archivo y el próximo deploy a PROD lo aplica.

## Test plan

- [ ] CI verde
- [ ] Merge a develop (no afecta QA — nginx config ya está OK)
- [ ] PR `develop` → `main`
- [ ] Merge → Deploy → Producción corre
- [ ] El step "Actualizando nginx config desde el repo" loguea "Config nginx sin cambios — skip"
- [ ] `https://qa.fatrans.com.ve/` y `https://fatrans.com.ve/` siguen funcionando con sus URLs respectivas
- [ ] Backend + frontends de PROD se actualizan normal con los cambios pendientes (#287, #288)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
