### PR TITLE
feat(kyc): sincronizar biometría pulleando a Didit (suple webhook)

### DIFF
--- a/backend/src/main/java/com/tufondo/kyc/api/controller/BiometricController.java
+++ b/backend/src/main/java/com/tufondo/kyc/api/controller/BiometricController.java
@@ -7,6 +7,8 @@ import com.tufondo.kyc.application.usecase.IniciarVerificacionBiometricaUseCase;
 import com.tufondo.kyc.application.usecase.ProcesarWebhookBiometricoUseCase;
 import com.tufondo.kyc.application.usecase.RegistrarConsentimientoBiometricoUseCase;
 import com.tufondo.kyc.application.usecase.RevocarConsentimientoBiometricoUseCase;
+import com.tufondo.kyc.application.usecase.SincronizarVerificacionBiometricaUseCase;
+import com.tufondo.kyc.domain.model.enums.EstadoBiometria;
 import com.tufondo.kyc.domain.model.port.BiometricVerificatorPort;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -46,6 +48,7 @@ public class BiometricController {
     private final IniciarVerificacionBiometricaUseCase iniciarBiometriaUseCase;
     private final ProcesarWebhookBiometricoUseCase procesarWebhookUseCase;
     private final RevocarConsentimientoBiometricoUseCase revocarConsentimientoUseCase;
+    private final SincronizarVerificacionBiometricaUseCase sincronizarBiometriaUseCase;
     private final BiometricVerificatorPort biometricPort;
 
     @PostMapping("/consentimiento")
@@ -111,6 +114,23 @@ public class BiometricController {
         procesarWebhookUseCase.ejecutar(rawBody, sig, timestamp);
         return ResponseEntity.ok().build();
     }
+
+    /**
+     * Fuerza sincronización del estado biométrico consultando al proveedor.
+     * Usado por el frontend (polling cada 5s) para suplir al webhook cuando
+     * éste no está configurado o no llegó a tiempo. Idempotente.
+     */
+    @PostMapping("/refresh")
+    @PreAuthorize("hasRole('SOCIO')")
+    @Operation(summary = "Sincronizar estado biométrico desde el proveedor (pull)")
+    public ResponseEntity<RefreshResponse> refresh(Authentication auth) {
+        UUID socioId = extraerSocioId(auth);
+        EstadoBiometria estado = sincronizarBiometriaUseCase.sincronizar(socioId);
+        return ResponseEntity.ok(new RefreshResponse(estado.name()));
+    }
+
+    /** Response del endpoint /refresh — solo el estado actual, sin metadata. */
+    public record RefreshResponse(String estadoBiometria) {}
 
     @PostMapping("/revocar")
     @PreAuthorize("hasRole('SOCIO')")

--- a/backend/src/main/java/com/tufondo/kyc/application/usecase/SincronizarVerificacionBiometricaUseCase.java
+++ b/backend/src/main/java/com/tufondo/kyc/application/usecase/SincronizarVerificacionBiometricaUseCase.java
@@ -1,0 +1,122 @@
+package com.tufondo.kyc.application.usecase;
+
+import com.tufondo.kyc.domain.model.VerificacionBiometrica;
+import com.tufondo.kyc.domain.model.VerificacionKYC;
+import com.tufondo.kyc.domain.model.enums.EstadoBiometria;
+import com.tufondo.kyc.domain.model.enums.EstadoIntentoBiometrico;
+import com.tufondo.kyc.domain.model.port.BiometricVerificatorPort;
+import com.tufondo.kyc.domain.repository.VerificacionBiometricaRepository;
+import com.tufondo.kyc.domain.repository.VerificacionKYCRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Sincroniza el estado biométrico de un socio consultando directamente al
+ * proveedor (Didit) en lugar de esperar al webhook. Necesario cuando:
+ *  - El webhook no está configurado en el dashboard del proveedor.
+ *  - El webhook llegó pero falló (firma inválida, network blip, etc.).
+ *  - Queremos UX más responsiva — el frontend hace polling cada 5s y
+ *    fuerza sync sin esperar al webhook asíncrono.
+ *
+ * Es idempotente: si el intento ya está en estado final (APROBADA/RECHAZADA)
+ * no llama al proveedor y devuelve el estado actual. Si la sesión sigue en
+ * pending del lado del proveedor, no muta nada.
+ *
+ * Diseñado para ser invocado **muchas veces** (polling): la única llamada
+ * externa es la consulta a Didit, idempotente por su API, no genera efectos
+ * secundarios cuando no hay novedad.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SincronizarVerificacionBiometricaUseCase {
+
+    private final BiometricVerificatorPort biometricPort;
+    private final VerificacionBiometricaRepository biometricaRepository;
+    private final VerificacionKYCRepository kycRepository;
+
+    /**
+     * @param socioId el socio cuyo último intento biométrico queremos sincronizar
+     * @return el estado actual de la biometría del socio (puede no haber cambiado)
+     */
+    @Transactional
+    public EstadoBiometria sincronizar(UUID socioId) {
+        // 1. Buscar el último intento biométrico del socio. Si no hay, no
+        //    tiene sentido sincronizar — devolvemos NO_INICIADA.
+        Optional<VerificacionBiometrica> ultimoIntento =
+                biometricaRepository.findLastBySocioId(socioId);
+        if (ultimoIntento.isEmpty()) {
+            return EstadoBiometria.NO_INICIADA;
+        }
+        VerificacionBiometrica intento = ultimoIntento.get();
+
+        // 2. Idempotencia local: si ya está en estado final, no llamamos al
+        //    proveedor — el resultado no puede cambiar.
+        EstadoIntentoBiometrico estadoActual = intento.getEstado();
+        if (estadoActual == EstadoIntentoBiometrico.APROBADA) {
+            return EstadoBiometria.APROBADA;
+        }
+        if (estadoActual == EstadoIntentoBiometrico.RECHAZADA) {
+            return EstadoBiometria.RECHAZADA;
+        }
+        if (estadoActual == EstadoIntentoBiometrico.EXPIRADA) {
+            return EstadoBiometria.EXPIRADA;
+        }
+
+        // 3. Estado intermedio (PENDIENTE/EN_PROGRESO): pull al proveedor.
+        BiometricVerificatorPort.BiometricWebhookResult result;
+        try {
+            result = biometricPort.consultarDecision(intento.getProveedorSessionId());
+        } catch (Exception e) {
+            log.warn("Sync biométrico falló al consultar proveedor (socioId={} session={}): {}",
+                    socioId, intento.getProveedorSessionId(), e.getMessage());
+            // Si el proveedor falla, devolvemos el estado actual del cache —
+            // el siguiente polling reintentará. No queremos romper el frontend.
+            return EstadoBiometria.EN_PROGRESO;
+        }
+
+        // 4. Aplicar transición — misma lógica que ProcesarWebhookBiometricoUseCase.
+        VerificacionBiometrica actualizado;
+        EstadoBiometria nuevoCache;
+        switch (result.outcome()) {
+            case APROBADO -> {
+                actualizado = intento.aprobar(
+                        result.livenessScore(), result.faceMatchScore(), result.documentOcrScore());
+                nuevoCache = EstadoBiometria.APROBADA;
+            }
+            case RECHAZADO -> {
+                actualizado = intento.rechazar(result.motivoFallo(), result.tipoAtaqueDetectado());
+                nuevoCache = EstadoBiometria.RECHAZADA;
+            }
+            case EXPIRADO -> {
+                actualizado = intento.expirar();
+                nuevoCache = EstadoBiometria.EXPIRADA;
+            }
+            case CANCELADO -> {
+                actualizado = intento.cancelar();
+                nuevoCache = EstadoBiometria.NO_INICIADA;
+            }
+            default -> {
+                // EN_PROGRESO en el proveedor — todavía no terminó. No mutamos.
+                return EstadoBiometria.EN_PROGRESO;
+            }
+        }
+        biometricaRepository.save(actualizado);
+
+        // 5. Actualizar cache en VerificacionKYC.
+        VerificacionKYC kyc = kycRepository.findById(intento.getVerificacionKycId()).orElse(null);
+        if (kyc != null && kyc.getEstadoBiometria() != nuevoCache) {
+            kyc.setEstadoBiometria(nuevoCache);
+            kycRepository.save(kyc);
+        }
+
+        log.info("Sync biométrico aplicado. socioId={} session={} outcome={}",
+                socioId, intento.getProveedorSessionId(), result.outcome());
+        return nuevoCache;
+    }
+}

--- a/backend/src/main/java/com/tufondo/kyc/domain/model/port/BiometricVerificatorPort.java
+++ b/backend/src/main/java/com/tufondo/kyc/domain/model/port/BiometricVerificatorPort.java
@@ -36,6 +36,23 @@ public interface BiometricVerificatorPort {
     BiometricWebhookResult procesarWebhook(byte[] rawBody, String signatureHeader, String timestampHeader);
 
     /**
+     * Consulta el estado actual de una sesión directamente al proveedor (pull).
+     *
+     * Se usa para suplir el webhook cuando éste no está configurado o no llega
+     * a tiempo: el frontend hace polling y el backend pregunta a Didit en cada
+     * tick. Idempotente: si la sesión sigue en pending del lado del proveedor,
+     * devuelve `outcome=EN_PROGRESO` sin efectos secundarios.
+     *
+     * El resultado tiene el mismo shape que el del webhook
+     * ({@link BiometricWebhookResult}) para que el use case pueda aplicarlo
+     * con la misma lógica de transición de estado.
+     *
+     * @param proveedorSessionId session id devuelto por {@link #iniciarSesion}
+     * @return resultado normalizado (puede ser EN_PROGRESO si aún no terminó)
+     */
+    BiometricWebhookResult consultarDecision(String proveedorSessionId);
+
+    /**
      * Solicita al proveedor que borre todos los datos asociados al session id.
      * Se invoca cuando el socio revoca su consentimiento biométrico (LOPDP Art. 7).
      */

--- a/backend/src/main/java/com/tufondo/kyc/domain/repository/VerificacionBiometricaRepository.java
+++ b/backend/src/main/java/com/tufondo/kyc/domain/repository/VerificacionBiometricaRepository.java
@@ -20,6 +20,13 @@ public interface VerificacionBiometricaRepository {
     List<VerificacionBiometrica> findBySocioId(UUID socioId);
 
     /**
+     * Devuelve el último intento biométrico del socio (mayor fecha_inicio).
+     * Usado por el use case de sincronización vía pull al proveedor: el frontend
+     * hace polling y necesitamos saber qué sesión consultarle a Didit.
+     */
+    Optional<VerificacionBiometrica> findLastBySocioId(UUID socioId);
+
+    /**
      * Borra todos los intentos biométricos asociados a un socio. Lo usa el flujo de
      * revocación de consentimiento (LOPDP Art. 7 — derecho al olvido).
      */

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/biometric/DiditKycAdapter.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/biometric/DiditKycAdapter.java
@@ -166,6 +166,69 @@ public class DiditKycAdapter implements BiometricVerificatorPort {
     }
 
     /**
+     * Consulta el estado actual de una sesión vía GET a {@code /v2/session/{id}/decision/}.
+     *
+     * Usado por {@link com.tufondo.kyc.application.usecase.SincronizarVerificacionBiometricaUseCase}
+     * cuando el frontend hace polling — suple al webhook cuando éste no está
+     * configurado o no llegó a tiempo. Idempotente.
+     *
+     * El payload de /decision/ tiene shape DIFERENTE al de webhook:
+     *  - Webhook: `{status, decision: {liveness_checks: [{score}], face_matches: [{score}]}}`
+     *  - Decision: `{status, liveness: {status, score}, face_match: {status, score}}`
+     * y los scores van 0-100 (no 0-1). Por eso normalizamos.
+     */
+    @Override
+    public BiometricWebhookResult consultarDecision(String proveedorSessionId) {
+        ensureEnabled();
+        if (proveedorSessionId == null || proveedorSessionId.isBlank()) {
+            throw new KYCException("session_id requerido para consultar decisión");
+        }
+        HttpHeaders headers = baseHeaders();
+        try {
+            ResponseEntity<JsonNode> response = restTemplate.exchange(
+                    props.getBaseUrl() + "/session/" + proveedorSessionId + "/decision/",
+                    HttpMethod.GET,
+                    new HttpEntity<>(headers),
+                    JsonNode.class
+            );
+            JsonNode payload = response.getBody();
+            if (payload == null) {
+                throw new KYCException("Didit devolvió payload vacío al consultar decisión");
+            }
+            String status = textOrNull(payload, "status");
+            BiometricOutcome outcome = mapStatus(status);
+
+            // Scores del /decision/ vienen 0-100 → readScore normaliza a 0-1.
+            BigDecimal livenessScore = readScore(payload, "liveness", "score");
+            BigDecimal faceMatchScore = readScore(payload, "face_match", "score");
+            // documentOcrScore se omite — el endpoint /decision/ no expone un
+            // score plano para el documento (vienen sub-scores) y el use case
+            // no lo necesita para decidir aprobar/rechazar.
+            BigDecimal documentOcrScore = null;
+
+            String motivoFallo = null;
+            if (outcome == BiometricOutcome.RECHAZADO) {
+                // Si vino rechazado, intentar capturar la razón. Didit la pone en
+                // un campo "warnings" o "reasons" según el tipo de check.
+                motivoFallo = textOrNull(payload, "decline_reason");
+            }
+
+            return new BiometricWebhookResult(
+                    proveedorSessionId, outcome,
+                    livenessScore, faceMatchScore, documentOcrScore,
+                    motivoFallo, null
+            );
+        } catch (org.springframework.web.client.HttpStatusCodeException e) {
+            log.error("Didit /decision/ error: HTTP {} body={}",
+                    e.getStatusCode().value(), e.getResponseBodyAsString());
+            throw new KYCException("Error consultando decisión biométrica con el proveedor");
+        } catch (RestClientException e) {
+            log.error("Didit /decision/ error (network/transport): {}", e.getMessage());
+            throw new KYCException("Error consultando decisión biométrica con el proveedor");
+        }
+    }
+
+    /**
      * Procesa un webhook de Didit. Soporta DOS esquemas de firma:
      *
      * <ol>

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/adapter/VerificacionBiometricaRepositoryImpl.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/adapter/VerificacionBiometricaRepositoryImpl.java
@@ -50,6 +50,12 @@ public class VerificacionBiometricaRepositoryImpl implements VerificacionBiometr
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public Optional<VerificacionBiometrica> findLastBySocioId(UUID socioId) {
+        return jpaRepository.findFirstBySocioIdOrderByFechaInicioDesc(socioId).map(this::toDomain);
+    }
+
+    @Override
     @Transactional
     public void deleteAllBySocioId(UUID socioId) {
         jpaRepository.deleteAllBySocioId(socioId);

--- a/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/jpa/VerificacionBiometricaJpaRepository.java
+++ b/backend/src/main/java/com/tufondo/kyc/infrastructure/persistence/jpa/VerificacionBiometricaJpaRepository.java
@@ -17,5 +17,7 @@ public interface VerificacionBiometricaJpaRepository extends JpaRepository<Verif
 
     List<VerificacionBiometricaEntity> findBySocioId(UUID socioId);
 
+    Optional<VerificacionBiometricaEntity> findFirstBySocioIdOrderByFechaInicioDesc(UUID socioId);
+
     void deleteAllBySocioId(UUID socioId);
 }

--- a/frontend-web/src/app/api/kyc/biometric/refresh/route.ts
+++ b/frontend-web/src/app/api/kyc/biometric/refresh/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+/**
+ * BFF: pide al backend que sincronice el estado biométrico con el proveedor
+ * (Didit) y devuelve el estado actual. Usado por el componente
+ * `BiometricCapture` en polling cada 5s mientras la verificación está en
+ * progreso — suple al webhook cuando éste no está configurado o tarda.
+ *
+ * Idempotente: si el intento ya está en estado final, el backend devuelve sin
+ * llamar al proveedor.
+ */
+export async function POST(request: NextRequest) {
+  const token = request.cookies.get('access_token')?.value;
+  if (!token) {
+    return NextResponse.json({ message: 'No autenticado' }, { status: 401 });
+  }
+
+  const backendResponse = await fetch(`${BACKEND_URL}/api/v1/kyc/biometric/refresh`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token.replace(/^"|"$/g, '')}`,
+    },
+  });
+
+  // No traducimos 5xx a 502 acá: el componente está en polling, queremos
+  // que vea el error real y decida si sigue intentando o muestra fallback.
+  if (!backendResponse.ok) {
+    const errorData = await backendResponse.json().catch(() => ({}));
+    return NextResponse.json(
+      { message: errorData.message || 'No pudimos sincronizar la verificación' },
+      { status: backendResponse.status },
+    );
+  }
+
+  const data = await backendResponse.json();
+  return NextResponse.json(data, { status: 200 });
+}

--- a/frontend-web/src/components/features/kyc/biometric-capture.tsx
+++ b/frontend-web/src/components/features/kyc/biometric-capture.tsx
@@ -108,14 +108,38 @@ export function BiometricCapture({
     setStep(deriveStepFromBackend(estadoBackend));
   }, [estadoBackend]);
 
-  // Polling automático mientras estamos esperando el webhook de Didit.
-  // Cada 5s pide al padre que refetch — si el webhook ya llegó, el
-  // useEffect anterior nos transiciona a `aprobada` o `rechazada`.
-  // Se detiene cuando salimos de `en_progreso` y al desmontar.
+  // Polling activo mientras estamos esperando el resultado de Didit.
+  // En lugar de solo refetch /api/kyc/estado (que lee BD pasiva), llamamos
+  // a /api/kyc/biometric/refresh que FUERZA al backend a consultar Didit
+  // por pull. Eso suple al webhook cuando no está configurado o tarda —
+  // sin esto, los socios quedaban atascados en EN_PROGRESO eternamente
+  // y había que hacer UPDATE manual a la BD (caso real reportado en PROD
+  // con carlos, alexander, gabriel).
+  //
+  // Cada 5s: POST /refresh → backend pulla Didit → si Approved/Rejected,
+  // actualiza BD localmente + devuelve el nuevo estado → el padre hace
+  // refetch para que el useEffect de arriba transicione el step.
   useEffect(() => {
-    if (step === 'en_progreso' && onCompleted) {
-      pollingRef.current = setInterval(() => onCompleted(), 5000);
-    }
+    if (step !== 'en_progreso' || !onCompleted) return;
+    const tick = async () => {
+      try {
+        await fetch('/api/kyc/biometric/refresh', {
+          method: 'POST',
+          credentials: 'include',
+        });
+      } catch {
+        // Silencioso: el polling es best-effort. Si el endpoint falla,
+        // el próximo tick lo reintenta.
+      }
+      // Independientemente del resultado del refresh, pedimos al padre que
+      // refetch /api/kyc/estado para reflejar el cache local actualizado.
+      onCompleted();
+    };
+    // Primer tick inmediato — útil cuando el socio vuelve a la pantalla
+    // después de completar Didit en otra pestaña. Sin esto, esperaría
+    // 5s para ver el cambio.
+    tick();
+    pollingRef.current = setInterval(tick, 5000);
     return () => {
       if (pollingRef.current) {
         clearInterval(pollingRef.current);


### PR DESCRIPTION
Backend pulla a Didit cuando frontend pregunta — suple el webhook. El polling cada 5s del componente BiometricCapture ahora llama a /api/kyc/biometric/refresh que fuerza sync via GET /v2/session/{id}/decision/. Idempotente: si el intento ya está en estado final no consulta a Didit. Cuando se merge + deploye, los socios nuevos no van a necesitar UPDATE manual a BD para desbloquear el comprobante.