### PR TITLE
feat(kyc): email al socio cuando se aprueba/rechaza/requiere info

### DIFF
--- a/backend/src/main/java/com/tufondo/notificaciones/application/service/NotificacionPublisher.java
+++ b/backend/src/main/java/com/tufondo/notificaciones/application/service/NotificacionPublisher.java
@@ -1,10 +1,12 @@
 package com.tufondo.notificaciones.application.service;
 
+import com.tufondo.auth.domain.model.Usuario;
 import com.tufondo.auth.domain.repository.UsuarioRepository;
 import com.tufondo.notificaciones.domain.model.Notificacion;
 import com.tufondo.notificaciones.domain.model.enums.PrioridadNotificacion;
 import com.tufondo.notificaciones.domain.model.enums.TipoNotificacion;
 import com.tufondo.notificaciones.domain.repository.NotificacionRepository;
+import com.tufondo.socios.infrastructure.notification.EmailNotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -38,6 +40,13 @@ public class NotificacionPublisher {
 
     private final NotificacionRepository notificacionRepository;
     private final UsuarioRepository usuarioRepository;
+    /**
+     * Servicio de envío de email. Inyectado para que las notificaciones de
+     * KYC (y otras de alto valor para el socio) también lleguen por correo
+     * además de la notificación in-app. El servicio es best-effort: si SMTP
+     * falla, el flujo del caller NO se ve afectado.
+     */
+    private final EmailNotificationService emailService;
 
     // === Notificaciones a SOCIO (resuelven socioId → usuarioId) ===
 
@@ -49,6 +58,12 @@ public class NotificacionPublisher {
                 .linkAccion("/dashboard/kyc")
                 .prioridad(PrioridadNotificacion.NORMAL)
                 .build());
+        // Email además de notificación in-app: el KYC aprobado es un evento de
+        // alto valor que el socio espera por mail (caso real reportado por el
+        // admin de QA, 19-may-2026 — el socio no se enteraba de la aprobación
+        // porque solo se guardaba la notificación interna).
+        enviarEmailASocio(socioId, (email, nombre) -> emailService.enviarKycAprobado(email, nombre),
+                "KYC_APROBADO");
     }
 
     public void notificarSocioKycRechazado(UUID socioId, String motivo) {
@@ -62,6 +77,8 @@ public class NotificacionPublisher {
                 .linkAccion("/dashboard/kyc")
                 .prioridad(PrioridadNotificacion.URGENTE)
                 .build());
+        enviarEmailASocio(socioId, (email, nombre) -> emailService.enviarKycRechazado(email, nombre, motivo),
+                "KYC_RECHAZADO");
     }
 
     public void notificarSocioKycRequiereInfo(UUID socioId, String detalle) {
@@ -75,6 +92,8 @@ public class NotificacionPublisher {
                 .linkAccion("/dashboard/kyc")
                 .prioridad(PrioridadNotificacion.NORMAL)
                 .build());
+        enviarEmailASocio(socioId, (email, nombre) -> emailService.enviarKycRequiereInfo(email, nombre, detalle),
+                "KYC_REQUIERE_INFO");
     }
 
     public void notificarSocioCreditoAprobado(UUID socioId, BigDecimal monto, String moneda, String numeroSolicitud) {
@@ -183,5 +202,57 @@ public class NotificacionPublisher {
 
     private static String safe(String s) {
         return s != null ? s : "";
+    }
+
+    // === Email helpers ===
+
+    /**
+     * Functional interface usada por {@link #enviarEmailASocio} para parametrizar
+     * el método específico del EmailNotificationService que queremos invocar
+     * (aprobado / rechazado / requiere info) sin duplicar la resolución
+     * socioId → (email, nombreCompleto).
+     */
+    @FunctionalInterface
+    private interface EmailSender {
+        void send(String email, String nombreCompleto);
+    }
+
+    /**
+     * Resuelve socioId → (email del usuario, nombreCompleto) y delega al
+     * {@code emailSender}. Best-effort: cualquier excepción se loguea y se
+     * traga — nunca debe romper el flujo del use case que llamó al publisher.
+     *
+     * <p>Notar que esto NO está en una @Transactional propia: solo lee del
+     * UsuarioRepository (idempotente) y llama al SMTP (efecto externo). El
+     * mail no es transaccional con la BD — si el COMMIT del KYC falla, el
+     * mail YA pudo haberse mandado (al revés también puede pasar). Para el
+     * caso de KYC eso es aceptable: el peor escenario es un email enviado
+     * sin cambio persistente, que el socio interpreta como un error puntual
+     * y vuelve a verificar en la app.</p>
+     */
+    private void enviarEmailASocio(UUID socioId, EmailSender emailSender, String tipoTag) {
+        try {
+            if (socioId == null) {
+                log.debug("Skip email {}: socioId null", tipoTag);
+                return;
+            }
+            Optional<Usuario> usuario = usuarioRepository.buscarPorSocioId(socioId);
+            if (usuario.isEmpty()) {
+                log.warn("Skip email {}: no hay usuario para socioId={}", tipoTag, socioId);
+                return;
+            }
+            String email = usuario.get().correoElectronico();
+            String nombre = usuario.get().nombreCompleto();
+            if (email == null || email.isBlank()) {
+                log.warn("Skip email {}: usuario {} sin correo", tipoTag, usuario.get().id());
+                return;
+            }
+            emailSender.send(email, nombre);
+        } catch (Throwable t) {
+            // Defensivo: cualquier excepción del SMTP o resolución debe quedar
+            // contenida acá — el flujo del use case que disparó la notificación
+            // sigue su curso.
+            log.error("Falló envío de email {} a socioId={}: {}", tipoTag, socioId, t.getMessage(), t);
+        }
     }
 }

--- a/backend/src/main/java/com/tufondo/socios/infrastructure/notification/EmailNotificationService.java
+++ b/backend/src/main/java/com/tufondo/socios/infrastructure/notification/EmailNotificationService.java
@@ -20,4 +20,27 @@ public interface EmailNotificationService {
      * Envía confirmación de solicitud recibida.
      */
     void enviarNotificacionSolicitudRecibida(String email);
+
+    /**
+     * Notifica al socio que su verificación KYC fue aprobada.
+     * Best-effort: si falla SMTP no propaga error al caller (mismo contract
+     * que los demás métodos de este interface).
+     */
+    void enviarKycAprobado(String email, String nombreCompleto);
+
+    /**
+     * Notifica al socio que su verificación KYC fue rechazada.
+     *
+     * @param motivo motivo del rechazo (lo escribió el analista). Puede ser null/blank;
+     *               en ese caso se muestra un texto genérico.
+     */
+    void enviarKycRechazado(String email, String nombreCompleto, String motivo);
+
+    /**
+     * Notifica al socio que el analista necesita más información para
+     * completar la verificación.
+     *
+     * @param detalle qué información se necesita (lo escribió el analista). Puede ser null/blank.
+     */
+    void enviarKycRequiereInfo(String email, String nombreCompleto, String detalle);
 }

--- a/backend/src/main/java/com/tufondo/socios/infrastructure/notification/EmailNotificationServiceImpl.java
+++ b/backend/src/main/java/com/tufondo/socios/infrastructure/notification/EmailNotificationServiceImpl.java
@@ -145,6 +145,110 @@ public class EmailNotificationServiceImpl implements EmailNotificationService {
         }
     }
 
+    @Override
+    public void enviarKycAprobado(String email, String nombreCompleto) {
+        if (!isReal()) {
+            log.info("Email 'KYC aprobado' enviado (MOCK) a {}", email);
+            return;
+        }
+        String nombre = nombreCompleto == null || nombreCompleto.isBlank() ? "Hola" : "Hola " + escapeHtml(nombreCompleto);
+        String html = """
+                <p>%s,</p>
+                <p>¡Buenas noticias! Tu <strong>verificación de identidad</strong> fue
+                aprobada por nuestro equipo. Ya podés usar todos los servicios del
+                Fondo de Ahorro Fatrans:</p>
+                <ul>
+                  <li>Depósitos y retiros sin límites adicionales</li>
+                  <li>Solicitud de créditos</li>
+                  <li>Gestión de beneficiarios</li>
+                </ul>
+                <p style="margin-top: 20px;">
+                  <a href="%s/dashboard" style="background:#16A34A;color:#fff;padding:10px 20px;
+                  text-decoration:none;border-radius:6px;display:inline-block;">
+                    Ir a mi panel
+                  </a>
+                </p>
+                <hr style="border:none;border-top:1px solid #ddd;margin:24px 0;"/>
+                <p style="font-size:11px;color:#666;">
+                  Asociación de Ahorro y Crédito Fatrans (RIF J-50516835-5).
+                </p>
+                """.formatted(nombre, appBaseUrl);
+
+        boolean ok = sendHtml(email, "Tu identidad fue verificada — Fatrans", html);
+        if (ok) {
+            log.info("Email 'KYC aprobado' enviado vía SMTP a {}", email);
+        }
+    }
+
+    @Override
+    public void enviarKycRechazado(String email, String nombreCompleto, String motivo) {
+        if (!isReal()) {
+            log.info("Email 'KYC rechazado' enviado (MOCK) a {}", email);
+            return;
+        }
+        String nombre = nombreCompleto == null || nombreCompleto.isBlank() ? "Hola" : "Hola " + escapeHtml(nombreCompleto);
+        String textoMotivo = motivo == null || motivo.isBlank()
+                ? "Revisá los detalles desde tu panel y volvé a enviar."
+                : "Motivo: " + escapeHtml(motivo);
+        String html = """
+                <p>%s,</p>
+                <p>Tu <strong>verificación de identidad</strong> no pasó la revisión.</p>
+                <p>%s</p>
+                <p>No te preocupes — podés volver a intentarlo. Asegurate de subir documentos
+                legibles, completos y vigentes.</p>
+                <p style="margin-top: 20px;">
+                  <a href="%s/dashboard/kyc" style="background:#DC2626;color:#fff;padding:10px 20px;
+                  text-decoration:none;border-radius:6px;display:inline-block;">
+                    Reintentar verificación
+                  </a>
+                </p>
+                <hr style="border:none;border-top:1px solid #ddd;margin:24px 0;"/>
+                <p style="font-size:11px;color:#666;">
+                  Si tenés dudas, escribinos a
+                  <a href="mailto:soporte@fatrans.com.ve">soporte@fatrans.com.ve</a>.
+                  Asociación de Ahorro y Crédito Fatrans (RIF J-50516835-5).
+                </p>
+                """.formatted(nombre, textoMotivo, appBaseUrl);
+
+        boolean ok = sendHtml(email, "Tu verificación de identidad no pasó la revisión — Fatrans", html);
+        if (ok) {
+            log.info("Email 'KYC rechazado' enviado vía SMTP a {}", email);
+        }
+    }
+
+    @Override
+    public void enviarKycRequiereInfo(String email, String nombreCompleto, String detalle) {
+        if (!isReal()) {
+            log.info("Email 'KYC requiere info' enviado (MOCK) a {}", email);
+            return;
+        }
+        String nombre = nombreCompleto == null || nombreCompleto.isBlank() ? "Hola" : "Hola " + escapeHtml(nombreCompleto);
+        String textoDetalle = detalle == null || detalle.isBlank()
+                ? "El analista necesita información adicional para continuar."
+                : "El analista necesita lo siguiente: " + escapeHtml(detalle);
+        String html = """
+                <p>%s,</p>
+                <p>Estamos revisando tu <strong>verificación de identidad</strong> y necesitamos
+                un poco más de información.</p>
+                <p>%s</p>
+                <p style="margin-top: 20px;">
+                  <a href="%s/dashboard/kyc" style="background:#2563EB;color:#fff;padding:10px 20px;
+                  text-decoration:none;border-radius:6px;display:inline-block;">
+                    Completar verificación
+                  </a>
+                </p>
+                <hr style="border:none;border-top:1px solid #ddd;margin:24px 0;"/>
+                <p style="font-size:11px;color:#666;">
+                  Asociación de Ahorro y Crédito Fatrans (RIF J-50516835-5).
+                </p>
+                """.formatted(nombre, textoDetalle, appBaseUrl);
+
+        boolean ok = sendHtml(email, "Necesitamos más información para tu verificación — Fatrans", html);
+        if (ok) {
+            log.info("Email 'KYC requiere info' enviado vía SMTP a {}", email);
+        }
+    }
+
     // ────────────────────────────────────────────────────────
     //  Helpers privados
     // ────────────────────────────────────────────────────────

--- a/backend/src/test/java/com/tufondo/notificaciones/application/service/NotificacionPublisherTest.java
+++ b/backend/src/test/java/com/tufondo/notificaciones/application/service/NotificacionPublisherTest.java
@@ -7,6 +7,7 @@ import com.tufondo.notificaciones.domain.model.Notificacion;
 import com.tufondo.notificaciones.domain.model.enums.PrioridadNotificacion;
 import com.tufondo.notificaciones.domain.model.enums.TipoNotificacion;
 import com.tufondo.notificaciones.domain.repository.NotificacionRepository;
+import com.tufondo.socios.infrastructure.notification.EmailNotificationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,6 +42,9 @@ class NotificacionPublisherTest {
 
     @Mock
     private UsuarioRepository usuarioRepository;
+
+    @Mock
+    private EmailNotificationService emailService;
 
     @InjectMocks
     private NotificacionPublisher publisher;
@@ -171,6 +175,55 @@ class NotificacionPublisherTest {
         // Verificamos que SÍ intentó persistir (no fue skip)
         verify(notificacionRepository).guardar(any());
         // Sin assert sobre exception — el punto es que NO lanzó
+    }
+
+    @Test
+    @DisplayName("KYC aprobado: ADEMÁS de notificación in-app, dispara email al socio (mayo-2026)")
+    void kyc_aprobado_dispara_email() {
+        stubUsuarioParaSocio();
+
+        publisher.notificarSocioKycAprobado(socioId);
+
+        // Notificación in-app: 1 vez
+        verify(notificacionRepository).guardar(any());
+        // Email: 1 vez con email + nombre del usuario resuelto
+        verify(emailService).enviarKycAprobado("socio@test.com", "Test");
+    }
+
+    @Test
+    @DisplayName("KYC rechazado: dispara email pasando el motivo del analista")
+    void kyc_rechazado_dispara_email_con_motivo() {
+        stubUsuarioParaSocio();
+        String motivo = "Comprobante de domicilio vencido";
+
+        publisher.notificarSocioKycRechazado(socioId, motivo);
+
+        verify(emailService).enviarKycRechazado("socio@test.com", "Test", motivo);
+    }
+
+    @Test
+    @DisplayName("KYC requiere info: dispara email pasando el detalle del analista")
+    void kyc_requiere_info_dispara_email() {
+        stubUsuarioParaSocio();
+        String detalle = "Subí un selfie con la cédula visible";
+
+        publisher.notificarSocioKycRequiereInfo(socioId, detalle);
+
+        verify(emailService).enviarKycRequiereInfo("socio@test.com", "Test", detalle);
+    }
+
+    @Test
+    @DisplayName("RESILIENCIA: si el email falla, la notificación in-app YA quedó guardada y el flujo no aborta")
+    void email_fail_no_propaga() {
+        stubUsuarioParaSocio();
+        doThrow(new RuntimeException("SMTP caído"))
+                .when(emailService).enviarKycAprobado(any(), any());
+
+        // No debe lanzar
+        publisher.notificarSocioKycAprobado(socioId);
+
+        // La notificación in-app igual se guardó (el publicarASocio corre antes del email)
+        verify(notificacionRepository).guardar(any());
     }
 
     @Test


### PR DESCRIPTION
## Resumen

Bug reportado por el admin en QA (Gabriel, 19-may-2026):
- Aprobó el KYC desde el panel administrador
- El socio NUNCA recibió correo confirmando la aprobación
- Solo aparecía la notificación in-app, que el socio podía no estar mirando

## Causa

`NotificacionPublisher#notificarSocioKycAprobado/Rechazado/RequiereInfo` solo persistía la notificación en la tabla `notificaciones`. No invocaba al `EmailNotificationService` (que ya está activo con SMTP Zoho desde mayo-2026).

## Fix

- **`EmailNotificationService`** (port en \`socios.infrastructure.notification\`): 3 métodos nuevos
  - \`enviarKycAprobado(email, nombre)\`
  - \`enviarKycRechazado(email, nombre, motivo)\`
  - \`enviarKycRequiereInfo(email, nombre, detalle)\`
  Best-effort: si SMTP falla, NO propaga error.
- **`EmailNotificationServiceImpl`**: templates HTML con branding institucional, CTA al panel de socio, motivo del analista cuando aplica.
- **`NotificacionPublisher`**: inyecta el service y dispara el email DESPUÉS de la notificación in-app, vía helper `enviarEmailASocio()` que resuelve socioId→(email, nombre) y atrapa excepciones localmente.

## Tests

4 nuevos en `NotificacionPublisherTest`:
- Email se dispara junto con notificación in-app
- Motivo del analista se propaga al cuerpo
- Detalle del analista se propaga al cuerpo (caso requiere info)
- Si SMTP cae, la notificación in-app igual queda guardada y el flujo no aborta

## Test plan

- [ ] Auto-deploy a QA
- [ ] Admin aprueba KYC de socio en QA
- [ ] Socio recibe correo con \"Tu identidad fue verificada\" + CTA al panel
- [ ] Admin rechaza KYC con motivo → socio recibe correo con motivo del analista
- [ ] Verificar logs QA: \`Email 'KYC aprobado' enviado vía SMTP a ...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)