### PR TITLE
fix(bff): force-dynamic en TODOS los route handlers (sweep masivo)

### DIFF
--- a/frontend-web/src/app/api/admin/auditoria/route.ts
+++ b/frontend-web/src/app/api/admin/auditoria/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/admin/creditos/solicitudes/[numero]/aprobar/route.ts
+++ b/frontend-web/src/app/api/admin/creditos/solicitudes/[numero]/aprobar/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess, validarNumeroSolicitud } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(

--- a/frontend-web/src/app/api/admin/creditos/solicitudes/[numero]/desembolsar/route.ts
+++ b/frontend-web/src/app/api/admin/creditos/solicitudes/[numero]/desembolsar/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess, validarNumeroSolicitud } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(

--- a/frontend-web/src/app/api/admin/creditos/solicitudes/[numero]/evaluar/route.ts
+++ b/frontend-web/src/app/api/admin/creditos/solicitudes/[numero]/evaluar/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess, validarNumeroSolicitud } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(

--- a/frontend-web/src/app/api/admin/creditos/solicitudes/[numero]/plan/route.ts
+++ b/frontend-web/src/app/api/admin/creditos/solicitudes/[numero]/plan/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess, validarNumeroSolicitud } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/admin/creditos/solicitudes/[numero]/rechazar/route.ts
+++ b/frontend-web/src/app/api/admin/creditos/solicitudes/[numero]/rechazar/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess, validarNumeroSolicitud } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(

--- a/frontend-web/src/app/api/admin/creditos/solicitudes/[numero]/route.ts
+++ b/frontend-web/src/app/api/admin/creditos/solicitudes/[numero]/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess, validarNumeroSolicitud } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/admin/creditos/solicitudes/route.ts
+++ b/frontend-web/src/app/api/admin/creditos/solicitudes/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/admin/dashboard/actividad/route.ts
+++ b/frontend-web/src/app/api/admin/dashboard/actividad/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/admin/dashboard/estadisticas/route.ts
+++ b/frontend-web/src/app/api/admin/dashboard/estadisticas/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/admin/kyc/documentos/[id]/descargar/route.ts
+++ b/frontend-web/src/app/api/admin/kyc/documentos/[id]/descargar/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 /**

--- a/frontend-web/src/app/api/admin/kyc/estadisticas/route.ts
+++ b/frontend-web/src/app/api/admin/kyc/estadisticas/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/admin/kyc/revision/[id]/[action]/route.ts
+++ b/frontend-web/src/app/api/admin/kyc/revision/[id]/[action]/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess, validarUUID } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(

--- a/frontend-web/src/app/api/admin/kyc/revision/[id]/route.ts
+++ b/frontend-web/src/app/api/admin/kyc/revision/[id]/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess, validarUUID } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/admin/parametros/route.ts
+++ b/frontend-web/src/app/api/admin/parametros/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/admin/reportes/creditos/route.ts
+++ b/frontend-web/src/app/api/admin/reportes/creditos/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/admin/reportes/estado-cuenta/route.ts
+++ b/frontend-web/src/app/api/admin/reportes/estado-cuenta/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess, validarUUID, validarAnio, validarMes } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/admin/reportes/socios/route.ts
+++ b/frontend-web/src/app/api/admin/reportes/socios/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/admin/socios/[id]/action/route.ts
+++ b/frontend-web/src/app/api/admin/socios/[id]/action/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(

--- a/frontend-web/src/app/api/admin/socios/[id]/beneficiarios/route.ts
+++ b/frontend-web/src/app/api/admin/socios/[id]/beneficiarios/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/admin/socios/[id]/creditos/route.ts
+++ b/frontend-web/src/app/api/admin/socios/[id]/creditos/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/admin/socios/[id]/cuentas/route.ts
+++ b/frontend-web/src/app/api/admin/socios/[id]/cuentas/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/admin/socios/[id]/kyc/route.ts
+++ b/frontend-web/src/app/api/admin/socios/[id]/kyc/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess, validarUUID } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/admin/socios/[id]/route.ts
+++ b/frontend-web/src/app/api/admin/socios/[id]/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/admin/socios/route.ts
+++ b/frontend-web/src/app/api/admin/socios/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/admin/solicitudes/[id]/aprobar/route.ts
+++ b/frontend-web/src/app/api/admin/solicitudes/[id]/aprobar/route.ts
@@ -2,6 +2,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(

--- a/frontend-web/src/app/api/admin/solicitudes/[id]/rechazar/route.ts
+++ b/frontend-web/src/app/api/admin/solicitudes/[id]/rechazar/route.ts
@@ -2,6 +2,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(

--- a/frontend-web/src/app/api/admin/solicitudes/route.ts
+++ b/frontend-web/src/app/api/admin/solicitudes/route.ts
@@ -2,6 +2,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/admin/tipos-cambio/route.ts
+++ b/frontend-web/src/app/api/admin/tipos-cambio/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/admin/tipos-credito/[id]/route.ts
+++ b/frontend-web/src/app/api/admin/tipos-credito/[id]/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/admin/tipos-credito/route.ts
+++ b/frontend-web/src/app/api/admin/tipos-credito/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/admin/usuarios/[id]/route.ts
+++ b/frontend-web/src/app/api/admin/usuarios/[id]/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/admin/usuarios/route.ts
+++ b/frontend-web/src/app/api/admin/usuarios/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAdminAccess } from '@/lib/auth/admin-validation';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/auth/cambiar-password/route.ts
+++ b/frontend-web/src/app/api/auth/cambiar-password/route.ts
@@ -2,6 +2,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 const changePasswordRequestSchema = z.object({

--- a/frontend-web/src/app/api/auth/login/route.ts
+++ b/frontend-web/src/app/api/auth/login/route.ts
@@ -2,6 +2,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import { loginSchema } from '@/lib/utils/validators';
 import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(request: NextRequest) {

--- a/frontend-web/src/app/api/auth/logout/route.ts
+++ b/frontend-web/src/app/api/auth/logout/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(request: NextRequest) {

--- a/frontend-web/src/app/api/auth/me/route.ts
+++ b/frontend-web/src/app/api/auth/me/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/auth/recuperar-password/route.ts
+++ b/frontend-web/src/app/api/auth/recuperar-password/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(request: NextRequest) {

--- a/frontend-web/src/app/api/auth/registro/route.ts
+++ b/frontend-web/src/app/api/auth/registro/route.ts
@@ -2,6 +2,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import { registroSchema } from '@/lib/utils/validators';
 import { enforceOriginPolicy } from '@/lib/security/origin-check';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 /**

--- a/frontend-web/src/app/api/auth/reset-password/route.ts
+++ b/frontend-web/src/app/api/auth/reset-password/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(request: NextRequest) {

--- a/frontend-web/src/app/api/beneficiarios/[id]/route.ts
+++ b/frontend-web/src/app/api/beneficiarios/[id]/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 interface RouteParams {

--- a/frontend-web/src/app/api/beneficiarios/route.ts
+++ b/frontend-web/src/app/api/beneficiarios/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/compliance/locdoft/umbral/route.ts
+++ b/frontend-web/src/app/api/compliance/locdoft/umbral/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 /**

--- a/frontend-web/src/app/api/creditos/simulador/route.ts
+++ b/frontend-web/src/app/api/creditos/simulador/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(request: NextRequest) {

--- a/frontend-web/src/app/api/creditos/solicitudes/[numero]/route.ts
+++ b/frontend-web/src/app/api/creditos/solicitudes/[numero]/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import jwt from 'jsonwebtoken';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 const JWT_SECRET = process.env.JWT_SECRET || process.env.NEXTAUTH_SECRET || 'fallback-secret-do-not-use-in-production';
 

--- a/frontend-web/src/app/api/creditos/solicitudes/route.ts
+++ b/frontend-web/src/app/api/creditos/solicitudes/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import jwt from 'jsonwebtoken';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 const JWT_SECRET = process.env.JWT_SECRET || process.env.NEXTAUTH_SECRET || 'fallback-secret-do-not-use-in-production';
 

--- a/frontend-web/src/app/api/creditos/solicitudes/socio/[socioId]/route.ts
+++ b/frontend-web/src/app/api/creditos/solicitudes/socio/[socioId]/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import jwt from 'jsonwebtoken';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 const JWT_SECRET = process.env.JWT_SECRET || process.env.NEXTAUTH_SECRET || 'fallback-secret-do-not-use-in-production';
 

--- a/frontend-web/src/app/api/creditos/tipos-credito/route.ts
+++ b/frontend-web/src/app/api/creditos/tipos-credito/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/cuentas/[numeroCuenta]/depositos/route.ts
+++ b/frontend-web/src/app/api/cuentas/[numeroCuenta]/depositos/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(

--- a/frontend-web/src/app/api/cuentas/[numeroCuenta]/movimientos/[numeroOperacion]/comprobante/route.ts
+++ b/frontend-web/src/app/api/cuentas/[numeroCuenta]/movimientos/[numeroOperacion]/comprobante/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 /**

--- a/frontend-web/src/app/api/cuentas/[numeroCuenta]/movimientos/route.ts
+++ b/frontend-web/src/app/api/cuentas/[numeroCuenta]/movimientos/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/cuentas/[numeroCuenta]/retiros/route.ts
+++ b/frontend-web/src/app/api/cuentas/[numeroCuenta]/retiros/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(

--- a/frontend-web/src/app/api/cuentas/[numeroCuenta]/route.ts
+++ b/frontend-web/src/app/api/cuentas/[numeroCuenta]/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/cuentas/[numeroCuenta]/saldo/route.ts
+++ b/frontend-web/src/app/api/cuentas/[numeroCuenta]/saldo/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/cuentas/socio/[socioId]/route.ts
+++ b/frontend-web/src/app/api/cuentas/socio/[socioId]/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/documentos/[id]/descargar/route.ts
+++ b/frontend-web/src/app/api/documentos/[id]/descargar/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/documentos/[id]/route.ts
+++ b/frontend-web/src/app/api/documentos/[id]/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/documentos/carta-beneficiarios/[socioId]/route.ts
+++ b/frontend-web/src/app/api/documentos/carta-beneficiarios/[socioId]/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/documentos/constancia-afiliacion/[socioId]/route.ts
+++ b/frontend-web/src/app/api/documentos/constancia-afiliacion/[socioId]/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/documentos/estado-cuenta/[cuentaId]/route.ts
+++ b/frontend-web/src/app/api/documentos/estado-cuenta/[cuentaId]/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/documentos/route.ts
+++ b/frontend-web/src/app/api/documentos/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {

--- a/frontend-web/src/app/api/documentos/tabla-amortizacion/[creditoId]/route.ts
+++ b/frontend-web/src/app/api/documentos/tabla-amortizacion/[creditoId]/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(

--- a/frontend-web/src/app/api/kyc/biometric/consentimiento/route.ts
+++ b/frontend-web/src/app/api/kyc/biometric/consentimiento/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 /**

--- a/frontend-web/src/app/api/kyc/biometric/iniciar/route.ts
+++ b/frontend-web/src/app/api/kyc/biometric/iniciar/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 /**

--- a/frontend-web/src/app/api/kyc/biometric/refresh/route.ts
+++ b/frontend-web/src/app/api/kyc/biometric/refresh/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 /**

--- a/frontend-web/src/app/api/kyc/documentos/route.ts
+++ b/frontend-web/src/app/api/kyc/documentos/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 /**

--- a/frontend-web/src/app/api/kyc/enviar/route.ts
+++ b/frontend-web/src/app/api/kyc/enviar/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 /**

--- a/frontend-web/src/app/api/kyc/estado/route.ts
+++ b/frontend-web/src/app/api/kyc/estado/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 /**

--- a/frontend-web/src/app/api/notificaciones/[id]/leida/route.ts
+++ b/frontend-web/src/app/api/notificaciones/[id]/leida/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 /**

--- a/frontend-web/src/app/api/notificaciones/count/route.ts
+++ b/frontend-web/src/app/api/notificaciones/count/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 /**

--- a/frontend-web/src/app/api/notificaciones/marcar-todas-leidas/route.ts
+++ b/frontend-web/src/app/api/notificaciones/marcar-todas-leidas/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 /**

--- a/frontend-web/src/app/api/notificaciones/route.ts
+++ b/frontend-web/src/app/api/notificaciones/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 /**

--- a/frontend-web/src/app/api/perfil/verificar-password/route.ts
+++ b/frontend-web/src/app/api/perfil/verificar-password/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function POST(request: NextRequest) {

--- a/frontend-web/src/app/api/simulador/route.ts
+++ b/frontend-web/src/app/api/simulador/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 interface Cuota {
   numero: number;
   fechaPago: string;

--- a/frontend-web/src/app/api/tipos-cambio/route.ts
+++ b/frontend-web/src/app/api/tipos-cambio/route.ts
@@ -1,5 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// `export const dynamic = 'force-dynamic'` desactiva el cache automático de
+// fetch() del lado del server en Next.js 14. Sin esto, los GET internos del BFF
+// al backend Java se cachean por URL+headers, devolviendo respuestas viejas tras
+// mutaciones (caso real Ronni QA 19-may-2026: KYC aprobado en BD pero el admin
+// veía la solicitud aún en la cola).
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
 
 export async function GET(request: NextRequest) {


### PR DESCRIPTION
## Bug reportado en QA por el admin (19-may-2026)

Tras aprobar el KYC de Ronni desde el panel admin:
- Backend persistió el cambio en BD (\`verificacion_kyc.estado = APROBADO\`)
- Pero la cola del admin SEGUÍA mostrando la solicitud pendiente
- Mismo problema con la lista de solicitudes de registro

Verificado en BD QA:
\`\`\`
SELECT estado, fecha_revision FROM verificacion_kyc WHERE socio_id IN (...ronni...);
APROBADO | 2026-05-19 20:30:22 ← persistió bien
\`\`\`

## Causa raíz

Mismo bug que PR #305 (\`/me\`, \`/kyc/estado\`, \`/biometric/refresh\`) pero ahora en los GETs del admin. **Next.js 14 cachea \`fetch()\` del lado server por default** — el cache es por URL+headers y se comparte entre requests HTTP independientes.

Flow:
1. Admin entra a \`/admin/kyc\` → BFF hace fetch al backend
2. Next.js cachea esa respuesta (con Ronni pendiente)
3. Admin aprueba (POST) → backend OK → BD updates a APROBADO
4. Admin refresca la cola → BFF llama el mismo fetch → Next.js sirve cache viejo
5. UI muestra Ronni AÚN pendiente

## Fix

\`export const dynamic = 'force-dynamic';\` agregado a los **75 route handlers** que faltaban. Es la directiva oficial de Next.js para desactivar el caching de fetch en un Route Handler.

Cero cambios funcionales: cada request ahora siempre va al backend en lugar de servir cache local.

## Verificación

- ✅ Aplicado a 75/76 route.ts (el restante ya tenía la directiva)
- ✅ TypeScript pasa (cero errores nuevos)
- ✅ Suite de tests: 543/550 (los 7 fallos son preexistentes en admin-dashboard/socios/reportes)

## Test plan

- [ ] Auto-deploy a QA
- [ ] Admin aprueba KYC de Ronni → cola se actualiza inmediatamente
- [ ] Admin aprueba solicitud de registro → lista se actualiza
- [ ] Mismo flow para otros endpoints (créditos, socios, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)