### PR TITLE
fix(kyc): rediseñar verificación biométrica + sync con todos los estados

### DIFF
--- a/frontend-web/src/components/features/kyc/biometric-capture.tsx
+++ b/frontend-web/src/components/features/kyc/biometric-capture.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -12,7 +12,15 @@ import {
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
-import { Loader2, Camera, ShieldCheck, AlertCircle, CheckCircle2, ExternalLink, XCircle } from 'lucide-react';
+import {
+  Loader2,
+  Camera,
+  ShieldCheck,
+  CheckCircle2,
+  ExternalLink,
+  XCircle,
+  RotateCw,
+} from 'lucide-react';
 import { toast } from 'sonner';
 
 /** Estado biométrico del backend — coincide con el enum `EstadoBiometria` Java. */
@@ -24,124 +32,171 @@ type EstadoBiometricoBackend =
   | 'EXPIRADA';
 
 /**
- * Captura biométrica del KYC — proxy hacia el widget de Didit (passive liveness +
- * face match + ID document OCR).
- *
- * Flujo:
- *  1. Usuario acepta consentimiento LOPDP biométrico (checkbox separado del KYC general).
- *  2. Hacemos POST a `/api/kyc/biometric/consentimiento`.
- *  3. Hacemos POST a `/api/kyc/biometric/iniciar` → recibimos `widgetUrl`.
- *  4. Abrimos el widget de Didit en una nueva pestaña (más seguro que iframe; Didit
- *     usa permisos de cámara que algunos navegadores bloquean en iframes cross-origin).
- *  5. El widget redirige al usuario de vuelta a la app; el backend recibe el resultado
- *     por webhook y actualiza el estado. La UI sondea (o se refresca al volver) y
- *     muestra "Verificación en revisión".
+ * Steps internos de UI. Antes había 6 (consent/ready/in_progress/submitted/
+ * aprobado/rechazado) que confundían al socio — el rediseño los colapsa a 4
+ * con flujo lineal: pendiente → en_progreso → (aprobada | rechazada).
  */
-/**
- * Mapea el estado biométrico que viene del backend al step interno de UI.
- *  - `APROBADA`         → muestra confirmación (no pedir verificación de nuevo).
- *  - `RECHAZADA`        → muestra mensaje de rechazo + permite reintentar.
- *  - `EN_PROGRESO`      → asumimos que ya envió y está esperando webhook.
- *  - `NO_INICIADA`/null → muestra consent (flujo normal).
- *  - `EXPIRADA`         → permite reintentar (vuelve a consent).
- */
-function deriveStepFromBackend(estado: EstadoBiometricoBackend | null | undefined):
-  'consent' | 'ready' | 'in_progress' | 'submitted' | 'aprobado' | 'rechazado' {
+type Step = 'pendiente' | 'en_progreso' | 'aprobada' | 'rechazada';
+
+function deriveStepFromBackend(
+  estado: EstadoBiometricoBackend | null | undefined
+): Step {
   switch (estado) {
     case 'APROBADA':
-      return 'aprobado';
+      return 'aprobada';
     case 'RECHAZADA':
-      return 'rechazado';
-    case 'EN_PROGRESO':
-      return 'in_progress';
     case 'EXPIRADA':
+      return 'rechazada';
+    case 'EN_PROGRESO':
+      return 'en_progreso';
     case 'NO_INICIADA':
     case null:
     case undefined:
     default:
-      return 'consent';
+      return 'pendiente';
   }
 }
 
+/**
+ * Captura biométrica del KYC — wrapper alrededor del widget de Didit
+ * (passive liveness + face match + OCR de cédula).
+ *
+ * Rediseño (19-may-2026) — motivado por feedback de PROD: el socio veía
+ * dos pasos (consent → ready → iniciar) y se confundía. Además, después de
+ * pasar la verificación, el componente seguía pidiendo aceptar términos
+ * porque el `useEffect` solo sincronizaba para APROBADA/RECHAZADA y se
+ * comía la transición de `NO_INICIADA → EN_PROGRESO`.
+ *
+ * Cambios:
+ *  1. Un solo botón "Iniciar verificación facial" — registra consent +
+ *     crea sesión Didit + abre pestaña en una sola acción.
+ *  2. `useEffect` sincroniza el step con TODOS los estados del backend
+ *     (no solo terminales). El step deja de quedarse "atrás" tras un
+ *     refetch.
+ *  3. Auto-polling cada 5s cuando estamos en `en_progreso` — pide al
+ *     padre que refetch /api/kyc/estado. Cuando llega el webhook de Didit,
+ *     la UI pasa a `aprobada` sin que el socio haga nada.
+ *  4. Mensaje terminal "aprobada" indica el siguiente paso explícitamente
+ *     ("subí el comprobante de domicilio abajo") en vez de solo confirmar.
+ *  5. "Rechazada" muestra checklist de qué revisar al reintentar.
+ */
 export function BiometricCapture({
   onCompleted,
   estadoBackend,
 }: {
+  /** Callback para que el padre re-fetchee el estado KYC. */
   onCompleted?: () => void;
-  /** Estado biométrico actual según el backend — el componente lo usa para
-      decidir si mostrar consent / abrir verificación / mostrar "ya aprobada". */
+  /** Estado biométrico actual según el backend (viene de /api/kyc/estado). */
   estadoBackend?: EstadoBiometricoBackend | null;
 }) {
-  const [step, setStep] = useState<'consent' | 'ready' | 'in_progress' | 'submitted' | 'aprobado' | 'rechazado'>(
-    () => deriveStepFromBackend(estadoBackend)
+  const [step, setStep] = useState<Step>(() =>
+    deriveStepFromBackend(estadoBackend)
   );
   const [aceptado, setAceptado] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  /** Cacheamos el URL del widget para que el socio pueda re-abrir la
+      pestaña si la cerró sin completar (sin tener que crear sesión nueva
+      en Didit). Se pierde si el componente se desmonta — en ese caso
+      `handleReabrirWidget` inicia una sesión nueva. */
+  const [widgetUrl, setWidgetUrl] = useState<string | null>(null);
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Si el backend nos avisa que el estado cambió (porque hicimos refetch
-  // después del webhook), sincronizamos el step. No tocamos los estados
-  // intermedios `ready`/`in_progress`/`submitted` porque esos son locales —
-  // solo nos importa pasar a `aprobado`/`rechazado` cuando llegan del server.
+  // Sincroniza step con TODOS los cambios de estadoBackend. Fix histórico:
+  // antes este efecto solo manejaba APROBADA/RECHAZADA y dejaba al step
+  // estancado en estados intermedios después de un refetch.
   useEffect(() => {
-    if (estadoBackend === 'APROBADA') setStep('aprobado');
-    else if (estadoBackend === 'RECHAZADA') setStep('rechazado');
+    setStep(deriveStepFromBackend(estadoBackend));
   }, [estadoBackend]);
 
-  const handleAceptarConsentimiento = async () => {
+  // Polling automático mientras estamos esperando el webhook de Didit.
+  // Cada 5s pide al padre que refetch — si el webhook ya llegó, el
+  // useEffect anterior nos transiciona a `aprobada` o `rechazada`.
+  // Se detiene cuando salimos de `en_progreso` y al desmontar.
+  useEffect(() => {
+    if (step === 'en_progreso' && onCompleted) {
+      pollingRef.current = setInterval(() => onCompleted(), 5000);
+    }
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
+    };
+  }, [step, onCompleted]);
+
+  /**
+   * Inicia verificación: registra consent + crea sesión Didit + abre pestaña.
+   * Todo en una acción para evitar el step intermedio donde el socio se perdía.
+   */
+  const handleIniciar = async () => {
     if (!aceptado) {
-      toast.error('Debes aceptar la política biométrica');
+      toast.error('Aceptá el consentimiento para continuar');
       return;
     }
     setIsLoading(true);
     try {
-      const res = await fetch('/api/kyc/biometric/consentimiento', {
+      // 1) Consentimiento. El backend acepta repetir (idempotente vía upsert
+      //    en biometric_consent), así que no hace falta saltarlo si ya existe.
+      const consentRes = await fetch('/api/kyc/biometric/consentimiento', {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ aceptado: true, versionPolitica: '1.0' }),
       });
-      if (!res.ok) {
-        const e = await res.json().catch(() => ({}));
-        throw new Error(e.message || 'Error registrando consentimiento');
+      if (!consentRes.ok && consentRes.status !== 409) {
+        const e = await consentRes.json().catch(() => ({}));
+        throw new Error(e.message || 'No pudimos registrar el consentimiento');
       }
-      setStep('ready');
-      toast.success('Consentimiento registrado');
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-    } finally {
-      setIsLoading(false);
-    }
-  };
 
-  const handleIniciar = async () => {
-    setIsLoading(true);
-    try {
-      const res = await fetch('/api/kyc/biometric/iniciar', {
+      // 2) Crear sesión Didit y abrir el widget en pestaña nueva.
+      const iniciarRes = await fetch('/api/kyc/biometric/iniciar', {
         method: 'POST',
         credentials: 'include',
       });
-      if (!res.ok) {
-        const e = await res.json().catch(() => ({}));
-        throw new Error(e.message || 'Error iniciando verificación');
+      if (!iniciarRes.ok) {
+        const e = await iniciarRes.json().catch(() => ({}));
+        throw new Error(
+          e.message || 'No pudimos iniciar la verificación, intentá de nuevo'
+        );
       }
-      const data = await res.json();
+      const data = await iniciarRes.json();
       if (!data?.widgetUrl) {
-        throw new Error('El proveedor no devolvió URL del widget');
+        throw new Error('El proveedor no devolvió el enlace de verificación');
       }
-      // Abrir Didit en pestaña nueva — necesita permisos de cámara propios.
+
+      setWidgetUrl(data.widgetUrl);
       window.open(data.widgetUrl, '_blank', 'noopener,noreferrer');
-      setStep('in_progress');
+      setStep('en_progreso');
+      // Refetch del padre para persistir EN_PROGRESO en estadoBiometria
+      // — si el socio refresca, no vuelve a pedirle consent.
+      onCompleted?.();
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Error');
+      toast.error(err instanceof Error ? err.message : 'Error inesperado');
     } finally {
       setIsLoading(false);
     }
   };
 
-  const handleMarcarTerminado = () => {
-    setStep('submitted');
-    onCompleted?.();
-    toast.info('La verificación está siendo procesada por el proveedor');
+  /**
+   * Re-abrir la pestaña de Didit. Si tenemos URL en memoria la usamos;
+   * si no (post-refresh), arrancamos una sesión nueva. Didit detecta
+   * sesiones existentes por vendor_data y devuelve la cacheada cuando
+   * aplica, así que no creamos duplicados.
+   */
+  const handleReabrirWidget = async () => {
+    if (widgetUrl) {
+      window.open(widgetUrl, '_blank', 'noopener,noreferrer');
+      return;
+    }
+    setAceptado(true); // ya aceptó antes, no le pedimos de nuevo
+    await handleIniciar();
+  };
+
+  /** Tras un rechazo, vuelve al estado inicial para que el socio reintente. */
+  const handleReintentar = () => {
+    setStep('pendiente');
+    setAceptado(false);
+    setWidgetUrl(null);
   };
 
   return (
@@ -149,136 +204,156 @@ export function BiometricCapture({
       <CardHeader>
         <div className="flex items-center gap-2">
           <Camera className="h-5 w-5 text-blue-600" />
-          <CardTitle>Verificación biométrica</CardTitle>
+          <CardTitle>Verificación facial</CardTitle>
         </div>
         <CardDescription>
-          Necesitamos confirmar que eres tú con un selfie + tu cédula. La captura
-          se procesa en Didit (proveedor externo) bajo encriptación TLS.
+          Confirmá tu identidad con un selfie y tu cédula. Toma menos de 1 minuto.
         </CardDescription>
       </CardHeader>
 
       <CardContent className="space-y-4">
-        {step === 'consent' && (
+        {/* ============================================================
+             PASO 1 — Pendiente: acepta consent + arranca todo en una acción.
+            ============================================================ */}
+        {step === 'pendiente' && (
           <>
             <Alert>
               <ShieldCheck className="h-4 w-4" />
-              <AlertTitle>Consentimiento LOPDP biométrico</AlertTitle>
-              <AlertDescription className="space-y-2 text-sm">
+              <AlertTitle>Cómo funciona</AlertTitle>
+              <AlertDescription className="text-sm space-y-2">
                 <p>
-                  Tu imagen facial es un <strong>dato biométrico sensible</strong>. Será
-                  procesada por <strong>Didit</strong> (proveedor con sede en España) bajo
-                  cifrado, solo para comparar tu selfie con tu cédula y detectar suplantación.
+                  <strong>1.</strong> Abrimos el widget de <strong>Didit</strong> (proveedor externo) en una pestaña nueva.
                 </p>
                 <p>
-                  Las imágenes se eliminan a los <strong>90 días</strong>. Puedes revocar este
-                  consentimiento en cualquier momento desde tu perfil — al revocar, también
-                  se solicitará al proveedor que elimine tus datos.
+                  <strong>2.</strong> Te pide permiso para usar la cámara, sacar foto a tu cédula y un selfie corto.
+                </p>
+                <p>
+                  <strong>3.</strong> Cuando termines, volvé acá. Te avisamos automáticamente cuando esté listo.
                 </p>
               </AlertDescription>
             </Alert>
 
-            <div className="flex items-start gap-3 p-3 border rounded-lg">
+            <div className="flex items-start gap-3 p-3 border rounded-lg bg-slate-50">
               <Checkbox
                 id="biometric-consent"
                 checked={aceptado}
                 onCheckedChange={(c) => setAceptado(c === true)}
                 disabled={isLoading}
+                className="mt-0.5"
               />
-              <Label htmlFor="biometric-consent" className="text-sm leading-snug cursor-pointer">
-                Acepto que mi imagen facial sea procesada por Didit (España) para verificar
-                mi identidad bajo la política biométrica de Fatrans. Entiendo que es un
-                consentimiento separado del KYC documental y que puedo revocarlo.
+              <Label
+                htmlFor="biometric-consent"
+                className="text-xs leading-snug cursor-pointer text-slate-700"
+              >
+                Acepto que mi imagen facial se procese en Didit (España) para verificar mi identidad
+                bajo la política LOPDP. Las imágenes se eliminan a los 90 días. Puedo revocar este
+                consentimiento desde mi perfil.
               </Label>
             </div>
 
             <Button
-              onClick={handleAceptarConsentimiento}
+              onClick={handleIniciar}
               disabled={!aceptado || isLoading}
-              className="w-full bg-green-600 hover:bg-green-700"
+              className="w-full h-12 text-base bg-blue-600 hover:bg-blue-700"
             >
-              {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-              Aceptar y continuar
+              {isLoading ? (
+                <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+              ) : (
+                <Camera className="mr-2 h-5 w-5" />
+              )}
+              Iniciar verificación facial
             </Button>
           </>
         )}
 
-        {step === 'ready' && (
+        {/* ============================================================
+             PASO 2 — En progreso: pestaña abierta, polling activo.
+            ============================================================ */}
+        {step === 'en_progreso' && (
           <>
-            <Alert>
-              <Camera className="h-4 w-4" />
-              <AlertTitle>Lo que vas a hacer</AlertTitle>
-              <AlertDescription className="text-sm">
-                Vamos a abrir el widget de Didit en una pestaña nueva. Te pedirá permiso
-                para usar la cámara, capturar tu cédula y un selfie corto. Toma menos
-                de 1 minuto.
+            <div className="flex flex-col items-center gap-3 py-6">
+              <Loader2 className="h-12 w-12 animate-spin text-blue-600" />
+              <h3 className="font-semibold text-base text-center">
+                Esperando el resultado
+              </h3>
+              <p className="text-sm text-center text-slate-600 max-w-sm">
+                Completá la captura en la pestaña que se abrió. Cuando termines, esperá unos
+                segundos.
+              </p>
+              <p className="text-xs text-slate-500 text-center">
+                Verificamos cada 5 segundos — el resultado aparece solo.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Button
+                onClick={handleReabrirWidget}
+                variant="outline"
+                disabled={isLoading}
+                className="w-full"
+              >
+                {isLoading ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <ExternalLink className="mr-2 h-4 w-4" />
+                )}
+                Volver a abrir la pestaña de verificación
+              </Button>
+              <Button
+                onClick={() => onCompleted?.()}
+                variant="ghost"
+                size="sm"
+                className="text-xs"
+              >
+                <RotateCw className="mr-2 h-3 w-3" />
+                Actualizar manualmente
+              </Button>
+            </div>
+          </>
+        )}
+
+        {/* ============================================================
+             PASO 3a — Aprobada: terminal verde con next step explícito.
+            ============================================================ */}
+        {step === 'aprobada' && (
+          <Alert className="border-green-300 bg-green-50">
+            <CheckCircle2 className="h-5 w-5 text-green-600" />
+            <AlertTitle className="text-green-900 font-semibold">
+              Identidad verificada ✓
+            </AlertTitle>
+            <AlertDescription className="text-green-800 text-sm space-y-2">
+              <p>Tu verificación facial fue aprobada. Ya tenemos tu cédula y tu selfie.</p>
+              <p className="font-medium">
+                👇 Ahora subí el comprobante de domicilio abajo para terminar.
+              </p>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* ============================================================
+             PASO 3b — Rechazada / Expirada: terminal rojo con tips.
+            ============================================================ */}
+        {step === 'rechazada' && (
+          <>
+            <Alert className="border-red-300 bg-red-50">
+              <XCircle className="h-5 w-5 text-red-600" />
+              <AlertTitle className="text-red-900 font-semibold">
+                La verificación no pasó
+              </AlertTitle>
+              <AlertDescription className="text-red-800 text-sm space-y-2">
+                <p>No pudimos confirmar tu identidad. Probá de nuevo asegurándote de:</p>
+                <ul className="list-disc list-inside space-y-1 ml-1">
+                  <li>Estar en un lugar con buena luz</li>
+                  <li>Mostrar la cédula completa y sin reflejos</li>
+                  <li>Hacer el selfie con la cara totalmente visible</li>
+                </ul>
               </AlertDescription>
             </Alert>
             <Button
-              onClick={handleIniciar}
-              disabled={isLoading}
+              onClick={handleReintentar}
               className="w-full bg-blue-600 hover:bg-blue-700"
             >
-              {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <ExternalLink className="mr-2 h-4 w-4" />}
-              Abrir verificación
-            </Button>
-          </>
-        )}
-
-        {step === 'in_progress' && (
-          <>
-            <Alert>
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>Estamos esperando el resultado</AlertTitle>
-              <AlertDescription className="text-sm">
-                Completa el flujo en la pestaña que abrimos. Cuando termines, vuelve aquí
-                y presiona <em>"Ya terminé"</em>. El proveedor nos enviará el resultado
-                automáticamente en cuanto procese tu captura.
-              </AlertDescription>
-            </Alert>
-            <Button onClick={handleMarcarTerminado} variant="outline" className="w-full">
-              Ya terminé la verificación
-            </Button>
-          </>
-        )}
-
-        {step === 'submitted' && (
-          <Alert className="border-green-200 bg-green-50">
-            <ShieldCheck className="h-4 w-4 text-green-600" />
-            <AlertTitle className="text-green-900">Verificación enviada</AlertTitle>
-            <AlertDescription className="text-green-800 text-sm">
-              Tu captura está siendo procesada. Recibirás el resultado en unos minutos.
-              Puedes cerrar esta página — la decisión llegará por correo.
-            </AlertDescription>
-          </Alert>
-        )}
-
-        {/* Estados terminales que vienen del backend (webhook ya procesado). */}
-        {step === 'aprobado' && (
-          <Alert className="border-green-200 bg-green-50">
-            <CheckCircle2 className="h-4 w-4 text-green-600" />
-            <AlertTitle className="text-green-900">Verificación biométrica aprobada</AlertTitle>
-            <AlertDescription className="text-green-800 text-sm">
-              Ya pasaste la verificación facial. No necesitas hacerla de nuevo.
-              La cédula y el selfie quedaron registrados.
-            </AlertDescription>
-          </Alert>
-        )}
-
-        {step === 'rechazado' && (
-          <>
-            <Alert className="border-red-200 bg-red-50">
-              <XCircle className="h-4 w-4 text-red-600" />
-              <AlertTitle className="text-red-900">Verificación biométrica rechazada</AlertTitle>
-              <AlertDescription className="text-red-800 text-sm">
-                No pudimos confirmar tu identidad con el selfie y la cédula.
-                Podés intentarlo de nuevo o subir los documentos manualmente abajo.
-              </AlertDescription>
-            </Alert>
-            <Button
-              onClick={() => setStep('consent')}
-              variant="outline"
-              className="w-full"
-            >
+              <Camera className="mr-2 h-4 w-4" />
               Reintentar verificación
             </Button>
           </>


### PR DESCRIPTION
## Bug reportado en PROD (hoy)

`alexander.alexander` (PROD) pasó la verificación facial en Didit pero la UI seguía mostrando el botón "aceptar términos y volver a hacer la verificación", sin permitirle continuar al comprobante de domicilio.

## Causas raíz

1. **`useEffect` solo sincronizaba terminales**: el efecto que escuchaba `estadoBackend` solo cambiaba el step para `APROBADA` y `RECHAZADA`. Si el backend pasaba a `EN_PROGRESO` después de un refetch, el step local se quedaba en su estado anterior (`consent` por default), por eso seguía pidiendo aceptar términos.

2. **Flujo de 6 steps confuso**: `consent → ready → in_progress → submitted → aprobado/rechazado`. El socio tenía que aceptar checkbox, presionar "Aceptar y continuar", leer otra explicación, y recién después "Abrir verificación".

3. **Sin polling**: cuando el socio terminaba en Didit, la UI no se actualizaba sola. Había que clickear "Ya terminé" o refrescar.

## Rediseño

**De 6 steps a 4 lineales**:

| Step | Lo que ve el socio |
|------|--------------------|
| `pendiente` | Explicación numerada (1, 2, 3) + checkbox + **un solo** botón "Iniciar verificación facial" |
| `en_progreso` | Spinner + "Esperando el resultado" + "Verificamos cada 5s — el resultado aparece solo" + botones secundarios "Volver a abrir pestaña" / "Actualizar manualmente" |
| `aprobada` | ✅ Verde "Identidad verificada" + **next step explícito**: "👇 Ahora subí el comprobante de domicilio abajo para terminar" |
| `rechazada` | ❌ Rojo con checklist (luz, cédula visible, cara visible) + botón "Reintentar verificación". `EXPIRADA` mapea acá también. |

**Cambios técnicos**:

- **Un solo botón** "Iniciar verificación facial" registra consent + crea sesión Didit + abre pestaña en una sola acción.
- **`useEffect` sincroniza step con TODOS los estados** del backend, no solo terminales. Fixea el bug del reporte.
- **Auto-polling cada 5s** en `en_progreso`: cuando llega el webhook de Didit, el padre refetch `/api/kyc/estado` y el step transiciona a `aprobada` sin intervención del socio.
- **Cache de widget URL** en memoria + handler "Volver a abrir pestaña". Si la URL se pierde (post-refresh), crea sesión nueva automáticamente.

## Test plan post-deploy

- [ ] Socio nuevo (post-aprobación admin) entra a `/dashboard/kyc`
- [ ] Ve UN solo botón "Iniciar verificación facial" (no dos pasos)
- [ ] Tildando el checkbox se habilita el botón
- [ ] Click → se abre pestaña con Didit
- [ ] El componente queda en "Esperando el resultado"
- [ ] El socio completa Didit en la pestaña
- [ ] **(con webhook configurado)** A los 5-10s la UI pasa sola a "Identidad verificada ✓"
- [ ] El botón "Subir comprobante" del paso 2 se habilita
- [ ] Si Didit rechaza, ve checklist y puede reintentar
- [ ] Si el socio refresca la página estando en `en_progreso`, vuelve al mismo estado (no le pide consent de nuevo)

## Notas

- El **webhook de Didit todavía no está configurado** en el dashboard (https://business.didit.me). Mientras no esté, el polling no va a hacer milagros — el estado_biometria del backend nunca pasa a APROBADA sin webhook. Para socios que pasen por el flow antes de configurar el webhook, sigue siendo necesario el workaround manual (UPDATE en BD). Una vez configurado el webhook, todo este flujo se vuelve automático.

- Workaround puntual ya aplicado a `alexander.alexander` y `carlos` (socio_prueba) en PROD para que puedan continuar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
