### PR TITLE
fix(auth+kyc): no-cache en endpoints con estado volátil

### DIFF
--- a/frontend-web/src/app/api/auth/me/route.ts
+++ b/frontend-web/src/app/api/auth/me/route.ts
@@ -31,7 +31,20 @@ export async function GET(request: NextRequest) {
 
     const userData = await backendResponse.json();
 
-    return NextResponse.json(userData, { status: 200 });
+    // No-cache headers: el cliente (incluido el modal de cambio de password)
+    // necesita poder re-sincronizar con el backend inmediatamente después de
+    // mutaciones de usuario (cambio de password, actualización de perfil, etc).
+    // Sin esto, el navegador puede servir una versión vieja del usuario
+    // (caso real Gabriel QA 19-may-2026: vio `debeCambiarPassword=true`
+    // cacheado después de haberlo cambiado correctamente).
+    return NextResponse.json(userData, {
+      status: 200,
+      headers: {
+        'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+        Pragma: 'no-cache',
+        Expires: '0',
+      },
+    });
 
   } catch (error) {
     console.error('Get user error:', error);

--- a/frontend-web/src/components/shared/change-password-modal.test.tsx
+++ b/frontend-web/src/components/shared/change-password-modal.test.tsx
@@ -119,8 +119,11 @@ describe('ChangePasswordModal', () => {
         expect.objectContaining({ method: 'POST' })
       );
       expect(global.fetch).toHaveBeenCalledWith(
-        '/api/auth/me',
-        expect.objectContaining({ credentials: 'include' })
+        expect.stringMatching(/^\/api\/auth\/me\?t=/),
+        expect.objectContaining({
+          credentials: 'include',
+          cache: 'no-store',
+        })
       );
     });
 

--- a/frontend-web/src/components/shared/change-password-modal.tsx
+++ b/frontend-web/src/components/shared/change-password-modal.tsx
@@ -117,7 +117,18 @@ export function ChangePasswordModal({ open }: ChangePasswordModalProps) {
       // porque `/me` retornaba `true` desde DB. Pullear /me obliga a usar la
       // verdad del backend — si quedó `true` ahí, el modal NO se cierra y
       // mostramos el error real al socio en vez de fingir que pasó.
-      const meRes = await fetch('/api/auth/me', { credentials: 'include' });
+      //
+      // Caso real reportado en QA (Gabriel, 19-may-2026): la BD persistió
+      // `debe_cambiar_password=false`, pero `/me` devolvía la respuesta
+      // cacheada del primer hidrate de ProtectedRoute (donde aún era `true`).
+      // El socio veía "el sistema aceptó tu nueva contraseña pero no la guardó"
+      // pese a que sí se había guardado. Forzamos `cache: 'no-store'` +
+      // cache-buster para garantizar que vamos siempre al backend.
+      const meRes = await fetch(`/api/auth/me?t=${Date.now()}`, {
+        credentials: 'include',
+        cache: 'no-store',
+        headers: { 'Cache-Control': 'no-cache', Pragma: 'no-cache' },
+      });
       if (meRes.ok) {
         const fresh = await meRes.json();
         if (fresh.debeCambiarPassword === true) {


### PR DESCRIPTION
## Resumen

Bug reportado por el admin en QA (Gabriel, 19-may-2026):
- Cambió su contraseña obligatoria → backend devolvió 200 → BD persistió `debe_cambiar_password=false`
- Pero el modal mostró \"el sistema aceptó tu nueva contraseña pero no la guardó. Intentá de nuevo o contactá a soporte\"
- Lo verifiqué directo en QA postgres: la BD efectivamente tiene `false`. El backend hizo bien su parte.

## Causa raíz

Mi refetch a `/api/auth/me` (introducido en #300 como salvaguarda) leía la respuesta cacheada del **primer** `/me` que hace `ProtectedRoute` al hidratar el store post-login (cuando `debeCambiarPassword` todavía era `true`). El navegador entregó la respuesta cacheada y mi guard de seguridad disparó el error pese a que el backend sí había guardado el cambio.

## Fix

- Frontend: el modal hace `fetch('/api/auth/me?t=${Date.now()}', { cache: 'no-store', headers: { 'Cache-Control': 'no-cache', Pragma: 'no-cache' } })`.
- BFF (`/api/auth/me/route.ts`): la respuesta lleva `Cache-Control: no-store, no-cache, must-revalidate`, `Pragma: no-cache`, `Expires: 0` — defense in depth para que ningún intermediario o el navegador la cachee jamás.
- Tests actualizados (7/7 pasan).

## Test plan

- [ ] Auto-deploy a QA
- [ ] Crear nuevo socio en QA, aprobar, login con temporal
- [ ] Cambiar password → toast verde + modal cierra (sin error fantasma)
- [ ] Refrescar página → modal NO reaparece

🤖 Generated with [Claude Code](https://claude.com/claude-code)