### PR TITLE
release: 3ª promoción — resilience + registro/cedula + nginx versionado

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -48,7 +48,13 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
           port: 22
+          # `timeout` es solo el handshake SSH; `command_timeout` es lo que
+          # corre el script. Default es 10m — insuficiente para el primer
+          # deploy a PROD donde hay que buildear backend (4 min) + frontend
+          # (5 min) + correr 10 migrations + start de Spring + healthcheck.
+          # 30 min cubre primeros deploys cold y deja margen.
           timeout: 20m
+          command_timeout: 30m
           script: |
             chmod +x /opt/fatrans/deploy-prod.sh
             bash /opt/fatrans/deploy-prod.sh ${{ github.sha }}
@@ -67,6 +73,14 @@ jobs:
             const sha = context.sha.substring(0, 7);
             console.log('✅ Deploy producción OK — SHA ' + sha);
 
+      # Rollback condicional: solo ejecuta si el backend NO está
+      # respondiendo. La versión anterior corría en todo failure() —
+      # incluyendo timeouts SSH o errores en steps de verificación
+      # cosméticos, casos donde el backend en realidad estaba arriba.
+      # Eso causó (18-05-2026) que matáramos un deploy exitoso porque
+      # el SSH timeout de 10m disparó el rollback y el rollback re-taggeó
+      # `latest` apuntando a una imagen anterior incompatible con la BD
+      # ya migrada a V20, dejando PROD sin backend usable.
       - name: Rollback automático si falla
         if: failure()
         uses: appleboy/ssh-action@v1.0.3
@@ -76,13 +90,26 @@ jobs:
           key: ${{ secrets.VPS_SSH_KEY }}
           port: 22
           script: |
-            echo "⚠️ Deploy falló — intentando rollback..."
-            PREV=$(docker images fatrans-backend --format "{{.Tag}}" | grep -v latest | sort -r | sed -n '2p')
+            echo "⚠️ Workflow falló — evaluando si necesita rollback..."
+            sleep 5
+            # Si el backend responde en 8080, asumimos que el deploy llegó
+            # lejos y que el "failure" del workflow fue cosmético (timeout,
+            # healthcheck mal configurado, etc). No tocar nada.
+            if docker exec fatrans-backend nc -z -w 3 localhost 8080 2>/dev/null; then
+              echo "✅ Backend responde en :8080 — NO rollback. Verificar manualmente."
+              exit 0
+            fi
+            echo "❌ Backend no responde — iniciando rollback..."
+            # Buscar la imagen anterior (segunda en orden reverso, descartando :latest)
+            PREV=$(docker images fatrans-backend --format "{{.Tag}}" \
+                    | grep -v '^latest$' | grep -v '^<none>$' \
+                    | sort -r | sed -n '2p')
             if [ -n "$PREV" ]; then
-              docker tag fatrans-backend:$PREV fatrans-backend:latest
+              echo "→ Rollback a fatrans-backend:$PREV"
+              docker tag "fatrans-backend:$PREV" fatrans-backend:latest
               cd /opt/fatrans/backend/infrastructure
-              docker-compose -f docker-compose.prod.yml up -d --no-deps --force-recreate backend
-              echo "Rollback a $PREV completado"
+              docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate backend
+              echo "Rollback completado"
             else
-              echo "No hay imagen anterior para rollback"
+              echo "No hay imagen anterior para rollback — backend queda caído"
             fi

--- a/frontend-web/src/app/api/admin/solicitudes/[id]/aprobar/route.ts
+++ b/frontend-web/src/app/api/admin/solicitudes/[id]/aprobar/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
+import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
@@ -7,18 +8,8 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const origin = request.headers.get('origin');
-    const allowedOrigins = [
-    'http://localhost:3000',
-    'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL,
-    process.env.NEXT_PUBLIC_ADMIN_URL,
-    process.env.NEXT_PUBLIC_AUTH_URL,
-  ].filter(Boolean);
-
-  if (origin && !allowedOrigins.includes(origin)) {
-    return NextResponse.json({ message: 'Origen no permitido' }, { status: 403 });
-  }
+  const blocked = enforceOriginPolicy(request);
+  if (blocked) return blocked;
 
   try {
     const accessToken = request.cookies.get('access_token');

--- a/frontend-web/src/app/api/admin/solicitudes/[id]/rechazar/route.ts
+++ b/frontend-web/src/app/api/admin/solicitudes/[id]/rechazar/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
+import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
@@ -7,18 +8,8 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const origin = request.headers.get('origin');
-    const allowedOrigins = [
-    'http://localhost:3000',
-    'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL,
-    process.env.NEXT_PUBLIC_ADMIN_URL,
-    process.env.NEXT_PUBLIC_AUTH_URL,
-  ].filter(Boolean);
-
-  if (origin && !allowedOrigins.includes(origin)) {
-    return NextResponse.json({ message: 'Origen no permitido' }, { status: 403 });
-  }
+  const blocked = enforceOriginPolicy(request);
+  if (blocked) return blocked;
 
   try {
     const accessToken = request.cookies.get('access_token');

--- a/frontend-web/src/app/api/admin/solicitudes/route.ts
+++ b/frontend-web/src/app/api/admin/solicitudes/route.ts
@@ -1,21 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
+import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {
-  const origin = request.headers.get('origin');
-    const allowedOrigins = [
-    'http://localhost:3000',
-    'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL,
-    process.env.NEXT_PUBLIC_ADMIN_URL,
-    process.env.NEXT_PUBLIC_AUTH_URL,
-  ].filter(Boolean);
-
-  if (origin && !allowedOrigins.includes(origin)) {
-    return NextResponse.json({ message: 'Origen no permitido' }, { status: 403 });
-  }
+  const blocked = enforceOriginPolicy(request);
+  if (blocked) return blocked;
 
   try {
     const accessToken = request.cookies.get('access_token');

--- a/frontend-web/src/app/api/auth/cambiar-password/route.ts
+++ b/frontend-web/src/app/api/auth/cambiar-password/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
+import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
@@ -16,18 +17,8 @@ const changePasswordRequestSchema = z.object({
 });
 
 export async function POST(request: NextRequest) {
-  const origin = request.headers.get('origin');
-    const allowedOrigins = [
-    'http://localhost:3000',
-    'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL,
-    process.env.NEXT_PUBLIC_ADMIN_URL,
-    process.env.NEXT_PUBLIC_AUTH_URL,
-  ].filter(Boolean);
-
-  if (origin && !allowedOrigins.includes(origin)) {
-    return NextResponse.json({ message: 'Origen no permitido' }, { status: 403 });
-  }
+  const blocked = enforceOriginPolicy(request);
+  if (blocked) return blocked;
 
   try {
     const body = await request.json();

--- a/frontend-web/src/app/api/auth/login/route.ts
+++ b/frontend-web/src/app/api/auth/login/route.ts
@@ -1,21 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { loginSchema } from '@/lib/utils/validators';
+import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(request: NextRequest) {
-  const origin = request.headers.get('origin');
-    const allowedOrigins = [
-    'http://localhost:3000',
-    'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL,
-    process.env.NEXT_PUBLIC_ADMIN_URL,
-    process.env.NEXT_PUBLIC_AUTH_URL,
-  ].filter(Boolean);
-
-  if (origin && !allowedOrigins.includes(origin)) {
-    return NextResponse.json({ message: 'Origen no permitido' }, { status: 403 });
-  }
+  const blocked = enforceOriginPolicy(request);
+  if (blocked) return blocked;
 
   try {
     const body = await request.json();

--- a/frontend-web/src/app/api/auth/registro/route.ts
+++ b/frontend-web/src/app/api/auth/registro/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { registroSchema } from '@/lib/utils/validators';
+import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
@@ -49,36 +50,14 @@ function getClientIp(request: NextRequest): string | null {
 }
 
 export async function POST(request: NextRequest) {
-  const origin = request.headers.get('origin');
-  const referer = request.headers.get('referer');
-  const allowedOrigins = [
-    'http://localhost:3000',
-    'http://localhost:13000',
-    process.env.NEXT_PUBLIC_APP_URL,
-    process.env.NEXT_PUBLIC_ADMIN_URL,
-    process.env.NEXT_PUBLIC_AUTH_URL,
-  ].filter(Boolean);
-
-  // El referer llega como "https://qa-auth.fatrans.com.ve/registro". Parseamos su origin
-  // y lo comparamos con la misma whitelist de allowedOrigins (evita drift entre listas).
-  // OJO con startsWith: "https://auth.fatrans.com.ve.evil.com" también empezaría con
-  // "https://auth.fatrans.com.ve" — por eso usamos URL.origin que extrae esquema+host+puerto.
-  function refererOriginAllowed(headerValue: string): boolean {
-    try {
-      const refOrigin = new URL(headerValue).origin;
-      return allowedOrigins.includes(refOrigin);
-    } catch {
-      return false;
-    }
-  }
-
-  if (origin && !allowedOrigins.includes(origin)) {
-    return NextResponse.json({ message: 'Origen no permitido' }, { status: 403 });
-  }
-
-  if (referer && !refererOriginAllowed(referer)) {
-    return NextResponse.json({ message: 'Referer no permitido' }, { status: 403 });
-  }
+  // Whitelist centralizada en `lib/security/origin-check`. Antes vivía
+  // inline en cada route, derivada de `NEXT_PUBLIC_*_URL` — y como esos
+  // env vars se inlinen al BUILD (no runtime), bastaba con que el deploy
+  // no pasara un build-arg para que el bundle quedara con la lista mal.
+  // El 18-may-2026 los usuarios que entraban por `www.fatrans.com.ve` no
+  // podían registrarse por eso.
+  const blocked = enforceOriginPolicy(request);
+  if (blocked) return blocked;
 
   try {
     const body = await request.json();

--- a/frontend-web/src/components/features/auth/registration-form.tsx
+++ b/frontend-web/src/components/features/auth/registration-form.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
-import { useForm, Controller, type Path } from 'react-hook-form';
+import { useEffect, useMemo, useState } from 'react';
+import { useForm, useWatch, Controller, type Path } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
 import {
@@ -152,11 +152,40 @@ export function RegistrationForm() {
     trigger,
     control,
     getValues,
+    setValue,
   } = useForm<RegistroFormData>({
     resolver: zodResolver(registroSchema),
     mode: 'onBlur',
     reValidateMode: 'onChange',
   });
+
+  // Auto-prefix de cédula según tipoDocumento. El usuario seleccionó
+  // "Cédula de Identidad (V-)" → mostramos un "V-" fijo a la izquierda
+  // del input y el usuario solo escribe los dígitos. Idem "E-" para
+  // extranjeros. Para RIF/Pasaporte dejamos el input plano (formato
+  // libre: RIF es V/E/J/G-XXXXXXX-Y y Pasaporte es alfanumérico).
+  const tipoDocumento = useWatch({ control, name: 'tipoDocumento' });
+  const cedulaPrefix = useMemo<'V-' | 'E-' | ''>(() => {
+    if (tipoDocumento === 'CEDULA') return 'V-';
+    if (tipoDocumento === 'CEDULA_EXTRANJERO') return 'E-';
+    return '';
+  }, [tipoDocumento]);
+
+  // Cuando cambia el tipo, re-prefijar los dígitos existentes para que
+  // pasar de Cédula → Extranjero (o viceversa) no obligue al usuario
+  // a retipear. Si pasa a RIF/Pasaporte, dejamos el valor sin prefijo.
+  useEffect(() => {
+    const current = getValues('cedula') || '';
+    const digits = current.replace(/^[VEJG]-?/, '');
+    if (cedulaPrefix) {
+      setValue('cedula', `${cedulaPrefix}${digits}`, { shouldValidate: false });
+    } else if (current && current !== digits) {
+      // Estábamos en CEDULA/EXTRANJERO y ahora es RIF/Pasaporte: limpiar
+      // prefijo automático para que el usuario lo escriba libremente.
+      setValue('cedula', digits, { shouldValidate: false });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cedulaPrefix]);
 
   const currentStep = STEPS[stepIndex];
   const isLastStep = stepIndex === STEPS.length - 1;
@@ -305,16 +334,71 @@ export function RegistrationForm() {
                 </div>
 
                 <div className="space-y-2">
-                  <FieldLabel htmlFor="cedula">Cédula</FieldLabel>
-                  <Input
-                    id="cedula"
-                    type="text"
-                    placeholder="V-12345678"
-                    autoComplete="off"
-                    disabled={isLoading}
-                    aria-invalid={!!errors.cedula}
-                    {...register('cedula')}
-                  />
+                  <FieldLabel htmlFor="cedula">
+                    {tipoDocumento === 'RIF' ? 'RIF' : 'Cédula'}
+                  </FieldLabel>
+                  {cedulaPrefix ? (
+                    // Cédula nacional o extranjera — prefijo V-/E- fijo a la izquierda.
+                    // El input solo acepta dígitos; almacenamos `<prefix><digits>`
+                    // en el form state para que pase el regex /^(V|E)-\d{7,8}$/.
+                    <Controller
+                      control={control}
+                      name="cedula"
+                      render={({ field }) => {
+                        const digitsOnly = (field.value || '').replace(/^[VE]-?/, '');
+                        return (
+                          <div
+                            className={`flex items-stretch rounded-md border bg-background overflow-hidden focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 ${
+                              errors.cedula ? 'border-destructive' : 'border-input'
+                            }`}
+                          >
+                            <span
+                              className="flex items-center px-3 bg-muted/50 text-sm font-semibold border-r border-input select-none text-foreground/80"
+                              aria-hidden="true"
+                            >
+                              {cedulaPrefix}
+                            </span>
+                            <Input
+                              id="cedula"
+                              type="text"
+                              inputMode="numeric"
+                              pattern="[0-9]*"
+                              placeholder="12345678"
+                              autoComplete="off"
+                              maxLength={8}
+                              disabled={isLoading}
+                              aria-invalid={!!errors.cedula}
+                              value={digitsOnly}
+                              onChange={(e) => {
+                                const onlyDigits = e.target.value.replace(/\D/g, '').slice(0, 8);
+                                field.onChange(`${cedulaPrefix}${onlyDigits}`);
+                              }}
+                              onBlur={field.onBlur}
+                              className="border-0 focus-visible:ring-0 focus-visible:ring-offset-0 shadow-none"
+                            />
+                          </div>
+                        );
+                      }}
+                    />
+                  ) : (
+                    // RIF / Pasaporte — formato libre.
+                    <Input
+                      id="cedula"
+                      type="text"
+                      placeholder={
+                        tipoDocumento === 'RIF' ? 'J-123456789-0' : 'Documento'
+                      }
+                      autoComplete="off"
+                      disabled={isLoading || !tipoDocumento}
+                      aria-invalid={!!errors.cedula}
+                      {...register('cedula')}
+                    />
+                  )}
+                  {!tipoDocumento && (
+                    <p className="text-xs text-muted-foreground">
+                      Primero seleccioná el tipo de documento.
+                    </p>
+                  )}
                   <FieldError message={errors.cedula?.message} />
                 </div>
 

--- a/frontend-web/src/lib/security/origin-check.ts
+++ b/frontend-web/src/lib/security/origin-check.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Whitelist de Origins permitidos para las API routes del BFF (Next.js).
+ *
+ * Por qué un módulo compartido en vez de duplicar `allowedOrigins` en cada
+ * route handler:
+ *
+ *  1. **Inlining de NEXT_PUBLIC_* al BUILD**: Next.js sustituye
+ *     `process.env.NEXT_PUBLIC_X` por la literal en build-time, no en
+ *     runtime. Si el build no recibió un `--build-arg`, el bundle queda
+ *     con el default del Dockerfile o con `undefined`, y el `process.env`
+ *     del runtime ya no lo alcanza. Eso causó el bug del 18-may-2026:
+ *     `NEXT_PUBLIC_AUTH_URL` no se pasó como build-arg → quedó horneado
+ *     con el default `https://fatrans.com.ve` en vez de
+ *     `https://auth.fatrans.com.ve` → usuarios entrando por
+ *     `www.fatrans.com.ve/registro` recibían 403 "Origen no permitido".
+ *
+ *  2. **www y root variantes**: los usuarios escriben `www.` o no,
+ *     entran por subdominio público o protegido. Hay que aceptar TODOS
+ *     los hosts canónicos donde puede vivir un form, no solo los que
+ *     coincidan con un env var puntual.
+ *
+ *  3. **PROD + QA en mismo bundle no aplica** pero por defensa-en-
+ *     profundidad y por DX (corre QA local apuntando a PROD si quisiera),
+ *     incluimos ambos sets explícitos.
+ *
+ * El check sigue siendo opt-in: la API route llama a `enforceOriginPolicy`
+ * al inicio del handler y, si devuelve un NextResponse, lo retorna tal cual.
+ */
+
+const STATIC_ALLOWED_ORIGINS = [
+  // Local development
+  'http://localhost:3000',
+  'http://localhost:3001',
+  'http://localhost:13000',
+
+  // Producción — todos los hosts canónicos
+  'https://fatrans.com.ve',
+  'https://www.fatrans.com.ve',
+  'https://app.fatrans.com.ve',
+  'https://admin.fatrans.com.ve',
+  'https://auth.fatrans.com.ve',
+  'https://api.fatrans.com.ve',
+
+  // QA — todos los hosts canónicos
+  'https://qa.fatrans.com.ve',
+  'https://www.qa.fatrans.com.ve',
+  'https://qa-app.fatrans.com.ve',
+  'https://qa-admin.fatrans.com.ve',
+  'https://qa-auth.fatrans.com.ve',
+  'https://qa-api.fatrans.com.ve',
+] as const;
+
+/**
+ * Devuelve la lista efectiva de origins permitidos:
+ * la estática + lo que indiquen los env vars (por si en QA/PROD
+ * apunta a un dominio nuevo que aún no está en STATIC).
+ */
+export function getAllowedOrigins(): string[] {
+  const envOrigins = [
+    process.env.NEXT_PUBLIC_APP_URL,
+    process.env.NEXT_PUBLIC_ADMIN_URL,
+    process.env.NEXT_PUBLIC_AUTH_URL,
+  ].filter((v): v is string => typeof v === 'string' && v.length > 0);
+
+  return Array.from(new Set<string>([...STATIC_ALLOWED_ORIGINS, ...envOrigins]));
+}
+
+export function isOriginAllowed(origin: string): boolean {
+  return getAllowedOrigins().includes(origin);
+}
+
+/**
+ * Para Referer no hacemos startsWith (vulnerable a
+ * `https://app.fatrans.com.ve.evil.com`); parseamos con `new URL().origin`
+ * y comparamos contra la misma lista.
+ */
+export function isRefererAllowed(referer: string): boolean {
+  try {
+    return isOriginAllowed(new URL(referer).origin);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verifica Origin + Referer de la request. Devuelve un NextResponse listo
+ * para retornar si la request está bloqueada, o `null` si pasa el check.
+ *
+ *     export async function POST(request: NextRequest) {
+ *       const blocked = enforceOriginPolicy(request);
+ *       if (blocked) return blocked;
+ *       // ... rest of handler
+ *     }
+ */
+export function enforceOriginPolicy(request: Request): NextResponse | null {
+  const origin = request.headers.get('origin');
+  const referer = request.headers.get('referer');
+
+  if (origin && !isOriginAllowed(origin)) {
+    return NextResponse.json({ message: 'Origen no permitido' }, { status: 403 });
+  }
+  if (referer && !isRefererAllowed(referer)) {
+    return NextResponse.json({ message: 'Referer no permitido' }, { status: 403 });
+  }
+  return null;
+}

--- a/infrastructure/docker-compose.prod.yml
+++ b/infrastructure/docker-compose.prod.yml
@@ -86,8 +86,15 @@ services:
         condition: service_healthy
     ports:
       - "8080:8080"
+    # La imagen del backend NO incluye curl — el healthcheck anterior
+    # (`curl -s ... | grep`) fallaba siempre con `/bin/sh: curl: not found`
+    # y dejaba al container en `unhealthy` aunque la app respondiera OK.
+    # Usamos `nc -z` (netcat, sí está en alpine vía busybox) para verificar
+    # que Tomcat está escuchando en 8080. Es un check de "liveness" mínimo
+    # — si Spring Boot crasheó en el arranque, el puerto no escucha y nc
+    # falla; si el contexto cargó, nc pasa.
     healthcheck:
-      test: ["CMD-SHELL", "curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/api/v1/auth/login | grep -E '405|400|200' || exit 1"]
+      test: ["CMD-SHELL", "nc -z -w 3 localhost 8080 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/infrastructure/nginx/fatrans.conf
+++ b/infrastructure/nginx/fatrans.conf
@@ -1,0 +1,279 @@
+# ============================================================
+#  /etc/nginx/sites-enabled/fatrans  —  fuente de verdad
+#
+#  Este archivo es la fuente de verdad del nginx config de la
+#  plataforma Fatrans (PROD + QA en el mismo VPS). El deploy a
+#  producción (`infrastructure/scripts/deploy-prod.sh`) lo copia a
+#  `/etc/nginx/sites-enabled/fatrans` en el VPS y ejecuta `nginx -t`
+#  + `nginx -s reload` — si la sintaxis falla, ABORTA el deploy sin
+#  tocar nginx para no dejar PROD sin servicio.
+#
+#  Hosts cubiertos:
+#   - fatrans.com.ve / www / auth  → frontend público :3000
+#   - app / admin                  → frontend protegido :3001
+#   - api                          → backend Spring Boot :8080
+#   - qa / qa-auth                 → frontend público QA :4000
+#   - qa-app / qa-admin            → frontend protegido QA :4001
+#   - qa-api                       → backend Spring Boot QA :8081
+#
+#  Bug histórico (18-may-2026): el config en el VPS NO incluía
+#  `qa.fatrans.com.ve` en ningún server_name. Cuando un usuario
+#  navegaba a `https://qa.fatrans.com.ve/` nginx no encontraba match
+#  y caía al default server (PROD landing). El HTML servido era el
+#  de PROD con sus URLs hardcodeadas (`href=https://fatrans.com.ve/
+#  registro`). Resultado: usuarios "registrándose en QA" terminaban
+#  enviando su solicitud a PROD. Fix: agregar `qa.fatrans.com.ve` al
+#  bloque qa-auth (sirven el mismo frontend público QA).
+# ============================================================
+
+upstream frontend_public {
+    server localhost:3000;
+}
+
+upstream frontend_protected {
+    server localhost:3001;
+}
+
+upstream backend_srv {
+    server 127.0.0.1:8080;
+}
+
+# === Stack QA (puertos 4000/4001/8081) ===
+upstream frontend_public_qa {
+    server localhost:4000;
+}
+
+upstream frontend_protected_qa {
+    server localhost:4001;
+}
+
+upstream backend_qa_srv {
+    server 127.0.0.1:8081;
+}
+
+proxy_buffer_size   128k;
+proxy_buffers       4 256k;
+proxy_busy_buffers_size 256k;
+
+server {
+    listen 80;
+    server_name fatrans.com.ve www.fatrans.com.ve auth.fatrans.com.ve app.fatrans.com.ve admin.fatrans.com.ve api.fatrans.com.ve
+                qa.fatrans.com.ve qa-auth.fatrans.com.ve qa-app.fatrans.com.ve qa-admin.fatrans.com.ve qa-api.fatrans.com.ve;
+    return 301 https://$host$request_uri;
+}
+
+# www + auth → frontend publico (:3000)
+server {
+    listen 443 ssl http2;
+    server_name fatrans.com.ve www.fatrans.com.ve auth.fatrans.com.ve;
+
+    ssl_certificate     /opt/fatrans/ssl/certificate.pem;
+    ssl_certificate_key /opt/fatrans/ssl/private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:50m;
+
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header CF-Connecting-IP;
+
+    location / {
+        proxy_pass http://frontend_public;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+
+# app + admin → frontend protegido (:3001)
+server {
+    listen 443 ssl http2;
+    server_name app.fatrans.com.ve admin.fatrans.com.ve;
+
+    ssl_certificate     /opt/fatrans/ssl/certificate.pem;
+    ssl_certificate_key /opt/fatrans/ssl/private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:50m;
+
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header CF-Connecting-IP;
+
+    location / {
+        proxy_pass http://frontend_protected;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+
+# api.fatrans.com.ve → backend Spring Boot (:8080)
+# Spring Boot maneja CORS — nginx NO duplica headers
+server {
+    listen 443 ssl http2;
+    server_name api.fatrans.com.ve;
+
+    ssl_certificate     /opt/fatrans/ssl/certificate.pem;
+    ssl_certificate_key /opt/fatrans/ssl/private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:50m;
+
+    # MCP server para Claude.ai connector (StreamableHTTP + SSE)
+    location /mcp {
+        proxy_pass http://127.0.0.1:3010;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+        chunked_transfer_encoding on;
+        add_header X-Accel-Buffering "no" always;
+    }
+
+    location / {
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin $http_origin always;
+            add_header Access-Control-Allow-Credentials true always;
+            add_header Access-Control-Allow-Methods "GET, POST, OPTIONS, PUT, DELETE, PATCH" always;
+            add_header Access-Control-Allow-Headers "Authorization,Content-Type,Accept,Origin,User-Agent,DNT,Cache-Control,X-Mx-ReqToken,Keep-Alive,X-Requested-With,If-Modified-Since,X-CSRF-Token" always;
+            add_header Access-Control-Max-Age 1728000;
+            add_header Content-Type "text/plain charset=UTF-8";
+            add_header Content-Length 0;
+            return 204;
+        }
+
+        proxy_pass http://backend_srv;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Authorization $http_authorization;
+        proxy_pass_header Authorization;
+    }
+}
+
+# =====================================================================
+#  STACK QA — develop branch → containers fatrans-qa-* en puertos 4000/4001/8081
+#  Mismo patrón que prod; cert wildcard *.fatrans.com.ve cubre los QA subdomains.
+# =====================================================================
+
+# qa + qa-auth → frontend público QA (:4000)
+#
+# `qa.fatrans.com.ve` es el equivalente QA de `fatrans.com.ve` (landing público).
+# `qa-auth.fatrans.com.ve` es el equivalente QA de `auth.fatrans.com.ve`. Ambos
+# sirven el mismo Next.js (frontend_public_qa) y el middleware decide qué
+# rutas habilitar por host. SIN `qa.fatrans.com.ve` acá, nginx caía al
+# default_server (PROD) y los usuarios veían HTML de PROD con URLs
+# hardcodeadas a fatrans.com.ve.
+server {
+    listen 443 ssl http2;
+    server_name qa.fatrans.com.ve qa-auth.fatrans.com.ve;
+
+    ssl_certificate     /opt/fatrans/ssl/certificate.pem;
+    ssl_certificate_key /opt/fatrans/ssl/private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:50m;
+
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header CF-Connecting-IP;
+
+    location / {
+        proxy_pass http://frontend_public_qa;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+
+# qa-app + qa-admin → frontend protegido QA (:4001)
+server {
+    listen 443 ssl http2;
+    server_name qa-app.fatrans.com.ve qa-admin.fatrans.com.ve;
+
+    ssl_certificate     /opt/fatrans/ssl/certificate.pem;
+    ssl_certificate_key /opt/fatrans/ssl/private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:50m;
+
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header CF-Connecting-IP;
+
+    location / {
+        proxy_pass http://frontend_protected_qa;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+
+# qa-api → backend Spring Boot QA (:8081)
+# Spring Boot maneja CORS — nginx NO duplica headers
+server {
+    listen 443 ssl http2;
+    server_name qa-api.fatrans.com.ve;
+
+    ssl_certificate     /opt/fatrans/ssl/certificate.pem;
+    ssl_certificate_key /opt/fatrans/ssl/private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:50m;
+
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header CF-Connecting-IP;
+
+    location / {
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin $http_origin always;
+            add_header Access-Control-Allow-Credentials true always;
+            add_header Access-Control-Allow-Methods "GET, POST, OPTIONS, PUT, DELETE, PATCH" always;
+            add_header Access-Control-Allow-Headers "Authorization,Content-Type,Accept,Origin,User-Agent,DNT,Cache-Control,X-Mx-ReqToken,Keep-Alive,X-Requested-With,If-Modified-Since,X-CSRF-Token" always;
+            add_header Access-Control-Max-Age 1728000;
+            add_header Content-Type "text/plain charset=UTF-8";
+            add_header Content-Length 0;
+            return 204;
+        }
+
+        proxy_pass http://backend_qa_srv;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Authorization $http_authorization;
+        proxy_pass_header Authorization;
+    }
+}

--- a/infrastructure/scripts/deploy-prod.sh
+++ b/infrastructure/scripts/deploy-prod.sh
@@ -18,6 +18,9 @@ LOG_FILE="/var/log/fatrans-prod-deploy.log"
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"; }
 
+NGINX_CONF_SRC="$REPO_DIR/infrastructure/nginx/fatrans.conf"
+NGINX_CONF_DST="/etc/nginx/sites-enabled/fatrans"
+
 log "======================================================"
 log " Iniciando deploy PRODUCCIÓN  —  SHA: $GIT_SHA"
 log "======================================================"
@@ -86,6 +89,37 @@ for c in fatrans-backend fatrans-frontend-public fatrans-frontend-protected; do
     fi
   fi
 done
+
+# 4.b. Actualizar config nginx desde el repo (fuente de verdad).
+#      Histórico: el config solo vivía en `/etc/nginx/sites-enabled/fatrans`
+#      sin version control. El 18-may-2026 le faltaba `qa.fatrans.com.ve`
+#      en server_name y nginx mandaba ese host al default_server (PROD
+#      landing), provocando que el botón "Registrarse" de QA llevara a
+#      PROD. Ahora el repo es la fuente de verdad y este deploy lo
+#      sincroniza. Si `nginx -t` falla, ABORTAMOS sin reload — nginx
+#      sigue sirviendo el config anterior. Backup previo a cada cambio.
+if [ -f "$NGINX_CONF_SRC" ]; then
+  log "→ Actualizando nginx config desde el repo..."
+  if ! diff -q "$NGINX_CONF_SRC" "$NGINX_CONF_DST" >/dev/null 2>&1; then
+    BAK="/root/fatrans.nginx.bak_$(date +%Y%m%d_%H%M%S)"
+    cp "$NGINX_CONF_DST" "$BAK"
+    log "   Backup del config previo: $BAK"
+    cp "$NGINX_CONF_SRC" "$NGINX_CONF_DST"
+    if nginx -t 2>>"$LOG_FILE"; then
+      nginx -s reload
+      log "   ✅ nginx config recargado"
+    else
+      log "   ❌ nginx -t FALLÓ — restaurando backup"
+      cp "$BAK" "$NGINX_CONF_DST"
+      nginx -t 2>>"$LOG_FILE"
+      exit 1
+    fi
+  else
+    log "   Config nginx sin cambios — skip"
+  fi
+else
+  log "   ⚠️ $NGINX_CONF_SRC no existe en el repo — skip nginx update"
+fi
 
 # 5. Restart con zero-downtime (recrear uno a uno)
 log "→ Actualizando backend..."

--- a/infrastructure/scripts/deploy-prod.sh
+++ b/infrastructure/scripts/deploy-prod.sh
@@ -44,12 +44,24 @@ docker build \
 log "   Backend build OK"
 
 # 3. Build del Frontend
+# IMPORTANTE: pasar los CUATRO build-args de NEXT_PUBLIC_*. Los valores
+# se inlinean al BUILD (no a runtime), así que si falta alguno acá, el
+# bundle queda con el default del Dockerfile y los env vars del
+# `docker-compose.prod.yml` no lo cambian en producción.
+#
+# El 18-may-2026 omitir ADMIN_URL y AUTH_URL hizo que el bundle quedara
+# con `NEXT_PUBLIC_AUTH_URL=https://fatrans.com.ve` (default del
+# Dockerfile) en vez de `auth.fatrans.com.ve` (compose). Los usuarios
+# que entraban por `www.fatrans.com.ve/registro` recibían 403
+# "Origen no permitido" porque la whitelist del BFF no incluía `www`.
 log "→ Construyendo imagen frontend (prod)..."
 docker build \
   -t fatrans-frontend:latest \
   -t "fatrans-frontend:$GIT_SHA" \
   --build-arg NEXT_PUBLIC_API_URL=https://api.fatrans.com.ve/api \
   --build-arg NEXT_PUBLIC_APP_URL=https://app.fatrans.com.ve \
+  --build-arg NEXT_PUBLIC_ADMIN_URL=https://admin.fatrans.com.ve \
+  --build-arg NEXT_PUBLIC_AUTH_URL=https://fatrans.com.ve \
   "$REPO_DIR/frontend-web/"
 
 docker tag fatrans-frontend:latest fatrans-frontend-public:latest


### PR DESCRIPTION
## 3ª promoción a main

Lleva a PROD tres PRs ya mergeados a develop:

### PR #287 — Deploy resilience
- `docker-compose.prod.yml`: healthcheck del backend con `nc -z` (curl no existe en la imagen alpine, antes quedaba `unhealthy` permanente)
- Workflow `deploy-prod.yml`: `command_timeout: 30m` (default 10m era insuficiente para builds cold + Flyway)
- Rollback automático ahora hace `nc -z 8080` al backend ANTES de tomar acciones destructivas — si responde, NO rollback

### PR #288 — Bug "Origen no permitido" + Cédula UX
- **BLOQUEANTE corregido**: usuarios entrando por `www.fatrans.com.ve/registro` ya no reciben 403. Whitelist robusta en `lib/security/origin-check.ts` con todos los hosts canónicos PROD + QA.
- **UX**: en el form de registro, cédula tiene prefijo automático `V-`/`E-` según `tipoDocumento` (el usuario solo tipea los dígitos)
- `deploy-prod.sh` pasa los 4 `--build-arg NEXT_PUBLIC_*_URL` (antes solo 2 → bundle quedaba con defaults del Dockerfile)

### PR #289 — nginx config versionado
- `infrastructure/nginx/fatrans.conf` (nuevo) — config nginx que antes vivía solo en el VPS sin version control
- Tiene `qa.fatrans.com.ve` en server_name del bloque QA (faltaba — causaba que QA landing sirviera HTML de PROD)
- `deploy-prod.sh` sincroniza `/etc/nginx/sites-enabled/fatrans` con el repo en cada deploy, con `nginx -t` antes de reload y rollback automático si syntax falla

## Estado de PROD pre-merge

- Backend: corriendo `fatrans-backend:latest` con código de promoción anterior (PR #284 + #286 mergeados a main). Migrations Flyway aplicadas hasta V20.
- Frontends: idem
- nginx: ya tiene el fix aplicado in-place desde hace ~10 min. El deploy-prod.sh nuevo va a hacer `diff` y verá que el archivo del repo coincide con el del VPS → skip (no toca nginx).

## Qué hará el deploy automático al mergear

1. Workflow scp del nuevo `deploy-prod.sh` al VPS
2. Script: `git fetch && git checkout -B main origin/main && git reset --hard`
3. **Sincroniza nginx config** (skip porque ya coincide)
4. Build backend → cacheado, rápido
5. Build frontend → rebuild necesario porque cambia código JS (fix origen + cedula prefix). Va a tardar ~5 min porque cambia el bundle
6. `docker rm -f` containers viejos
7. `docker compose up backend` → arranca con código nuevo, Spring Boot ~30s
8. Healthcheck `nc -z 8080` → debería pasar healthy esta vez
9. `docker compose up frontends`
10. Verificación con curl
11. Total: ~7–10 min

## ⚠️ Al mergear

**Usá "Create a merge commit"**, NO Squash.

Tendrás que aprobar el **environment gate `production`** en GitHub Actions cuando aparezca el run.

## Test plan post-deploy

- [ ] Action `Deploy → Producción` termina success
- [ ] `https://fatrans.com.ve` y `https://app.fatrans.com.ve` → 200
- [ ] `https://www.fatrans.com.ve/registro` → form envía OK (no más 403 "Origen no permitido")
- [ ] Selección de "Cédula de Identidad" → input muestra "V-" fijo + numérico
- [ ] Backend container queda `healthy` (no más `unhealthy` cosmético)
- [ ] Logout dropdown funciona

🤖 Generated with [Claude Code](https://claude.com/claude-code)
