### PR TITLE
fix(legal+bff): banner cookies vs modal password + cache de fetch interno Next.js

### DIFF
--- a/frontend-web/src/components/legal/cookie-consent-banner.test.tsx
+++ b/frontend-web/src/components/legal/cookie-consent-banner.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { CookieConsentBanner } from '@/components/legal/cookie-consent-banner';
 import { leerCookieConsent } from '@/lib/utils/cookie-consent-storage';
+import { useAuthStore } from '@/stores/auth-store';
 
 /**
  * Tests del banner de consentimiento de cookies (issue #218 PR-A).
@@ -14,6 +15,34 @@ import { leerCookieConsent } from '@/lib/utils/cookie-consent-storage';
 describe('CookieConsentBanner', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    // Reset auth store entre tests para evitar leak del flag debeCambiarPassword.
+    useAuthStore.setState({ user: null, isAuthenticated: false, isLoading: false });
+  });
+
+  it('NO aparece cuando el usuario tiene debeCambiarPassword=true (modal obligatorio abierto, evita conflicto z-index reportado en PROD 19-may-2026)', async () => {
+    // Sin preferencia guardada → normalmente el banner aparecería
+    useAuthStore.setState({
+      user: {
+        id: 'user-1',
+        nombreUsuario: 'socio_prueba',
+        correoElectronico: 'socio@test.com',
+        nombreCompleto: 'Socio Prueba',
+        rol: 'SOCIO',
+        socioId: 'socio-1',
+        debeCambiarPassword: true,
+      },
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    render(<CookieConsentBanner />);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // El banner debe permanecer oculto porque el modal de cambio de
+    // password está sobre la pantalla — su z-index entra en conflicto
+    // con el del banner y bloquea ambos. El socio ya aceptó cookies en
+    // el form de registro (LOPDP); el banner es informativo y puede esperar.
+    expect(screen.queryByRole('dialog')).toBeNull();
   });
 
   it('aparece cuando no hay preferencia guardada', async () => {

--- a/frontend-web/src/components/legal/cookie-consent-banner.tsx
+++ b/frontend-web/src/components/legal/cookie-consent-banner.tsx
@@ -9,6 +9,7 @@ import {
   rechazarOpcionales,
   guardarCookieConsent,
 } from '@/lib/utils/cookie-consent-storage';
+import { useAuthStore } from '@/stores/auth-store';
 
 /**
  * Banner de consentimiento de cookies (issue #218 PR-A).
@@ -36,6 +37,21 @@ export function CookieConsentBanner() {
   const [analiticas, setAnaliticas] = useState(false);
   const [marketing, setMarketing] = useState(false);
 
+  /**
+   * Si el socio tiene `debeCambiarPassword=true`, hay un modal obligatorio
+   * de cambio de contraseña abierto sobre la pantalla. Bug reportado en PROD
+   * (19-may-2026): el banner (`z-[100]`) quedaba encima del modal Radix
+   * (`z-50`), capturando los clicks que deberían ir al modal — el socio no
+   * podía ni cerrar el banner (no veía sus botones) ni completar el form
+   * (los inputs no recibían focus). Solución: posponer el banner hasta que
+   * el socio termine de cambiar la clave. Las cookies ya fueron aceptadas
+   * implícitamente en el formulario de registro (LOPDP), así que el banner
+   * es informativo y puede esperar.
+   */
+  const debeCambiarPassword = useAuthStore(
+    (state) => state.user?.debeCambiarPassword ?? false,
+  );
+
   useEffect(() => {
     // Solo en cliente — leerCookieConsent retorna null en SSR
     const consent = leerCookieConsent();
@@ -43,6 +59,7 @@ export function CookieConsentBanner() {
   }, []);
 
   if (visible !== true) return null;
+  if (debeCambiarPassword) return null;
 
   const handleAceptarTodas = () => {
     aceptarTodas();
@@ -64,7 +81,10 @@ export function CookieConsentBanner() {
       role="dialog"
       aria-labelledby="cookie-banner-title"
       aria-describedby="cookie-banner-desc"
-      className="fixed inset-x-0 bottom-0 z-[100] border-t border-slate-200 bg-white shadow-2xl"
+      // z-40 < z-50 de Radix Dialog para que cualquier modal crítico
+      // (cambio de password obligatorio, etc.) quede siempre por encima
+      // del banner aunque la guarda de `debeCambiarPassword` arriba falle.
+      className="fixed inset-x-0 bottom-0 z-40 border-t border-slate-200 bg-white shadow-2xl"
     >
       <div className="mx-auto max-w-6xl px-4 py-4 lg:py-5">
         {!expandido ? (


### PR DESCRIPTION
## Bug reportado en PROD (19-may-2026)

Socios que entraban por primera vez veían el modal de cambio de password obligatorio CON el banner de cookies encima:
- No se podía aceptar las cookies (sus botones quedaban detrás del overlay del modal Radix)
- Ni se podía completar el form de password (los inputs no recibían focus porque el banner capturaba clicks)

**Deadlock de UX**: el socio quedaba atrapado y solo podía cerrar la pestaña.

## Causa

| Elemento | z-index |
|----------|---------|
| Banner de cookies | `z-[100]` |
| Radix Dialog (modal password) | `z-50` |

El banner quedaba visualmente encima pero Radix capturaba los eventos de teclado/focus en su trap, generando el deadlock.

## Fix (dos capas)

1. **Guarda explícita**: `CookieConsentBanner` ahora se entera del estado del store de auth — si `user.debeCambiarPassword === true`, retorna null. Las cookies ya fueron aceptadas implícitamente en el formulario de registro (checks LOPDP obligatorios); el banner es informativo y puede esperar.
2. **z-index defense in depth**: banner bajado de `z-[100]` a `z-40` (debajo del `z-50` de Radix). Si en el futuro otro modal crítico aparece junto al banner, el modal siempre queda encima.

## Tests

1 nuevo en `cookie-consent-banner.test.tsx`: usuario con `debeCambiarPassword=true` → banner permanece oculto. Los 8 existentes siguen pasando (9/9).

## Test plan en QA/PROD

- [ ] Auto-deploy a QA
- [ ] Borrar `localStorage.fatrans.cookie.consent` en el navegador
- [ ] Login con un socio que tenga `debeCambiarPassword=true` (cualquier socio recién creado)
- [ ] Confirmar que solo aparece el modal del password (sin banner detrás)
- [ ] Cambiar la password
- [ ] El banner de cookies aparece tras el toast de éxito

🤖 Generated with [Claude Code](https://claude.com/claude-code)