### PR TITLE
feat(notifications): SMTP real Zoho para emails del flujo de registro

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -50,6 +50,14 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
+        <!-- Email — JavaMailSender + SMTP. Solo se activa si `fatrans.mail.enabled=true`
+             y hay credenciales `MAIL_USERNAME`/`MAIL_PASSWORD` en env. Caso contrario el
+             EmailNotificationServiceImpl cae a modo mock (loguea, no manda). -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+
         <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/backend/src/main/java/com/tufondo/socios/infrastructure/notification/EmailNotificationServiceImpl.java
+++ b/backend/src/main/java/com/tufondo/socios/infrastructure/notification/EmailNotificationServiceImpl.java
@@ -1,40 +1,194 @@
-// 📁 com/tufondo/socios/infrastructure/notification/EmailNotificationServiceImpl.java
 package com.tufondo.socios.infrastructure.notification;
 
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
 /**
- * Implementación mock del servicio de email.
- * Por ahora solo loguea los emails enviados.
+ * Implementación del servicio de email para notificaciones del flujo de registro.
+ *
+ * Dual-mode:
+ *  - **Mock**: si `fatrans.mail.enabled=false` o no hay `JavaMailSender` configurado,
+ *    loguea metadatos y sigue. Útil en dev, tests y en cualquier entorno donde
+ *    aún no tengamos credenciales SMTP.
+ *  - **Real**: si está habilitado, manda vía SMTP (Zoho por default). Falla
+ *    silenciosamente al log si hay error de auth/red — no quiere romper el flujo
+ *    de aprobación de un socio porque el SMTP esté caído momentáneamente. Si más
+ *    adelante necesitamos confiabilidad (retry, cola), agregar Spring Retry o
+ *    una cola dedicada.
+ *
+ * NUNCA logueamos la contraseña temporal en ningún caso (riesgo LOPDP).
+ *
+ * Templates: HTML inline en strings Java. Pragmático pero feo; cuando el set
+ * de emails crezca, migrar a Thymeleaf (`spring-boot-starter-thymeleaf`) con
+ * archivos en `src/main/resources/templates/email/`.
  */
 @Service
 @Slf4j
 public class EmailNotificationServiceImpl implements EmailNotificationService {
-    
+
+    private final boolean enabled;
+    private final JavaMailSender sender;
+    private final String from;
+    private final String fromName;
+    private final String appBaseUrl;
+
+    @Autowired
+    public EmailNotificationServiceImpl(
+            @Value("${fatrans.mail.enabled:false}") boolean enabled,
+            @Autowired(required = false) JavaMailSender sender,
+            @Value("${fatrans.mail.from:no-reply@fatrans.com.ve}") String from,
+            @Value("${fatrans.mail.from-name:Fatrans}") String fromName,
+            @Value("${fatrans.mail.app-base-url:https://app.fatrans.com.ve}") String appBaseUrl) {
+        this.enabled = enabled;
+        this.sender = sender;
+        this.from = from;
+        this.fromName = fromName;
+        this.appBaseUrl = appBaseUrl;
+        if (enabled && sender == null) {
+            log.warn("fatrans.mail.enabled=true pero JavaMailSender no fue creado " +
+                    "(faltan spring.mail.host/username?). Caigo a modo MOCK.");
+        }
+    }
+
     @Override
     public void enviarCredenciales(String email, String nombreUsuario, String passwordTemporal) {
-        // NUNCA loguear la contraseña temporal — riesgo LOPDP/seguridad.
-        // Solo se registran metadatos suficientes para auditoría operacional.
-        log.info("Email de credenciales enviado (mock) a usuario={} (asunto: 'Tu cuenta del Fondo de Ahorro ha sido creada')",
-                nombreUsuario);
+        if (!isReal()) {
+            // NUNCA logueamos passwordTemporal — solo metadatos para auditoría.
+            log.info("Email de credenciales enviado (MOCK) a usuario={} (real desactivado o sin SMTP)",
+                    nombreUsuario);
+            return;
+        }
+        String html = """
+                <p>Hola,</p>
+                <p>Tu cuenta del <strong>Fondo de Ahorro Fatrans</strong> ya está activa.</p>
+                <p><strong>Usuario:</strong> %s<br/>
+                <strong>Contraseña temporal:</strong> %s</p>
+                <p>Por seguridad, al ingresar por primera vez vas a tener que cambiar la
+                contraseña.</p>
+                <p style="margin-top: 20px;">
+                  <a href="%s/login" style="background:#16A34A;color:#fff;padding:10px 20px;
+                  text-decoration:none;border-radius:6px;display:inline-block;">
+                    Iniciar sesión
+                  </a>
+                </p>
+                <hr style="border:none;border-top:1px solid #ddd;margin:24px 0;"/>
+                <p style="font-size:11px;color:#666;">
+                  Si no solicitaste esta cuenta, ignorá este correo. Asociación de Ahorro y
+                  Crédito Fatrans (RIF J-50516835-5).
+                </p>
+                """.formatted(escapeHtml(nombreUsuario), escapeHtml(passwordTemporal), appBaseUrl);
+
+        boolean ok = sendHtml(email, "Tu cuenta del Fondo de Ahorro está activa", html);
+        if (ok) {
+            log.info("Email de credenciales enviado vía SMTP a usuario={}", nombreUsuario);
+        }
     }
-    
+
     @Override
     public void enviarNotificacionRechazo(String email, String motivo) {
-        log.info("========== EMAIL MOCK: RECHAZO DE SOLICITUD ==========");
-        log.info("Para: {}", email);
-        log.info("Asunto: Tu solicitud de registro ha sido rechazada");
-        log.info("Motivo: {}", motivo);
-        log.info("======================================================");
+        if (!isReal()) {
+            log.info("Email de rechazo enviado (MOCK) a {}", email);
+            return;
+        }
+        String html = """
+                <p>Hola,</p>
+                <p>Lamentamos informarte que tu <strong>solicitud de registro</strong> en el
+                Fondo de Ahorro Fatrans no pudo ser aprobada.</p>
+                <p><strong>Motivo:</strong> %s</p>
+                <p>Si pensás que es un error o querés intentar de nuevo, escribinos a
+                <a href="mailto:soporte@fatrans.com.ve">soporte@fatrans.com.ve</a> con tu
+                cédula y los datos relevantes.</p>
+                <hr style="border:none;border-top:1px solid #ddd;margin:24px 0;"/>
+                <p style="font-size:11px;color:#666;">
+                  Asociación de Ahorro y Crédito Fatrans (RIF J-50516835-5).
+                </p>
+                """.formatted(escapeHtml(motivo == null ? "(sin motivo especificado)" : motivo));
+
+        boolean ok = sendHtml(email, "Tu solicitud de registro no fue aprobada", html);
+        if (ok) {
+            log.info("Email de rechazo enviado vía SMTP a {}", email);
+        }
     }
-    
+
     @Override
     public void enviarNotificacionSolicitudRecibida(String email) {
-        log.info("========== EMAIL MOCK: SOLICITUD RECIBIDA ==========");
-        log.info("Para: {}", email);
-        log.info("Asunto: Hemos recibido tu solicitud de registro");
-        log.info("Cuerpo: Tu solicitud está siendo procesada. Te notificaremos cuando sea revisada.");
-        log.info("====================================================");
+        if (!isReal()) {
+            log.info("Email 'solicitud recibida' enviado (MOCK) a {}", email);
+            return;
+        }
+        String html = """
+                <p>Hola,</p>
+                <p>Recibimos tu <strong>solicitud de registro</strong> en el Fondo de Ahorro
+                Fatrans. Un administrador la va a revisar pronto.</p>
+                <p>Cuando esté aprobada vas a recibir otro correo con tus credenciales de
+                acceso.</p>
+                <hr style="border:none;border-top:1px solid #ddd;margin:24px 0;"/>
+                <p style="font-size:11px;color:#666;">
+                  Asociación de Ahorro y Crédito Fatrans (RIF J-50516835-5).
+                </p>
+                """;
+
+        boolean ok = sendHtml(email, "Recibimos tu solicitud de registro", html);
+        if (ok) {
+            log.info("Email 'solicitud recibida' enviado vía SMTP a {}", email);
+        }
+    }
+
+    // ────────────────────────────────────────────────────────
+    //  Helpers privados
+    // ────────────────────────────────────────────────────────
+
+    /** Sólo manda vía SMTP si está habilitado Y el sender se construyó. */
+    private boolean isReal() {
+        return enabled && sender != null;
+    }
+
+    /**
+     * Envía un email HTML. Devuelve true si fue OK, false si falló. NO propaga
+     * la excepción — el caller no se entera y el flujo de aprobación sigue su
+     * curso (preferible vs. abortar la aprobación de un socio porque SMTP cayó).
+     * Para reintentos confiables: integrar Spring Retry o una cola dedicada.
+     */
+    private boolean sendHtml(String to, String subject, String htmlBody) {
+        try {
+            MimeMessage mime = sender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mime, true, StandardCharsets.UTF_8.name());
+            try {
+                helper.setFrom(new InternetAddress(from, fromName, StandardCharsets.UTF_8.name()));
+            } catch (UnsupportedEncodingException e) {
+                helper.setFrom(from);
+            }
+            helper.setTo(to);
+            helper.setSubject(subject);
+            helper.setText(htmlBody, true);
+            sender.send(mime);
+            return true;
+        } catch (MailException | MessagingException e) {
+            log.error("Fallo enviando email a {} (asunto='{}'): {}", to, subject, e.getMessage());
+            return false;
+        }
+    }
+
+    /** Sanitización mínima de entidades HTML para evitar XSS en valores
+        dinámicos (nombre de usuario, motivo de rechazo). */
+    private static String escapeHtml(String s) {
+        if (s == null) return "";
+        return s
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -28,6 +28,25 @@ spring:
     baseline-on-migrate: true
     baseline-version: 1
 
+  # SMTP de Zoho — credenciales en .env.{prod,qa} via MAIL_USERNAME/MAIL_PASSWORD.
+  # Si están vacías, JavaMailSender se construye igual pero `enviar` falla con
+  # AuthenticationFailedException — `EmailNotificationServiceImpl` chequea
+  # `fatrans.mail.enabled` antes de intentar, así que en dev/test no rompe.
+  mail:
+    host: ${MAIL_HOST:smtp.zoho.com}
+    port: ${MAIL_PORT:465}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          ssl:
+            enable: true
+          starttls:
+            enable: false
+        debug: ${MAIL_DEBUG:false}
+
 springdoc:
   api-docs:
     path: /v3/api-docs
@@ -79,6 +98,22 @@ fatrans:
       base-url: ${DIDIT_BASE_URL:https://verification.didit.me/v2}
       callback-url: ${DIDIT_CALLBACK_URL:}
       webhook-timestamp-tolerance-seconds: 300
+  # ============================================
+  # NOTIFICACIONES POR EMAIL (Zoho SMTP)
+  # ============================================
+  # Si `enabled=false` o faltan credenciales, EmailNotificationServiceImpl cae a
+  # modo mock (loguea, no manda). Permite que la app arranque sin credenciales
+  # y que los tests no toquen SMTP real.
+  mail:
+    enabled: ${MAIL_ENABLED:false}
+    from: ${MAIL_FROM:no-reply@fatrans.com.ve}
+    from-name: ${MAIL_FROM_NAME:Fatrans}
+    # URL pública del frontend protected — usada en los emails para links
+    # (login, dashboard). Cambia entre PROD y QA.
+    app-base-url: ${MAIL_APP_BASE_URL:https://app.fatrans.com.ve}
+    # Email del super admin para notificaciones operacionales (nueva solicitud
+    # pendiente de aprobar, etc.). Vacío = no manda emails al admin.
+    admin-notification: ${MAIL_ADMIN_NOTIFICATION:}
 
 # ============================================
 # MÓDULO DOCUMENTOS PDF - CONFIGURACIÓN


### PR DESCRIPTION
## Por qué

El `EmailNotificationServiceImpl` actual es **mock** — solo loguea a stdout. Por eso `ronni.ronni`, `alexander.alexander` y todos los socios aprobados en PROD nunca recibieron sus credenciales por email, lo que generó el workaround manual recurrente de UPDATE en BD para resetear la password a `Admin123!`.

## Cambios

### Dependencia
`pom.xml` agrega `spring-boot-starter-mail` (JavaMailSender + JavaMail API).

### Config — `application.yml`

```yaml
spring.mail:           # Zoho SMTP
  host: smtp.zoho.com
  port: 465
  username: ${MAIL_USERNAME:}
  password: ${MAIL_PASSWORD:}
  properties.mail.smtp.ssl.enable: true

fatrans.mail:
  enabled: ${MAIL_ENABLED:false}  # switch maestro
  from: ${MAIL_FROM:no-reply@fatrans.com.ve}
  from-name: ${MAIL_FROM_NAME:Fatrans}
  app-base-url: ${MAIL_APP_BASE_URL:https://app.fatrans.com.ve}  # link "Iniciar sesión"
  admin-notification: ${MAIL_ADMIN_NOTIFICATION:}  # futuro: notif al super-admin
```

### Servicio dual-mode

`EmailNotificationServiceImpl` ahora:

- **Modo mock** (default, sin SMTP configurado) → loguea y vuelve OK. Permite arrancar sin credenciales en dev/test.
- **Modo SMTP real** (cuando `MAIL_ENABLED=true` y credenciales OK) → manda HTML real con `JavaMailSender`.

Características:
- Templates HTML inline con escape de XSS (`escapeHtml`).
- Fallos de SMTP se **loguean pero NO abortan el flujo de aprobación**. (Preferible "socio aprobado pero email tarda" vs "aprobación abortada porque Zoho cayó").
- NUNCA loguea la contraseña temporal.

### Eventos cubiertos (los 3 bloqueantes)

| Evento | Cuándo | Asunto del email |
|--------|--------|------------------|
| `enviarNotificacionSolicitudRecibida` | POST a `/api/auth/registro` exitoso | "Recibimos tu solicitud de registro" |
| `enviarCredenciales` | Admin aprueba la solicitud | "Tu cuenta del Fondo de Ahorro está activa" — incluye usuario, password temporal y botón "Iniciar sesión" |
| `enviarNotificacionRechazo` | Admin rechaza la solicitud | "Tu solicitud de registro no fue aprobada" — incluye motivo |

## Activación post-deploy

Pasos para vos:

1. En el panel de Zoho Mail Admin → **Add User** → crear `no-reply@fatrans.com.ve`
2. Logueate como `no-reply` → **Settings → Security → App passwords** → generar app password de 16 caracteres
3. Pasame el app password → lo seteo en `/opt/fatrans/backend/infrastructure/.env.prod` y `/opt/fatrans-qa/.env.qa`:
   ```
   MAIL_ENABLED=true
   MAIL_USERNAME=no-reply@fatrans.com.ve
   MAIL_PASSWORD=<app-password>
   MAIL_FROM=no-reply@fatrans.com.ve
   MAIL_FROM_NAME=Fatrans
   MAIL_APP_BASE_URL=https://app.fatrans.com.ve   # qa-app.fatrans.com.ve en QA
   ```
4. Mergear este PR → develop → main → deploy → recrear container backend → próximo registro recibe email real.

## Test plan

- [ ] `mvn compile` pasa (CI)
- [ ] Backend arranca con `MAIL_ENABLED=false` → modo mock, sin warnings
- [ ] Backend arranca con `MAIL_ENABLED=true` + credenciales válidas → SMTP listo, sin errores en logs de arranque
- [ ] Smoke: crear solicitud de registro en QA → recibir email "solicitud recibida"
- [ ] Smoke: admin aprueba → socio recibe email con credenciales + botón login
- [ ] Smoke: admin rechaza → socio recibe email con motivo

## Siguiente pasada (NO en este PR)

- Cambio de password → notificación de seguridad
- KYC aprobado / rechazado → notificación al socio
- Notificación al admin cuando hay solicitudes pendientes
- Migrar a Thymeleaf si el set de emails crece >5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
