### PR TITLE
release: 5ª promoción — emails reales + rediseño biométrico + secrets Didit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ target/
 .env
 .env.local
 .env.*.local
+.env.prod
+.env.qa
+.env.production
 .idea/
 .vscode/
 .ai/venv/

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -50,6 +50,14 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
+        <!-- Email — JavaMailSender + SMTP. Solo se activa si `fatrans.mail.enabled=true`
+             y hay credenciales `MAIL_USERNAME`/`MAIL_PASSWORD` en env. Caso contrario el
+             EmailNotificationServiceImpl cae a modo mock (loguea, no manda). -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+
         <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/backend/src/main/java/com/tufondo/socios/infrastructure/notification/EmailNotificationServiceImpl.java
+++ b/backend/src/main/java/com/tufondo/socios/infrastructure/notification/EmailNotificationServiceImpl.java
@@ -1,40 +1,194 @@
-// 📁 com/tufondo/socios/infrastructure/notification/EmailNotificationServiceImpl.java
 package com.tufondo.socios.infrastructure.notification;
 
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
 /**
- * Implementación mock del servicio de email.
- * Por ahora solo loguea los emails enviados.
+ * Implementación del servicio de email para notificaciones del flujo de registro.
+ *
+ * Dual-mode:
+ *  - **Mock**: si `fatrans.mail.enabled=false` o no hay `JavaMailSender` configurado,
+ *    loguea metadatos y sigue. Útil en dev, tests y en cualquier entorno donde
+ *    aún no tengamos credenciales SMTP.
+ *  - **Real**: si está habilitado, manda vía SMTP (Zoho por default). Falla
+ *    silenciosamente al log si hay error de auth/red — no quiere romper el flujo
+ *    de aprobación de un socio porque el SMTP esté caído momentáneamente. Si más
+ *    adelante necesitamos confiabilidad (retry, cola), agregar Spring Retry o
+ *    una cola dedicada.
+ *
+ * NUNCA logueamos la contraseña temporal en ningún caso (riesgo LOPDP).
+ *
+ * Templates: HTML inline en strings Java. Pragmático pero feo; cuando el set
+ * de emails crezca, migrar a Thymeleaf (`spring-boot-starter-thymeleaf`) con
+ * archivos en `src/main/resources/templates/email/`.
  */
 @Service
 @Slf4j
 public class EmailNotificationServiceImpl implements EmailNotificationService {
-    
+
+    private final boolean enabled;
+    private final JavaMailSender sender;
+    private final String from;
+    private final String fromName;
+    private final String appBaseUrl;
+
+    @Autowired
+    public EmailNotificationServiceImpl(
+            @Value("${fatrans.mail.enabled:false}") boolean enabled,
+            @Autowired(required = false) JavaMailSender sender,
+            @Value("${fatrans.mail.from:no-reply@fatrans.com.ve}") String from,
+            @Value("${fatrans.mail.from-name:Fatrans}") String fromName,
+            @Value("${fatrans.mail.app-base-url:https://app.fatrans.com.ve}") String appBaseUrl) {
+        this.enabled = enabled;
+        this.sender = sender;
+        this.from = from;
+        this.fromName = fromName;
+        this.appBaseUrl = appBaseUrl;
+        if (enabled && sender == null) {
+            log.warn("fatrans.mail.enabled=true pero JavaMailSender no fue creado " +
+                    "(faltan spring.mail.host/username?). Caigo a modo MOCK.");
+        }
+    }
+
     @Override
     public void enviarCredenciales(String email, String nombreUsuario, String passwordTemporal) {
-        // NUNCA loguear la contraseña temporal — riesgo LOPDP/seguridad.
-        // Solo se registran metadatos suficientes para auditoría operacional.
-        log.info("Email de credenciales enviado (mock) a usuario={} (asunto: 'Tu cuenta del Fondo de Ahorro ha sido creada')",
-                nombreUsuario);
+        if (!isReal()) {
+            // NUNCA logueamos passwordTemporal — solo metadatos para auditoría.
+            log.info("Email de credenciales enviado (MOCK) a usuario={} (real desactivado o sin SMTP)",
+                    nombreUsuario);
+            return;
+        }
+        String html = """
+                <p>Hola,</p>
+                <p>Tu cuenta del <strong>Fondo de Ahorro Fatrans</strong> ya está activa.</p>
+                <p><strong>Usuario:</strong> %s<br/>
+                <strong>Contraseña temporal:</strong> %s</p>
+                <p>Por seguridad, al ingresar por primera vez vas a tener que cambiar la
+                contraseña.</p>
+                <p style="margin-top: 20px;">
+                  <a href="%s/login" style="background:#16A34A;color:#fff;padding:10px 20px;
+                  text-decoration:none;border-radius:6px;display:inline-block;">
+                    Iniciar sesión
+                  </a>
+                </p>
+                <hr style="border:none;border-top:1px solid #ddd;margin:24px 0;"/>
+                <p style="font-size:11px;color:#666;">
+                  Si no solicitaste esta cuenta, ignorá este correo. Asociación de Ahorro y
+                  Crédito Fatrans (RIF J-50516835-5).
+                </p>
+                """.formatted(escapeHtml(nombreUsuario), escapeHtml(passwordTemporal), appBaseUrl);
+
+        boolean ok = sendHtml(email, "Tu cuenta del Fondo de Ahorro está activa", html);
+        if (ok) {
+            log.info("Email de credenciales enviado vía SMTP a usuario={}", nombreUsuario);
+        }
     }
-    
+
     @Override
     public void enviarNotificacionRechazo(String email, String motivo) {
-        log.info("========== EMAIL MOCK: RECHAZO DE SOLICITUD ==========");
-        log.info("Para: {}", email);
-        log.info("Asunto: Tu solicitud de registro ha sido rechazada");
-        log.info("Motivo: {}", motivo);
-        log.info("======================================================");
+        if (!isReal()) {
+            log.info("Email de rechazo enviado (MOCK) a {}", email);
+            return;
+        }
+        String html = """
+                <p>Hola,</p>
+                <p>Lamentamos informarte que tu <strong>solicitud de registro</strong> en el
+                Fondo de Ahorro Fatrans no pudo ser aprobada.</p>
+                <p><strong>Motivo:</strong> %s</p>
+                <p>Si pensás que es un error o querés intentar de nuevo, escribinos a
+                <a href="mailto:soporte@fatrans.com.ve">soporte@fatrans.com.ve</a> con tu
+                cédula y los datos relevantes.</p>
+                <hr style="border:none;border-top:1px solid #ddd;margin:24px 0;"/>
+                <p style="font-size:11px;color:#666;">
+                  Asociación de Ahorro y Crédito Fatrans (RIF J-50516835-5).
+                </p>
+                """.formatted(escapeHtml(motivo == null ? "(sin motivo especificado)" : motivo));
+
+        boolean ok = sendHtml(email, "Tu solicitud de registro no fue aprobada", html);
+        if (ok) {
+            log.info("Email de rechazo enviado vía SMTP a {}", email);
+        }
     }
-    
+
     @Override
     public void enviarNotificacionSolicitudRecibida(String email) {
-        log.info("========== EMAIL MOCK: SOLICITUD RECIBIDA ==========");
-        log.info("Para: {}", email);
-        log.info("Asunto: Hemos recibido tu solicitud de registro");
-        log.info("Cuerpo: Tu solicitud está siendo procesada. Te notificaremos cuando sea revisada.");
-        log.info("====================================================");
+        if (!isReal()) {
+            log.info("Email 'solicitud recibida' enviado (MOCK) a {}", email);
+            return;
+        }
+        String html = """
+                <p>Hola,</p>
+                <p>Recibimos tu <strong>solicitud de registro</strong> en el Fondo de Ahorro
+                Fatrans. Un administrador la va a revisar pronto.</p>
+                <p>Cuando esté aprobada vas a recibir otro correo con tus credenciales de
+                acceso.</p>
+                <hr style="border:none;border-top:1px solid #ddd;margin:24px 0;"/>
+                <p style="font-size:11px;color:#666;">
+                  Asociación de Ahorro y Crédito Fatrans (RIF J-50516835-5).
+                </p>
+                """;
+
+        boolean ok = sendHtml(email, "Recibimos tu solicitud de registro", html);
+        if (ok) {
+            log.info("Email 'solicitud recibida' enviado vía SMTP a {}", email);
+        }
+    }
+
+    // ────────────────────────────────────────────────────────
+    //  Helpers privados
+    // ────────────────────────────────────────────────────────
+
+    /** Sólo manda vía SMTP si está habilitado Y el sender se construyó. */
+    private boolean isReal() {
+        return enabled && sender != null;
+    }
+
+    /**
+     * Envía un email HTML. Devuelve true si fue OK, false si falló. NO propaga
+     * la excepción — el caller no se entera y el flujo de aprobación sigue su
+     * curso (preferible vs. abortar la aprobación de un socio porque SMTP cayó).
+     * Para reintentos confiables: integrar Spring Retry o una cola dedicada.
+     */
+    private boolean sendHtml(String to, String subject, String htmlBody) {
+        try {
+            MimeMessage mime = sender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mime, true, StandardCharsets.UTF_8.name());
+            try {
+                helper.setFrom(new InternetAddress(from, fromName, StandardCharsets.UTF_8.name()));
+            } catch (UnsupportedEncodingException e) {
+                helper.setFrom(from);
+            }
+            helper.setTo(to);
+            helper.setSubject(subject);
+            helper.setText(htmlBody, true);
+            sender.send(mime);
+            return true;
+        } catch (MailException | MessagingException e) {
+            log.error("Fallo enviando email a {} (asunto='{}'): {}", to, subject, e.getMessage());
+            return false;
+        }
+    }
+
+    /** Sanitización mínima de entidades HTML para evitar XSS en valores
+        dinámicos (nombre de usuario, motivo de rechazo). */
+    private static String escapeHtml(String s) {
+        if (s == null) return "";
+        return s
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
     }
 }

--- a/backend/src/main/java/com/tufondo/socios/infrastructure/notification/EmailNotificationServiceImpl.java
+++ b/backend/src/main/java/com/tufondo/socios/infrastructure/notification/EmailNotificationServiceImpl.java
@@ -69,27 +69,40 @@ public class EmailNotificationServiceImpl implements EmailNotificationService {
                     nombreUsuario);
             return;
         }
-        String html = """
-                <p>Hola,</p>
-                <p>Tu cuenta del <strong>Fondo de Ahorro Fatrans</strong> ya está activa.</p>
-                <p><strong>Usuario:</strong> %s<br/>
-                <strong>Contraseña temporal:</strong> %s</p>
-                <p>Por seguridad, al ingresar por primera vez vas a tener que cambiar la
-                contraseña.</p>
-                <p style="margin-top: 20px;">
-                  <a href="%s/login" style="background:#16A34A;color:#fff;padding:10px 20px;
-                  text-decoration:none;border-radius:6px;display:inline-block;">
-                    Iniciar sesión
-                  </a>
+        String preheader = "Tu cuenta del Fondo de Ahorro ya está activa. Cambia tu contraseña al primer ingreso.";
+        String contenido = """
+                <h1 style="margin:0 0 16px;font-size:22px;color:#0F2744;">¡Bienvenido al Fondo de Ahorro!</h1>
+                <p style="margin:0 0 16px;color:#475569;line-height:1.5;">
+                  Tu solicitud de registro fue aprobada. A continuación tus credenciales de acceso —
+                  guardalas en un lugar seguro.
                 </p>
-                <hr style="border:none;border-top:1px solid #ddd;margin:24px 0;"/>
-                <p style="font-size:11px;color:#666;">
-                  Si no solicitaste esta cuenta, ignorá este correo. Asociación de Ahorro y
-                  Crédito Fatrans (RIF J-50516835-5).
+                <table cellpadding="0" cellspacing="0" border="0" role="presentation"
+                  style="width:100%%;border-collapse:separate;border-spacing:0;border:1px solid #e2e8f0;
+                  border-radius:8px;background:#f8fafc;margin:8px 0 20px;">
+                  <tr>
+                    <td style="padding:14px 18px;border-bottom:1px solid #e2e8f0;
+                      font-family:'SF Mono','Consolas',monospace;font-size:14px;">
+                      <span style="color:#64748b;font-size:11px;text-transform:uppercase;
+                        letter-spacing:0.5px;display:block;margin-bottom:4px;">Usuario</span>
+                      <strong style="color:#0F2744;font-size:16px;">%s</strong>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding:14px 18px;
+                      font-family:'SF Mono','Consolas',monospace;font-size:14px;">
+                      <span style="color:#64748b;font-size:11px;text-transform:uppercase;
+                        letter-spacing:0.5px;display:block;margin-bottom:4px;">Contraseña temporal</span>
+                      <strong style="color:#0F2744;font-size:16px;">%s</strong>
+                    </td>
+                  </tr>
+                </table>
+                <p style="margin:0 0 24px;color:#475569;line-height:1.5;font-size:14px;">
+                  <strong>Importante:</strong> por seguridad, al ingresar por primera vez vamos a
+                  pedirte que cambies esta contraseña por una propia.
                 </p>
-                """.formatted(escapeHtml(nombreUsuario), escapeHtml(passwordTemporal), appBaseUrl);
-
-        boolean ok = sendHtml(email, "Tu cuenta del Fondo de Ahorro está activa", html);
+                """.formatted(escapeHtml(nombreUsuario), escapeHtml(passwordTemporal));
+        String html = renderEmail(preheader, contenido, "Iniciar sesión", appBaseUrl + "/login");
+        boolean ok = sendHtml(email, "Tu cuenta del Fondo de Ahorro Fatrans está activa", html);
         if (ok) {
             log.info("Email de credenciales enviado vía SMTP a usuario={}", nombreUsuario);
         }
@@ -101,20 +114,28 @@ public class EmailNotificationServiceImpl implements EmailNotificationService {
             log.info("Email de rechazo enviado (MOCK) a {}", email);
             return;
         }
-        String html = """
-                <p>Hola,</p>
-                <p>Lamentamos informarte que tu <strong>solicitud de registro</strong> en el
-                Fondo de Ahorro Fatrans no pudo ser aprobada.</p>
-                <p><strong>Motivo:</strong> %s</p>
-                <p>Si pensás que es un error o querés intentar de nuevo, escribinos a
-                <a href="mailto:soporte@fatrans.com.ve">soporte@fatrans.com.ve</a> con tu
-                cédula y los datos relevantes.</p>
-                <hr style="border:none;border-top:1px solid #ddd;margin:24px 0;"/>
-                <p style="font-size:11px;color:#666;">
-                  Asociación de Ahorro y Crédito Fatrans (RIF J-50516835-5).
+        String preheader = "Tu solicitud de registro no fue aprobada.";
+        String motivoSeguro = escapeHtml(motivo == null || motivo.isBlank() ? "(sin motivo especificado)" : motivo);
+        String contenido = """
+                <h1 style="margin:0 0 16px;font-size:22px;color:#0F2744;">Sobre tu solicitud</h1>
+                <p style="margin:0 0 16px;color:#475569;line-height:1.5;">
+                  Lamentamos informarte que tu solicitud de registro en el Fondo de Ahorro Fatrans
+                  no pudo ser aprobada en esta oportunidad.
                 </p>
-                """.formatted(escapeHtml(motivo == null ? "(sin motivo especificado)" : motivo));
-
+                <div style="background:#fef2f2;border-left:4px solid #ef4444;padding:14px 16px;
+                  border-radius:4px;margin:16px 0 24px;">
+                  <p style="margin:0 0 6px;color:#991b1b;font-size:12px;font-weight:600;
+                    text-transform:uppercase;letter-spacing:0.5px;">Motivo</p>
+                  <p style="margin:0;color:#7f1d1d;line-height:1.5;">%s</p>
+                </div>
+                <p style="margin:0 0 8px;color:#475569;line-height:1.5;font-size:14px;">
+                  Si pensás que es un error o querés intentar nuevamente, escribinos a
+                  <a href="mailto:soporte@fatrans.com.ve" style="color:#16A34A;font-weight:600;
+                    text-decoration:none;">soporte@fatrans.com.ve</a>
+                  con tu cédula y los datos relevantes.
+                </p>
+                """.formatted(motivoSeguro);
+        String html = renderEmail(preheader, contenido, null, null);
         boolean ok = sendHtml(email, "Tu solicitud de registro no fue aprobada", html);
         if (ok) {
             log.info("Email de rechazo enviado vía SMTP a {}", email);
@@ -127,19 +148,20 @@ public class EmailNotificationServiceImpl implements EmailNotificationService {
             log.info("Email 'solicitud recibida' enviado (MOCK) a {}", email);
             return;
         }
-        String html = """
-                <p>Hola,</p>
-                <p>Recibimos tu <strong>solicitud de registro</strong> en el Fondo de Ahorro
-                Fatrans. Un administrador la va a revisar pronto.</p>
-                <p>Cuando esté aprobada vas a recibir otro correo con tus credenciales de
-                acceso.</p>
-                <hr style="border:none;border-top:1px solid #ddd;margin:24px 0;"/>
-                <p style="font-size:11px;color:#666;">
-                  Asociación de Ahorro y Crédito Fatrans (RIF J-50516835-5).
+        String preheader = "Recibimos tu solicitud de registro. Te avisaremos cuando esté aprobada.";
+        String contenido = """
+                <h1 style="margin:0 0 16px;font-size:22px;color:#0F2744;">Recibimos tu solicitud</h1>
+                <p style="margin:0 0 16px;color:#475569;line-height:1.5;">
+                  Gracias por solicitar tu registro en el <strong>Fondo de Ahorro Fatrans</strong>.
+                  Un administrador revisará tu solicitud en las próximas horas.
+                </p>
+                <p style="margin:0 0 24px;color:#475569;line-height:1.5;">
+                  Cuando esté aprobada vas a recibir otro correo con tus credenciales de acceso.
+                  No necesitás hacer nada más por ahora.
                 </p>
                 """;
-
-        boolean ok = sendHtml(email, "Recibimos tu solicitud de registro", html);
+        String html = renderEmail(preheader, contenido, null, null);
+        boolean ok = sendHtml(email, "Recibimos tu solicitud de registro · Fatrans", html);
         if (ok) {
             log.info("Email 'solicitud recibida' enviado vía SMTP a {}", email);
         }
@@ -152,6 +174,111 @@ public class EmailNotificationServiceImpl implements EmailNotificationService {
     /** Sólo manda vía SMTP si está habilitado Y el sender se construyó. */
     private boolean isReal() {
         return enabled && sender != null;
+    }
+
+    /**
+     * Wrapper común para todos los emails: header con logo + contenido + CTA
+     * opcional + footer institucional.
+     *
+     * HTML cuidadosamente compatible con clientes problemáticos (Outlook,
+     * Gmail strip estilos, etc): solo `<table>` para layout, estilos INLINE
+     * (las `<style>` tag se ignoran en muchos clientes), sin imágenes
+     * críticas (las imágenes pueden no cargarse — el logo es decorativo,
+     * no transporta info).
+     *
+     * El logo se sirve desde `MAIL_APP_BASE_URL + /logo-fatrans.png`. Si el
+     * cliente bloquea imágenes, ven el `alt="Fatrans"` y el header sigue
+     * legible gracias al título textual debajo.
+     *
+     * `preheader` es texto invisible al principio del mail que los clientes
+     * muestran como preview en la bandeja de entrada (Gmail, Apple Mail).
+     * Truco estándar de email marketing.
+     */
+    private String renderEmail(String preheader, String contenidoHtml, String ctaText, String ctaUrl) {
+        String logoUrl = appBaseUrl + "/logo-fatrans.png";
+        String ctaHtml = "";
+        if (ctaText != null && ctaUrl != null) {
+            ctaHtml = """
+                    <table cellpadding="0" cellspacing="0" border="0" role="presentation"
+                      style="margin:0 0 24px;">
+                      <tr>
+                        <td style="background:#16A34A;border-radius:8px;">
+                          <a href="%s" style="display:inline-block;padding:12px 28px;
+                            font-family:Arial,Helvetica,sans-serif;font-size:15px;font-weight:600;
+                            color:#ffffff;text-decoration:none;">
+                            %s →
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+                    """.formatted(ctaUrl, escapeHtml(ctaText));
+        }
+
+        return """
+                <!DOCTYPE html>
+                <html lang="es">
+                <head>
+                  <meta charset="UTF-8"/>
+                  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+                  <title>Fatrans</title>
+                </head>
+                <body style="margin:0;padding:0;background:#f1f5f9;
+                  font-family:'Segoe UI',Tahoma,Geneva,Verdana,Arial,sans-serif;
+                  color:#0F2744;">
+                  <span style="display:none !important;visibility:hidden;opacity:0;color:transparent;
+                    height:0;max-height:0;overflow:hidden;mso-hide:all;">%s</span>
+                  <table cellpadding="0" cellspacing="0" border="0" role="presentation"
+                    style="width:100%%;background:#f1f5f9;">
+                    <tr>
+                      <td align="center" style="padding:24px 12px;">
+                        <table cellpadding="0" cellspacing="0" border="0" role="presentation"
+                          style="width:100%%;max-width:560px;background:#ffffff;
+                          border-radius:12px;overflow:hidden;
+                          box-shadow:0 1px 3px rgba(15,39,68,0.08);">
+                          <tr>
+                            <td style="background:#0F2744;padding:24px;text-align:center;">
+                              <img src="%s" alt="Fatrans" width="48" height="48"
+                                style="display:inline-block;border:0;outline:none;
+                                text-decoration:none;width:48px;height:48px;"/>
+                              <div style="margin-top:8px;color:#ffffff;font-size:18px;
+                                font-weight:600;letter-spacing:0.3px;">Fatrans</div>
+                              <div style="margin-top:2px;color:#94a3b8;font-size:11px;
+                                text-transform:uppercase;letter-spacing:1px;">
+                                Asociación de Ahorro y Crédito
+                              </div>
+                            </td>
+                          </tr>
+                          <tr>
+                            <td style="padding:32px 32px 8px;font-size:14px;line-height:1.5;">
+                              %s
+                              %s
+                            </td>
+                          </tr>
+                          <tr>
+                            <td style="background:#f8fafc;padding:20px 32px;
+                              border-top:1px solid #e2e8f0;color:#64748b;font-size:11px;
+                              line-height:1.5;">
+                              <strong style="color:#475569;">Fatrans</strong> · Asociación de
+                              Ahorro y Crédito · RIF J-50516835-5<br/>
+                              Si no esperabas este correo, podés ignorarlo o escribirnos a
+                              <a href="mailto:soporte@fatrans.com.ve"
+                                style="color:#16A34A;text-decoration:none;">soporte@fatrans.com.ve</a>
+                              <br/><br/>
+                              Este mensaje fue enviado automáticamente — no respondas a este buzón.
+                            </td>
+                          </tr>
+                        </table>
+                        <p style="margin:14px 0 0;color:#94a3b8;font-size:10px;
+                          font-family:Arial,Helvetica,sans-serif;">
+                          © 2026 Fatrans — Plataforma digital para socios del sector transporte
+                          venezolano.
+                        </p>
+                      </td>
+                    </tr>
+                  </table>
+                </body>
+                </html>
+                """.formatted(escapeHtml(preheader), logoUrl, contenidoHtml, ctaHtml);
     }
 
     /**

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -28,6 +28,25 @@ spring:
     baseline-on-migrate: true
     baseline-version: 1
 
+  # SMTP de Zoho — credenciales en .env.{prod,qa} via MAIL_USERNAME/MAIL_PASSWORD.
+  # Si están vacías, JavaMailSender se construye igual pero `enviar` falla con
+  # AuthenticationFailedException — `EmailNotificationServiceImpl` chequea
+  # `fatrans.mail.enabled` antes de intentar, así que en dev/test no rompe.
+  mail:
+    host: ${MAIL_HOST:smtp.zoho.com}
+    port: ${MAIL_PORT:465}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          ssl:
+            enable: true
+          starttls:
+            enable: false
+        debug: ${MAIL_DEBUG:false}
+
 springdoc:
   api-docs:
     path: /v3/api-docs
@@ -79,6 +98,22 @@ fatrans:
       base-url: ${DIDIT_BASE_URL:https://verification.didit.me/v2}
       callback-url: ${DIDIT_CALLBACK_URL:}
       webhook-timestamp-tolerance-seconds: 300
+  # ============================================
+  # NOTIFICACIONES POR EMAIL (Zoho SMTP)
+  # ============================================
+  # Si `enabled=false` o faltan credenciales, EmailNotificationServiceImpl cae a
+  # modo mock (loguea, no manda). Permite que la app arranque sin credenciales
+  # y que los tests no toquen SMTP real.
+  mail:
+    enabled: ${MAIL_ENABLED:false}
+    from: ${MAIL_FROM:no-reply@fatrans.com.ve}
+    from-name: ${MAIL_FROM_NAME:Fatrans}
+    # URL pública del frontend protected — usada en los emails para links
+    # (login, dashboard). Cambia entre PROD y QA.
+    app-base-url: ${MAIL_APP_BASE_URL:https://app.fatrans.com.ve}
+    # Email del super admin para notificaciones operacionales (nueva solicitud
+    # pendiente de aprobar, etc.). Vacío = no manda emails al admin.
+    admin-notification: ${MAIL_ADMIN_NOTIFICATION:}
 
 # ============================================
 # MÓDULO DOCUMENTOS PDF - CONFIGURACIÓN

--- a/frontend-web/src/components/features/kyc/biometric-capture.tsx
+++ b/frontend-web/src/components/features/kyc/biometric-capture.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -12,7 +12,15 @@ import {
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
-import { Loader2, Camera, ShieldCheck, AlertCircle, CheckCircle2, ExternalLink, XCircle } from 'lucide-react';
+import {
+  Loader2,
+  Camera,
+  ShieldCheck,
+  CheckCircle2,
+  ExternalLink,
+  XCircle,
+  RotateCw,
+} from 'lucide-react';
 import { toast } from 'sonner';
 
 /** Estado biométrico del backend — coincide con el enum `EstadoBiometria` Java. */
@@ -24,124 +32,171 @@ type EstadoBiometricoBackend =
   | 'EXPIRADA';
 
 /**
- * Captura biométrica del KYC — proxy hacia el widget de Didit (passive liveness +
- * face match + ID document OCR).
- *
- * Flujo:
- *  1. Usuario acepta consentimiento LOPDP biométrico (checkbox separado del KYC general).
- *  2. Hacemos POST a `/api/kyc/biometric/consentimiento`.
- *  3. Hacemos POST a `/api/kyc/biometric/iniciar` → recibimos `widgetUrl`.
- *  4. Abrimos el widget de Didit en una nueva pestaña (más seguro que iframe; Didit
- *     usa permisos de cámara que algunos navegadores bloquean en iframes cross-origin).
- *  5. El widget redirige al usuario de vuelta a la app; el backend recibe el resultado
- *     por webhook y actualiza el estado. La UI sondea (o se refresca al volver) y
- *     muestra "Verificación en revisión".
+ * Steps internos de UI. Antes había 6 (consent/ready/in_progress/submitted/
+ * aprobado/rechazado) que confundían al socio — el rediseño los colapsa a 4
+ * con flujo lineal: pendiente → en_progreso → (aprobada | rechazada).
  */
-/**
- * Mapea el estado biométrico que viene del backend al step interno de UI.
- *  - `APROBADA`         → muestra confirmación (no pedir verificación de nuevo).
- *  - `RECHAZADA`        → muestra mensaje de rechazo + permite reintentar.
- *  - `EN_PROGRESO`      → asumimos que ya envió y está esperando webhook.
- *  - `NO_INICIADA`/null → muestra consent (flujo normal).
- *  - `EXPIRADA`         → permite reintentar (vuelve a consent).
- */
-function deriveStepFromBackend(estado: EstadoBiometricoBackend | null | undefined):
-  'consent' | 'ready' | 'in_progress' | 'submitted' | 'aprobado' | 'rechazado' {
+type Step = 'pendiente' | 'en_progreso' | 'aprobada' | 'rechazada';
+
+function deriveStepFromBackend(
+  estado: EstadoBiometricoBackend | null | undefined
+): Step {
   switch (estado) {
     case 'APROBADA':
-      return 'aprobado';
+      return 'aprobada';
     case 'RECHAZADA':
-      return 'rechazado';
-    case 'EN_PROGRESO':
-      return 'in_progress';
     case 'EXPIRADA':
+      return 'rechazada';
+    case 'EN_PROGRESO':
+      return 'en_progreso';
     case 'NO_INICIADA':
     case null:
     case undefined:
     default:
-      return 'consent';
+      return 'pendiente';
   }
 }
 
+/**
+ * Captura biométrica del KYC — wrapper alrededor del widget de Didit
+ * (passive liveness + face match + OCR de cédula).
+ *
+ * Rediseño (19-may-2026) — motivado por feedback de PROD: el socio veía
+ * dos pasos (consent → ready → iniciar) y se confundía. Además, después de
+ * pasar la verificación, el componente seguía pidiendo aceptar términos
+ * porque el `useEffect` solo sincronizaba para APROBADA/RECHAZADA y se
+ * comía la transición de `NO_INICIADA → EN_PROGRESO`.
+ *
+ * Cambios:
+ *  1. Un solo botón "Iniciar verificación facial" — registra consent +
+ *     crea sesión Didit + abre pestaña en una sola acción.
+ *  2. `useEffect` sincroniza el step con TODOS los estados del backend
+ *     (no solo terminales). El step deja de quedarse "atrás" tras un
+ *     refetch.
+ *  3. Auto-polling cada 5s cuando estamos en `en_progreso` — pide al
+ *     padre que refetch /api/kyc/estado. Cuando llega el webhook de Didit,
+ *     la UI pasa a `aprobada` sin que el socio haga nada.
+ *  4. Mensaje terminal "aprobada" indica el siguiente paso explícitamente
+ *     ("subí el comprobante de domicilio abajo") en vez de solo confirmar.
+ *  5. "Rechazada" muestra checklist de qué revisar al reintentar.
+ */
 export function BiometricCapture({
   onCompleted,
   estadoBackend,
 }: {
+  /** Callback para que el padre re-fetchee el estado KYC. */
   onCompleted?: () => void;
-  /** Estado biométrico actual según el backend — el componente lo usa para
-      decidir si mostrar consent / abrir verificación / mostrar "ya aprobada". */
+  /** Estado biométrico actual según el backend (viene de /api/kyc/estado). */
   estadoBackend?: EstadoBiometricoBackend | null;
 }) {
-  const [step, setStep] = useState<'consent' | 'ready' | 'in_progress' | 'submitted' | 'aprobado' | 'rechazado'>(
-    () => deriveStepFromBackend(estadoBackend)
+  const [step, setStep] = useState<Step>(() =>
+    deriveStepFromBackend(estadoBackend)
   );
   const [aceptado, setAceptado] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  /** Cacheamos el URL del widget para que el socio pueda re-abrir la
+      pestaña si la cerró sin completar (sin tener que crear sesión nueva
+      en Didit). Se pierde si el componente se desmonta — en ese caso
+      `handleReabrirWidget` inicia una sesión nueva. */
+  const [widgetUrl, setWidgetUrl] = useState<string | null>(null);
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Si el backend nos avisa que el estado cambió (porque hicimos refetch
-  // después del webhook), sincronizamos el step. No tocamos los estados
-  // intermedios `ready`/`in_progress`/`submitted` porque esos son locales —
-  // solo nos importa pasar a `aprobado`/`rechazado` cuando llegan del server.
+  // Sincroniza step con TODOS los cambios de estadoBackend. Fix histórico:
+  // antes este efecto solo manejaba APROBADA/RECHAZADA y dejaba al step
+  // estancado en estados intermedios después de un refetch.
   useEffect(() => {
-    if (estadoBackend === 'APROBADA') setStep('aprobado');
-    else if (estadoBackend === 'RECHAZADA') setStep('rechazado');
+    setStep(deriveStepFromBackend(estadoBackend));
   }, [estadoBackend]);
 
-  const handleAceptarConsentimiento = async () => {
+  // Polling automático mientras estamos esperando el webhook de Didit.
+  // Cada 5s pide al padre que refetch — si el webhook ya llegó, el
+  // useEffect anterior nos transiciona a `aprobada` o `rechazada`.
+  // Se detiene cuando salimos de `en_progreso` y al desmontar.
+  useEffect(() => {
+    if (step === 'en_progreso' && onCompleted) {
+      pollingRef.current = setInterval(() => onCompleted(), 5000);
+    }
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
+    };
+  }, [step, onCompleted]);
+
+  /**
+   * Inicia verificación: registra consent + crea sesión Didit + abre pestaña.
+   * Todo en una acción para evitar el step intermedio donde el socio se perdía.
+   */
+  const handleIniciar = async () => {
     if (!aceptado) {
-      toast.error('Debes aceptar la política biométrica');
+      toast.error('Aceptá el consentimiento para continuar');
       return;
     }
     setIsLoading(true);
     try {
-      const res = await fetch('/api/kyc/biometric/consentimiento', {
+      // 1) Consentimiento. El backend acepta repetir (idempotente vía upsert
+      //    en biometric_consent), así que no hace falta saltarlo si ya existe.
+      const consentRes = await fetch('/api/kyc/biometric/consentimiento', {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ aceptado: true, versionPolitica: '1.0' }),
       });
-      if (!res.ok) {
-        const e = await res.json().catch(() => ({}));
-        throw new Error(e.message || 'Error registrando consentimiento');
+      if (!consentRes.ok && consentRes.status !== 409) {
+        const e = await consentRes.json().catch(() => ({}));
+        throw new Error(e.message || 'No pudimos registrar el consentimiento');
       }
-      setStep('ready');
-      toast.success('Consentimiento registrado');
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Error');
-    } finally {
-      setIsLoading(false);
-    }
-  };
 
-  const handleIniciar = async () => {
-    setIsLoading(true);
-    try {
-      const res = await fetch('/api/kyc/biometric/iniciar', {
+      // 2) Crear sesión Didit y abrir el widget en pestaña nueva.
+      const iniciarRes = await fetch('/api/kyc/biometric/iniciar', {
         method: 'POST',
         credentials: 'include',
       });
-      if (!res.ok) {
-        const e = await res.json().catch(() => ({}));
-        throw new Error(e.message || 'Error iniciando verificación');
+      if (!iniciarRes.ok) {
+        const e = await iniciarRes.json().catch(() => ({}));
+        throw new Error(
+          e.message || 'No pudimos iniciar la verificación, intentá de nuevo'
+        );
       }
-      const data = await res.json();
+      const data = await iniciarRes.json();
       if (!data?.widgetUrl) {
-        throw new Error('El proveedor no devolvió URL del widget');
+        throw new Error('El proveedor no devolvió el enlace de verificación');
       }
-      // Abrir Didit en pestaña nueva — necesita permisos de cámara propios.
+
+      setWidgetUrl(data.widgetUrl);
       window.open(data.widgetUrl, '_blank', 'noopener,noreferrer');
-      setStep('in_progress');
+      setStep('en_progreso');
+      // Refetch del padre para persistir EN_PROGRESO en estadoBiometria
+      // — si el socio refresca, no vuelve a pedirle consent.
+      onCompleted?.();
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Error');
+      toast.error(err instanceof Error ? err.message : 'Error inesperado');
     } finally {
       setIsLoading(false);
     }
   };
 
-  const handleMarcarTerminado = () => {
-    setStep('submitted');
-    onCompleted?.();
-    toast.info('La verificación está siendo procesada por el proveedor');
+  /**
+   * Re-abrir la pestaña de Didit. Si tenemos URL en memoria la usamos;
+   * si no (post-refresh), arrancamos una sesión nueva. Didit detecta
+   * sesiones existentes por vendor_data y devuelve la cacheada cuando
+   * aplica, así que no creamos duplicados.
+   */
+  const handleReabrirWidget = async () => {
+    if (widgetUrl) {
+      window.open(widgetUrl, '_blank', 'noopener,noreferrer');
+      return;
+    }
+    setAceptado(true); // ya aceptó antes, no le pedimos de nuevo
+    await handleIniciar();
+  };
+
+  /** Tras un rechazo, vuelve al estado inicial para que el socio reintente. */
+  const handleReintentar = () => {
+    setStep('pendiente');
+    setAceptado(false);
+    setWidgetUrl(null);
   };
 
   return (
@@ -149,136 +204,156 @@ export function BiometricCapture({
       <CardHeader>
         <div className="flex items-center gap-2">
           <Camera className="h-5 w-5 text-blue-600" />
-          <CardTitle>Verificación biométrica</CardTitle>
+          <CardTitle>Verificación facial</CardTitle>
         </div>
         <CardDescription>
-          Necesitamos confirmar que eres tú con un selfie + tu cédula. La captura
-          se procesa en Didit (proveedor externo) bajo encriptación TLS.
+          Confirmá tu identidad con un selfie y tu cédula. Toma menos de 1 minuto.
         </CardDescription>
       </CardHeader>
 
       <CardContent className="space-y-4">
-        {step === 'consent' && (
+        {/* ============================================================
+             PASO 1 — Pendiente: acepta consent + arranca todo en una acción.
+            ============================================================ */}
+        {step === 'pendiente' && (
           <>
             <Alert>
               <ShieldCheck className="h-4 w-4" />
-              <AlertTitle>Consentimiento LOPDP biométrico</AlertTitle>
-              <AlertDescription className="space-y-2 text-sm">
+              <AlertTitle>Cómo funciona</AlertTitle>
+              <AlertDescription className="text-sm space-y-2">
                 <p>
-                  Tu imagen facial es un <strong>dato biométrico sensible</strong>. Será
-                  procesada por <strong>Didit</strong> (proveedor con sede en España) bajo
-                  cifrado, solo para comparar tu selfie con tu cédula y detectar suplantación.
+                  <strong>1.</strong> Abrimos el widget de <strong>Didit</strong> (proveedor externo) en una pestaña nueva.
                 </p>
                 <p>
-                  Las imágenes se eliminan a los <strong>90 días</strong>. Puedes revocar este
-                  consentimiento en cualquier momento desde tu perfil — al revocar, también
-                  se solicitará al proveedor que elimine tus datos.
+                  <strong>2.</strong> Te pide permiso para usar la cámara, sacar foto a tu cédula y un selfie corto.
+                </p>
+                <p>
+                  <strong>3.</strong> Cuando termines, volvé acá. Te avisamos automáticamente cuando esté listo.
                 </p>
               </AlertDescription>
             </Alert>
 
-            <div className="flex items-start gap-3 p-3 border rounded-lg">
+            <div className="flex items-start gap-3 p-3 border rounded-lg bg-slate-50">
               <Checkbox
                 id="biometric-consent"
                 checked={aceptado}
                 onCheckedChange={(c) => setAceptado(c === true)}
                 disabled={isLoading}
+                className="mt-0.5"
               />
-              <Label htmlFor="biometric-consent" className="text-sm leading-snug cursor-pointer">
-                Acepto que mi imagen facial sea procesada por Didit (España) para verificar
-                mi identidad bajo la política biométrica de Fatrans. Entiendo que es un
-                consentimiento separado del KYC documental y que puedo revocarlo.
+              <Label
+                htmlFor="biometric-consent"
+                className="text-xs leading-snug cursor-pointer text-slate-700"
+              >
+                Acepto que mi imagen facial se procese en Didit (España) para verificar mi identidad
+                bajo la política LOPDP. Las imágenes se eliminan a los 90 días. Puedo revocar este
+                consentimiento desde mi perfil.
               </Label>
             </div>
 
             <Button
-              onClick={handleAceptarConsentimiento}
+              onClick={handleIniciar}
               disabled={!aceptado || isLoading}
-              className="w-full bg-green-600 hover:bg-green-700"
+              className="w-full h-12 text-base bg-blue-600 hover:bg-blue-700"
             >
-              {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-              Aceptar y continuar
+              {isLoading ? (
+                <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+              ) : (
+                <Camera className="mr-2 h-5 w-5" />
+              )}
+              Iniciar verificación facial
             </Button>
           </>
         )}
 
-        {step === 'ready' && (
+        {/* ============================================================
+             PASO 2 — En progreso: pestaña abierta, polling activo.
+            ============================================================ */}
+        {step === 'en_progreso' && (
           <>
-            <Alert>
-              <Camera className="h-4 w-4" />
-              <AlertTitle>Lo que vas a hacer</AlertTitle>
-              <AlertDescription className="text-sm">
-                Vamos a abrir el widget de Didit en una pestaña nueva. Te pedirá permiso
-                para usar la cámara, capturar tu cédula y un selfie corto. Toma menos
-                de 1 minuto.
+            <div className="flex flex-col items-center gap-3 py-6">
+              <Loader2 className="h-12 w-12 animate-spin text-blue-600" />
+              <h3 className="font-semibold text-base text-center">
+                Esperando el resultado
+              </h3>
+              <p className="text-sm text-center text-slate-600 max-w-sm">
+                Completá la captura en la pestaña que se abrió. Cuando termines, esperá unos
+                segundos.
+              </p>
+              <p className="text-xs text-slate-500 text-center">
+                Verificamos cada 5 segundos — el resultado aparece solo.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Button
+                onClick={handleReabrirWidget}
+                variant="outline"
+                disabled={isLoading}
+                className="w-full"
+              >
+                {isLoading ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <ExternalLink className="mr-2 h-4 w-4" />
+                )}
+                Volver a abrir la pestaña de verificación
+              </Button>
+              <Button
+                onClick={() => onCompleted?.()}
+                variant="ghost"
+                size="sm"
+                className="text-xs"
+              >
+                <RotateCw className="mr-2 h-3 w-3" />
+                Actualizar manualmente
+              </Button>
+            </div>
+          </>
+        )}
+
+        {/* ============================================================
+             PASO 3a — Aprobada: terminal verde con next step explícito.
+            ============================================================ */}
+        {step === 'aprobada' && (
+          <Alert className="border-green-300 bg-green-50">
+            <CheckCircle2 className="h-5 w-5 text-green-600" />
+            <AlertTitle className="text-green-900 font-semibold">
+              Identidad verificada ✓
+            </AlertTitle>
+            <AlertDescription className="text-green-800 text-sm space-y-2">
+              <p>Tu verificación facial fue aprobada. Ya tenemos tu cédula y tu selfie.</p>
+              <p className="font-medium">
+                👇 Ahora subí el comprobante de domicilio abajo para terminar.
+              </p>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* ============================================================
+             PASO 3b — Rechazada / Expirada: terminal rojo con tips.
+            ============================================================ */}
+        {step === 'rechazada' && (
+          <>
+            <Alert className="border-red-300 bg-red-50">
+              <XCircle className="h-5 w-5 text-red-600" />
+              <AlertTitle className="text-red-900 font-semibold">
+                La verificación no pasó
+              </AlertTitle>
+              <AlertDescription className="text-red-800 text-sm space-y-2">
+                <p>No pudimos confirmar tu identidad. Probá de nuevo asegurándote de:</p>
+                <ul className="list-disc list-inside space-y-1 ml-1">
+                  <li>Estar en un lugar con buena luz</li>
+                  <li>Mostrar la cédula completa y sin reflejos</li>
+                  <li>Hacer el selfie con la cara totalmente visible</li>
+                </ul>
               </AlertDescription>
             </Alert>
             <Button
-              onClick={handleIniciar}
-              disabled={isLoading}
+              onClick={handleReintentar}
               className="w-full bg-blue-600 hover:bg-blue-700"
             >
-              {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <ExternalLink className="mr-2 h-4 w-4" />}
-              Abrir verificación
-            </Button>
-          </>
-        )}
-
-        {step === 'in_progress' && (
-          <>
-            <Alert>
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>Estamos esperando el resultado</AlertTitle>
-              <AlertDescription className="text-sm">
-                Completa el flujo en la pestaña que abrimos. Cuando termines, vuelve aquí
-                y presiona <em>"Ya terminé"</em>. El proveedor nos enviará el resultado
-                automáticamente en cuanto procese tu captura.
-              </AlertDescription>
-            </Alert>
-            <Button onClick={handleMarcarTerminado} variant="outline" className="w-full">
-              Ya terminé la verificación
-            </Button>
-          </>
-        )}
-
-        {step === 'submitted' && (
-          <Alert className="border-green-200 bg-green-50">
-            <ShieldCheck className="h-4 w-4 text-green-600" />
-            <AlertTitle className="text-green-900">Verificación enviada</AlertTitle>
-            <AlertDescription className="text-green-800 text-sm">
-              Tu captura está siendo procesada. Recibirás el resultado en unos minutos.
-              Puedes cerrar esta página — la decisión llegará por correo.
-            </AlertDescription>
-          </Alert>
-        )}
-
-        {/* Estados terminales que vienen del backend (webhook ya procesado). */}
-        {step === 'aprobado' && (
-          <Alert className="border-green-200 bg-green-50">
-            <CheckCircle2 className="h-4 w-4 text-green-600" />
-            <AlertTitle className="text-green-900">Verificación biométrica aprobada</AlertTitle>
-            <AlertDescription className="text-green-800 text-sm">
-              Ya pasaste la verificación facial. No necesitas hacerla de nuevo.
-              La cédula y el selfie quedaron registrados.
-            </AlertDescription>
-          </Alert>
-        )}
-
-        {step === 'rechazado' && (
-          <>
-            <Alert className="border-red-200 bg-red-50">
-              <XCircle className="h-4 w-4 text-red-600" />
-              <AlertTitle className="text-red-900">Verificación biométrica rechazada</AlertTitle>
-              <AlertDescription className="text-red-800 text-sm">
-                No pudimos confirmar tu identidad con el selfie y la cédula.
-                Podés intentarlo de nuevo o subir los documentos manualmente abajo.
-              </AlertDescription>
-            </Alert>
-            <Button
-              onClick={() => setStep('consent')}
-              variant="outline"
-              className="w-full"
-            >
+              <Camera className="mr-2 h-4 w-4" />
               Reintentar verificación
             </Button>
           </>

--- a/frontend-web/src/components/layouts/admin/admin-shell.tsx
+++ b/frontend-web/src/components/layouts/admin/admin-shell.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 import { useAuthStore } from '@/stores/auth-store';
 import { ProtectedRoute } from '@/components/shared/protected-route';
 import { LogoutButton } from '@/components/shared/logout-button';
+import { ChangePasswordModal } from '@/components/shared/change-password-modal';
 import {
   LayoutDashboard,
   Users,
@@ -95,8 +96,11 @@ export function AdminShell({ children }: { children: React.ReactNode }) {
 
   const unreadCount = mockNotifications.filter((n) => !n.read).length;
 
+  // Modal forzado al primer login si `debeCambiarPassword=true` (control
+  // interno del componente). Mismo principio que en SocioShell.
   return (
     <ProtectedRoute allowedRoles={['ADMIN', 'SUPER_ADMIN', 'CAJERO', 'ANALISTA_KYC']}>
+      <ChangePasswordModal open />
       <div className="flex h-screen bg-slate-100">
         {/* Sidebar */}
         <aside className="hidden lg:flex w-64 bg-[#0F2744] text-white flex-col fixed h-full z-40">

--- a/frontend-web/src/components/layouts/socio/socio-shell.tsx
+++ b/frontend-web/src/components/layouts/socio/socio-shell.tsx
@@ -8,6 +8,7 @@ import { ProtectedRoute } from '@/components/shared/protected-route';
 import { LogoutButton } from '@/components/shared/logout-button';
 import { IdleTimeoutWatcher } from '@/components/shared/idle-timeout-watcher';
 import { NotificationBell } from '@/components/shared/notification-bell';
+import { ChangePasswordModal } from '@/components/shared/change-password-modal';
 import {
   LayoutDashboard,
   Wallet,
@@ -87,8 +88,14 @@ export function SocioShell({ children }: { children: React.ReactNode }) {
     month: 'long',
   });
 
+  // Si el socio entra por primera vez (password temporal del admin / reset),
+  // forzamos cambio antes de dejarlo navegar el dashboard. El modal se monta
+  // SIEMPRE pero se renderiza solo si `user.debeCambiarPassword=true` (control
+  // interno del componente). Después de cambiarla, el store actualiza el flag
+  // y el modal se oculta sin recargar.
   return (
     <ProtectedRoute allowedRoles={['SOCIO', 'ADMIN', 'SUPER_ADMIN']}>
+      <ChangePasswordModal open />
       {/* Issue #221: auto-logout por inactividad (banking standard) */}
       <IdleTimeoutWatcher idleMinutes={10} warningSeconds={60} />
       <div className="flex min-h-screen bg-slate-100">

--- a/infrastructure/docker-compose.prod.yml
+++ b/infrastructure/docker-compose.prod.yml
@@ -61,6 +61,14 @@ services:
   backend:
     image: fatrans-backend:latest
     container_name: fatrans-backend
+    # Secrets de proveedores externos (Didit, etc.) van en `.env.prod` con
+    # chmod 600 — fuera del repo. Histórico (sep 2026): el backend tenía las
+    # credenciales DIDIT_* hardcoded en el `docker run -e ...` original;
+    # nunca quedaron versionadas. Al recrear el container con
+    # `compose up --force-recreate`, las env vars se perdieron y la biometría
+    # dejó de funcionar sin explicación. Ahora vivimos del archivo.
+    env_file:
+      - .env.prod
     environment:
       SPRING_PROFILES_ACTIVE: prod
       DB_URL: jdbc:postgresql://fatrans-postgres:5432/fondo

--- a/infrastructure/scripts/deploy-qa.sh
+++ b/infrastructure/scripts/deploy-qa.sh
@@ -136,6 +136,19 @@ done
 log "   Redis QA OK"
 
 log "→ Levantando Backend QA (con healthcheck)..."
+# Secrets de proveedores externos (Didit, etc.) viven en /opt/fatrans-qa/.env.qa
+# con chmod 600 — fuera del repo. Histórico: las credenciales DIDIT_* originales
+# se perdieron en el recreate del container PROD (sep 2026) porque nunca
+# estuvieron versionadas. Ahora vivimos del archivo, no del shell.
+QA_ENV_FILE="/opt/fatrans-qa/.env.qa"
+ENV_FILE_FLAG=""
+if [ -f "$QA_ENV_FILE" ]; then
+  ENV_FILE_FLAG="--env-file $QA_ENV_FILE"
+  log "   Cargando secrets desde $QA_ENV_FILE"
+else
+  log "   ⚠️ $QA_ENV_FILE no existe — Didit y otras integraciones quedarán sin credenciales"
+fi
+# shellcheck disable=SC2086  # Queremos word-splitting de $ENV_FILE_FLAG
 docker run -d \
   --name fatrans-qa-backend \
   --network fatrans-network \
@@ -146,6 +159,7 @@ docker run -d \
   --health-timeout 10s \
   --health-retries 3 \
   --health-start-period 60s \
+  $ENV_FILE_FLAG \
   -e SPRING_PROFILES_ACTIVE=dev \
   -e DB_URL=jdbc:postgresql://fatrans-postgres:5432/fondo_qa \
   -e DB_USER=app \


### PR DESCRIPTION
## 5ª promoción a main

Lleva a PROD tres PRs ya mergeados a develop:

### PR #293 — Secrets Didit en `.env.{prod,qa}`
Las credenciales DIDIT_* ahora viven en archivos `.env` con chmod 600 en el VPS, cargados via `env_file:` (PROD) y `--env-file` (QA). Antes vivían hardcoded en el `docker run` original y se perdían en cada recreate. **Ya aplicado in-place al VPS** — el deploy va a hacer diff y skip.

### PR #294 — Rediseño verificación biométrica
- De 6 steps confusos a 4 lineales (`pendiente → en_progreso → aprobada/rechazada`)
- Un solo botón "Iniciar verificación facial" (registra consent + crea sesión Didit + abre pestaña en una sola acción)
- Auto-polling cada 5s cuando está en progreso — el resultado aparece solo cuando llega el webhook
- `useEffect` sincroniza step con TODOS los estados del backend (fixea bug donde se quedaba en "consent" si el backend ya estaba en EN_PROGRESO)
- Mensaje terminal "aprobada" indica next step explícito ("subí el comprobante de domicilio abajo")

### PR #295 — SMTP real Zoho para emails de registro
- `spring-boot-starter-mail` agregado al pom
- `EmailNotificationServiceImpl` dual-mode: mock si `MAIL_ENABLED=false`, real con `JavaMailSender` si está habilitado
- Templates HTML inline con escape de XSS para los 3 emails bloqueantes:
  - "Recibimos tu solicitud" (al recibir POST /api/auth/registro)
  - "Tu cuenta está activa" + credenciales (al aprobar admin)
  - "Tu solicitud no fue aprobada" + motivo (al rechazar admin)
- Fallos SMTP se loguean pero NO interrumpen el flujo de aprobación

## Estado pre-merge

**Ya está listo en el VPS** (no requiere deploy nuevo para activarse, solo el código nuevo):
- ✅ `.env.prod` con `MAIL_*` (Zoho SMTP + app password de `no-reply@fatrans.com.ve`)
- ✅ `.env.qa` con `MAIL_*` (mismo SMTP, `MAIL_APP_BASE_URL` diferente)
- ✅ Test SMTP directo desde el VPS → Zoho recibe (confirmado vía Python)

## Qué hará el deploy automático al mergear

1. Build backend con nueva dependencia `spring-boot-starter-mail`
2. Recrear container `fatrans-backend` con las env vars `MAIL_*` cargadas
3. Spring autoconfigura `JavaMailSender` con esas credenciales
4. `EmailNotificationServiceImpl` arranca en modo **REAL** (no mock)
5. Próximo POST a `/api/auth/registro` → socio recibe email de verdad

## ⚠️ Al mergear

**Usá "Create a merge commit"**, NO Squash. Tendrás que aprobar el environment gate `production`.

## Test plan post-deploy

- [ ] Action `Deploy → Producción` termina success
- [ ] Container `fatrans-backend` queda healthy
- [ ] Logs del backend post-arranque NO muestran warning "fatrans.mail.enabled=true pero JavaMailSender no fue creado"
- [ ] Smoke 1: alguien hace POST a `/api/auth/registro` en PROD → recibe email "Recibimos tu solicitud"
- [ ] Smoke 2: admin aprueba la solicitud → socio recibe email con credenciales y botón "Iniciar sesión"
- [ ] Smoke 3: hacer biometría con un socio aprobado en PROD → flujo UI nuevo (un botón + auto-polling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
