### PR TITLE
fix(bff): cache: 'no-store' en fetch INTERNO de Next.js (rescate del PR #304)

### DIFF
--- a/frontend-web/src/app/api/auth/me/route.ts
+++ b/frontend-web/src/app/api/auth/me/route.ts
@@ -16,10 +16,18 @@ export async function GET(request: NextRequest) {
     let accessTokenValue = accessToken.value;
     accessTokenValue = accessTokenValue.replace(/^"|"$/g, '');
 
+    // `cache: 'no-store'` es CRÍTICO acá. Next.js 14 cachea GET fetch() del
+    // lado del server por default — el cache es por URL+headers y se comparte
+    // entre requests. Bug reportado en QA (Ronni, 19-may-2026): cambió su
+    // password, la BD persistió debe_cambiar_password=false, pero el BFF
+    // /me devolvía true porque Next.js servía la respuesta cacheada del
+    // primer GET (cuando aún era true). Sin esta línea, el "fix de cache"
+    // de PR #301/#302 no funciona para flows post-mutation.
     const backendResponse = await fetch(`${BACKEND_URL}/api/v1/auth/me`, {
       method: 'GET',
       headers: { 'Authorization': `Bearer ${accessTokenValue}` },
       credentials: 'include',
+      cache: 'no-store',
     });
 
     if (!backendResponse.ok) {

--- a/frontend-web/src/app/api/kyc/biometric/refresh/route.ts
+++ b/frontend-web/src/app/api/kyc/biometric/refresh/route.ts
@@ -17,11 +17,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ message: 'No autenticado' }, { status: 401 });
   }
 
+  // `cache: 'no-store'` por defensa en profundidad. POSTs no se cachean
+  // por default, pero Next.js a veces hace cosas raras con server fetch.
   const backendResponse = await fetch(`${BACKEND_URL}/api/v1/kyc/biometric/refresh`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token.replace(/^"|"$/g, '')}`,
     },
+    cache: 'no-store',
   });
 
   // No traducimos 5xx a 502 acá: el componente está en polling, queremos

--- a/frontend-web/src/app/api/kyc/estado/route.ts
+++ b/frontend-web/src/app/api/kyc/estado/route.ts
@@ -23,6 +23,11 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ message: 'No autenticado' }, { status: 401 });
     }
 
+    // `cache: 'no-store'` evita que Next.js 14 cachee la respuesta del
+    // backend en el server side (el cache de Next.js es por URL+headers y
+    // se comparte entre requests). Sin esto, el polling de KYC sirve el
+    // estado del primer GET (NO_INICIADA/EN_PROGRESO) eternamente, aunque
+    // el backend ya haya cambiado a APROBADA.
     const backendResponse = await fetch(
       `${BACKEND_URL}/api/v1/kyc/estado`,
       {
@@ -32,6 +37,7 @@ export async function GET(request: NextRequest) {
           'Content-Type': 'application/json',
         },
         credentials: 'include',
+        cache: 'no-store',
       }
     );
 


### PR DESCRIPTION
## Problema

El commit \`d38aa55\` agregado al PR #304 se PERDIÓ en el squash merge — GitHub solo incluyó el primer commit del PR (cookie banner) y descartó el segundo. Develop quedó SIN el fix del cache de fetch interno, así que el bug de Ronni en QA sigue activo.

## Bug que esto resuelve (de nuevo)

Reportado por el admin con perfil de Ronni en QA — tras cambiar la contraseña con éxito (BD dice \`debe_cambiar_password=false\`), el modal seguía mostrando \"El sistema aceptó tu nueva contraseña pero no la guardó. Contactá a soporte\".

## Causa raíz

Los PRs #301/#302 agregaron \`Cache-Control: no-store\` en la RESPONSE del BFF al navegador. Pero **Next.js 14 también cachea los \`fetch()\` del lado server por default** — el cache es por URL+headers y se comparte entre requests HTTP independientes.

Flow:
1. Login → ProtectedRoute hace GET \`/api/auth/me\`
2. BFF llama internamente \`fetch('${BACKEND}/api/v1/auth/me')\`
3. Next.js cachea esa respuesta (\`debeCambiarPassword=true\`)
4. Socio cambia password → backend OK → BD persiste \`false\`
5. Modal refetch → BFF llama el mismo fetch interno → **Next.js sirve cache** (\`true\`)
6. Guard detecta \`true\` → \"no se guardó\" → bucle

## Fix

Agregar \`cache: 'no-store'\` al fetch INTERNO del BFF al backend en:
- \`/api/auth/me\`
- \`/api/kyc/estado\`
- \`/api/kyc/biometric/refresh\`

## Test plan

- [ ] Auto-deploy a QA
- [ ] Login con Ronni en QA
- [ ] Cambiar contraseña → modal cierra con toast verde
- [ ] Refrescar página → modal NO reaparece

🤖 Generated with [Claude Code](https://claude.com/claude-code)