### PR TITLE
fix(kyc): solo biometría + comprobante (bloquea uploads manuales de identidad)

### DIFF
--- a/frontend-web/src/app/(dashboard)/dashboard/kyc/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/kyc/page.tsx
@@ -41,14 +41,23 @@ interface EstadoKYC {
   estadoBiometria: 'NO_INICIADA' | 'EN_PROGRESO' | 'APROBADA' | 'RECHAZADA' | 'EXPIRADA' | null;
 }
 
-/** Todos los documentos que el KYC puede requerir. El subset visible depende
-    del estado biométrico — ver `documentosVisibles` abajo. Cuando la biometría
-    está APROBADA, los documentos con `cubrePorBiometria=true` se ocultan porque
-    Didit ya capturó esa información (cédula anverso/reverso + selfie). */
+/** Documentos que el socio sube **manualmente** desde esta UI.
+ *
+ *  Histórico (18-may-2026): antes había 4 entradas — cédula anverso/reverso,
+ *  selfie con cédula y comprobante de domicilio. Los 3 primeros estaban
+ *  marcados `cubrePorBiometria=true` y se ocultaban una vez que la biometría
+ *  pasaba. Problema: si el socio subía screenshots/fotos malas **antes** de
+ *  hacer la biometría, el backend interpretaba que ya estaban "los 4 docs"
+ *  y movía la verificación a EN_REVISION automáticamente. A partir de ahí
+ *  el socio quedaba bloqueado: ya no podía subir más documentos NI hacer
+ *  biometría sin intervención manual del admin. Caso real: ronni.ronni en
+ *  PROD subió 4 screenshots y quedó en EN_REVISION con biometría sin iniciar.
+ *
+ *  Fix: la cédula y la selfie YA NO se suben manualmente. La única forma
+ *  de aportar esos datos es vía verificación biométrica (Didit). Acá solo
+ *  queda el comprobante de domicilio, que Didit no puede capturar.
+ */
 const TIPOS_DOCUMENTO = [
-  { tipo: 'CEDULA_ANVERSO', label: 'Cédula - Anverso', required: true, cubrePorBiometria: true },
-  { tipo: 'CEDULA_REVERSO', label: 'Cédula - Reverso', required: true, cubrePorBiometria: true },
-  { tipo: 'SELFIE_CEDULA', label: 'Selfie con Cédula', required: true, cubrePorBiometria: true },
   { tipo: 'COMPROBANTE_DOMICILIO', label: 'Comprobante de Domicilio', required: true, cubrePorBiometria: false },
 ];
 
@@ -218,21 +227,20 @@ export default function DashboardKYCPagina() {
       (consentimiento → ready → in_progress → submitted). */
   const puedeBiometrica = estadoKYC && estadoKYC.estado !== 'APROBADO';
 
-  /** Si la biometría ya pasó, Didit ya capturó cédula + selfie. Ocultamos los
-      3 documentos correspondientes en "Paso 2" y dejamos solo los que NO cubre
-      la biometría (comprobante de domicilio). Evita que el socio resuba algo
-      que ya tenemos validado por el proveedor. */
   const biometriaAprobada = estadoKYC?.estadoBiometria === 'APROBADA';
-  const documentosVisibles = biometriaAprobada
-    ? TIPOS_DOCUMENTO.filter(d => !d.cubrePorBiometria)
-    : TIPOS_DOCUMENTO;
+  /** Cédula+selfie ya no son uploads manuales — solo se proveen vía biometría.
+      El array siempre devuelve solo `[COMPROBANTE_DOMICILIO]` independientemente
+      del estado biométrico. Mantengo `documentosVisibles` como nombre por
+      compatibilidad con el render abajo. */
+  const documentosVisibles = TIPOS_DOCUMENTO;
 
-  /** El backend siempre cuenta 4 documentos requeridos. Si la biometría
-      aprobó, sumamos los 3 que cubre Didit como ya validados — la barra
-      de progreso refleja el avance real considerando la biometría. */
-  const docsCubiertosPorBiometria = biometriaAprobada
-    ? TIPOS_DOCUMENTO.filter(d => d.cubrePorBiometria).length
-    : 0;
+  /** Backend sigue contando 4 docs requeridos (cédula anverso/reverso, selfie,
+      comprobante) por compatibilidad histórica — esa lógica habría que ajustar
+      en backend en otro pasada. Acá calculamos el progreso "visible" para el
+      socio: si la biometría está aprobada, los 3 docs de identidad ya están
+      cubiertos por Didit. */
+  const DOCS_CUBIERTOS_POR_BIOMETRIA = 3; // cédula anverso, cédula reverso, selfie
+  const docsCubiertosPorBiometria = biometriaAprobada ? DOCS_CUBIERTOS_POR_BIOMETRIA : 0;
   const docsValidosCalculados = (estadoKYC?.documentosValidos ?? 0) + docsCubiertosPorBiometria;
 
   return (
@@ -345,19 +353,20 @@ export default function DashboardKYCPagina() {
             </div>
           )}
 
-          {/* Documentos manuales: complemento del paso biométrico — si la
-              biometría está APROBADA, solo pedimos los documentos que Didit
-              NO captura (comprobante de domicilio). El resto se considera
-              cubierto por la verificación biométrica. */}
+          {/* Comprobante de domicilio: único documento que Didit no puede
+              capturar (la factura de servicios, contrato de alquiler, etc).
+              La cédula y la selfie las obtenemos del paso biométrico — ya no
+              se permite subirlas manualmente para evitar que el socio cargue
+              screenshots inválidos y dispare el auto-EN_REVISION del backend. */}
           <div className="space-y-2">
             <div className="flex items-center gap-2 px-1 flex-wrap">
               <Upload className="h-4 w-4 text-green-600" />
               <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
-                Paso 2 · Documentos
+                Paso 2 · Comprobante de domicilio
               </h2>
-              {biometriaAprobada && (
+              {!biometriaAprobada && (
                 <span className="text-xs text-gray-500">
-                  · cédula y selfie ya cubiertos por la verificación facial
+                  · completá la verificación facial primero
                 </span>
               )}
             </div>
@@ -424,7 +433,19 @@ export default function DashboardKYCPagina() {
                                 setTargetTipo(doc.tipo);
                                 fileInputRef.current?.click();
                               }}
-                              disabled={subiendoDocumento !== null || !puedeSubirDocumentos}
+                              // Bloqueado hasta que pase la biometría — forzamos
+                              // el orden "verificación facial → comprobante" para
+                              // que el socio no pueda saltarse el paso 1.
+                              disabled={
+                                subiendoDocumento !== null ||
+                                !puedeSubirDocumentos ||
+                                !biometriaAprobada
+                              }
+                              title={
+                                !biometriaAprobada
+                                  ? 'Completá la verificación facial (Paso 1) antes de subir el comprobante'
+                                  : undefined
+                              }
                             >
                               {subiendoDocumento === doc.tipo ? (
                                 <Loader2 className="h-4 w-4 animate-spin" />


### PR DESCRIPTION
## Bug reportado en PROD (18-may-2026)

> El KYC un usuario subió los documentos sin darle al botón de verificación, entonces está bloqueado. No puede subir los documentos, ni tampoco hacer la verificación facial.

**Caso real**: socio `ronni.ronni` (id `9d56f782-9af6-4901-b62a-df89a23632ea`) subió 4 screenshots (cédula anverso/reverso, selfie, comprobante) entre 18:15:32 y 18:15:45. Estado actual en BD:

```
verificacion_kyc.estado     = EN_REVISION
verificacion_kyc.estado_biometria = NO_INICIADA
biometric_verification: 0 rows (nunca arrancó)
documento_identidad: 4 docs PENDIENTE
```

Ronni nunca presionó "Enviar a revisión" — el backend lo hizo solo cuando detectó los 4 docs cargados. Resultado: bloqueado, no puede subir más, no puede iniciar biometría (la UI sí debería dejarlo pero el componente probablemente confunde estado).

## Causa raíz

La pantalla `/dashboard/kyc` mostraba 4 documentos para upload manual:
- Cédula anverso (marcado `cubrePorBiometria=true`)
- Cédula reverso (marcado `cubrePorBiometria=true`)
- Selfie con cédula (marcado `cubrePorBiometria=true`)
- Comprobante de domicilio (no cubre biometría)

Los 3 primeros se OCULTABAN sólo si la biometría estaba APROBADA. **Antes** de hacer la biometría, los 4 estaban visibles, y el socio podía subir cualquier imagen → backend dispara auto-EN_REVISION → bloqueo total.

## Fix UI (este PR)

1. **`TIPOS_DOCUMENTO` queda solo con `COMPROBANTE_DOMICILIO`**. Cédula y selfie únicamente vía biometría (Didit). Sin opción de upload manual de identidad.

2. **Botón "Subir" del comprobante deshabilitado** hasta que biometría esté APROBADA. Tooltip: "Completá la verificación facial (Paso 1) antes de subir el comprobante". Fuerza el orden secuencial.

3. **Título renombrado**: "Paso 2 · Documentos" → "Paso 2 · Comprobante de domicilio". Mensaje "completá la verificación facial primero" cuando aún no pasó biometría.

4. **Cálculo de progreso ajustado**: `DOCS_CUBIERTOS_POR_BIOMETRIA = 3` constante. El backend sigue contando 4 docs requeridos (compatibilidad histórica) pero la UI muestra "3 cubiertos por biometría + 1 comprobante = 4/4" cuando aplica.

## Deuda técnica que queda (no en este PR)

- **Backend `verificacion_kyc` auto-EN_REVISION**: la lógica que pasa el estado a EN_REVISION cuando hay 4 docs subidos sigue siendo vulnerable. Si alguien con acceso a la API directa sube 4 docs vía Postman, el bug se repite. Habría que cambiar para que el cambio de estado SOLO ocurra cuando el socio explícitamente presione "Enviar a revisión".

- **Reset de estado de ronni en PROD**: post-merge de este PR + deploy, hago el reset manual:
  ```sql
  DELETE FROM documento_identidad WHERE verificacion_id = '922d00cf-01a5-4117-9c3d-d2a723749031';
  UPDATE verificacion_kyc SET estado = 'PENDIENTE', estado_biometria = 'NO_INICIADA', motivo_rechazo = NULL WHERE id = '922d00cf-01a5-4117-9c3d-d2a723749031';
  ```

## Test plan

- [ ] Socio nuevo (post-aprobación admin) entra a `/dashboard/kyc`
- [ ] Solo ve la sección "Paso 1 · Verificación biométrica" + "Paso 2 · Comprobante de domicilio"
- [ ] El botón "Subir" del comprobante está deshabilitado, tooltip explicativo
- [ ] Hace biometría con Didit → al completar exitoso, vuelve a la pantalla
- [ ] El botón "Subir" del comprobante se habilita
- [ ] Sube el comprobante
- [ ] Aparece "Enviar a revisión"
- [ ] Click → verificacion_kyc pasa a EN_REVISION (esta vez por su acción explícita)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
