### PR TITLE
fix(infra): cargar secrets Didit desde .env.{prod,qa} fuera del repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ target/
 .env
 .env.local
 .env.*.local
+.env.prod
+.env.qa
+.env.production
 .idea/
 .vscode/
 .ai/venv/

--- a/infrastructure/docker-compose.prod.yml
+++ b/infrastructure/docker-compose.prod.yml
@@ -61,6 +61,14 @@ services:
   backend:
     image: fatrans-backend:latest
     container_name: fatrans-backend
+    # Secrets de proveedores externos (Didit, etc.) van en `.env.prod` con
+    # chmod 600 — fuera del repo. Histórico (sep 2026): el backend tenía las
+    # credenciales DIDIT_* hardcoded en el `docker run -e ...` original;
+    # nunca quedaron versionadas. Al recrear el container con
+    # `compose up --force-recreate`, las env vars se perdieron y la biometría
+    # dejó de funcionar sin explicación. Ahora vivimos del archivo.
+    env_file:
+      - .env.prod
     environment:
       SPRING_PROFILES_ACTIVE: prod
       DB_URL: jdbc:postgresql://fatrans-postgres:5432/fondo

--- a/infrastructure/scripts/deploy-qa.sh
+++ b/infrastructure/scripts/deploy-qa.sh
@@ -136,6 +136,19 @@ done
 log "   Redis QA OK"
 
 log "→ Levantando Backend QA (con healthcheck)..."
+# Secrets de proveedores externos (Didit, etc.) viven en /opt/fatrans-qa/.env.qa
+# con chmod 600 — fuera del repo. Histórico: las credenciales DIDIT_* originales
+# se perdieron en el recreate del container PROD (sep 2026) porque nunca
+# estuvieron versionadas. Ahora vivimos del archivo, no del shell.
+QA_ENV_FILE="/opt/fatrans-qa/.env.qa"
+ENV_FILE_FLAG=""
+if [ -f "$QA_ENV_FILE" ]; then
+  ENV_FILE_FLAG="--env-file $QA_ENV_FILE"
+  log "   Cargando secrets desde $QA_ENV_FILE"
+else
+  log "   ⚠️ $QA_ENV_FILE no existe — Didit y otras integraciones quedarán sin credenciales"
+fi
+# shellcheck disable=SC2086  # Queremos word-splitting de $ENV_FILE_FLAG
 docker run -d \
   --name fatrans-qa-backend \
   --network fatrans-network \
@@ -146,6 +159,7 @@ docker run -d \
   --health-timeout 10s \
   --health-retries 3 \
   --health-start-period 60s \
+  $ENV_FILE_FLAG \
   -e SPRING_PROFILES_ACTIVE=dev \
   -e DB_URL=jdbc:postgresql://fatrans-postgres:5432/fondo_qa \
   -e DB_USER=app \


### PR DESCRIPTION
## Por qué

Hoy (18-may-2026) tras los varios deploys a PROD, la biometría con Didit dejó de funcionar — al socio `ronni.ronni` le salía "Error iniciando verificacion" al click en "Verificación biométrica".

Causa raíz: las credenciales `DIDIT_API_KEY`, `DIDIT_WEBHOOK_SECRET` y `DIDIT_WORKFLOW_ID` estaban hardcoded en el `docker run -e ...` original que creó el container backend de PROD hace meses. **Nunca** quedaron versionadas en el repo, ni en `docker-compose.prod.yml`, ni en un `.env` persistente. Al recrear el container con `docker compose up --force-recreate backend` durante los deploys de hoy, las env vars se perdieron silenciosamente.

Sin esas variables, `DIDIT_ENABLED` cae a su default `false` en `application.yml`, el adapter biométrico queda inactivo, y cualquier intento de iniciar verificación falla.

## Cambios

### `infrastructure/docker-compose.prod.yml`
Servicio `backend` agrega:
```yaml
env_file:
  - .env.prod
```
El archivo `.env.prod` vive en `/opt/fatrans/backend/infrastructure/.env.prod` en el VPS, con `chmod 600` y NO commiteado al repo.

### `infrastructure/scripts/deploy-qa.sh`
El `docker run` del backend QA detecta `/opt/fatrans-qa/.env.qa` y lo pasa como `--env-file`. Si el archivo falta, warn pero no falla.

### `.gitignore`
Agrega `.env.prod`, `.env.qa`, `.env.production` para evitar accidentes.

## Estado actual

- ✅ `/opt/fatrans/backend/infrastructure/.env.prod` creado en VPS con credenciales reales
- ✅ `/opt/fatrans-qa/.env.qa` creado en VPS con las mismas credenciales pero `DIDIT_CALLBACK_URL=https://qa-app.fatrans.com.ve/dashboard/kyc`
- ✅ Container `fatrans-backend` recreado, healthy, todas las `DIDIT_*` populadas
- ✅ Container `fatrans-qa-backend` recreado, healthy, todas las `DIDIT_*` populadas
- ✅ Tanto el deploy-prod (vía compose) como el deploy-qa (vía docker run) cargarán las env vars en futuros deploys

## Test plan

- [ ] Mergear este PR a develop
- [ ] PR `develop` → `main`, deploy a PROD
- [ ] El deploy-prod-sh sincroniza el compose y el container backend se recrea — esta vez SÍ con `.env.prod` cargado
- [ ] Smoke: login con `ronni.ronni` en `https://app.fatrans.com.ve` → ir a `/dashboard/kyc` → click "Iniciar verificación biométrica" → debe abrir el widget de Didit en nueva pestaña

## Importante (post-merge)

Cuando el deploy a PROD corra (Deploy → Producción del PR de promoción que abriremos después), el `compose up --force-recreate backend` va a recrear el container backend OTRA vez. Si por alguna razón el `.env.prod` no está en el path correcto en el VPS al momento del recreate, las credenciales se perderían DE NUEVO.

Verificación pre-deploy: el archivo `/opt/fatrans/backend/infrastructure/.env.prod` ya existe (sigue ahí porque está fuera del git workspace, en el sentido de que git reset no toca archivos no trackeados que matchean .gitignore). Solo hay que asegurar que no se borre manualmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
