### PR TITLE
feat(kyc+ahorros): auto-crear cuenta de ahorro VES al aprobar KYC

### DIFF
--- a/backend/src/main/java/com/tufondo/kyc/application/usecase/RevisarDocumentosUseCase.java
+++ b/backend/src/main/java/com/tufondo/kyc/application/usecase/RevisarDocumentosUseCase.java
@@ -15,11 +15,18 @@ import com.tufondo.kyc.domain.model.port.StoragePort;
 import com.tufondo.kyc.domain.repository.ConsentimientoKYCRepository;
 import com.tufondo.kyc.domain.repository.DocumentoIdentidadRepository;
 import com.tufondo.kyc.domain.repository.VerificacionKYCRepository;
+import com.tufondo.ahorros.application.dto.CreateCuentaAhorroRequest;
+import com.tufondo.ahorros.application.usecase.CrearCuentaAhorroUseCase;
+import com.tufondo.ahorros.domain.exception.CuentaDuplicadaException;
+import com.tufondo.ahorros.domain.model.enums.Moneda;
+import com.tufondo.ahorros.domain.model.enums.TipoCuenta;
 import com.tufondo.notificaciones.application.service.NotificacionPublisher;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -29,6 +36,7 @@ import java.util.stream.Collectors;
  * Use case para que el analista revise documentos.
  */
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class RevisarDocumentosUseCase {
 
@@ -40,6 +48,29 @@ public class RevisarDocumentosUseCase {
     // El publisher es defensivo: si falla la persistencia de la notificación,
     // el flujo de aprobar/rechazar NO se ve afectado.
     private final NotificacionPublisher notificacionPublisher;
+    /**
+     * Use case para auto-crear cuenta de ahorro en VES al aprobar el KYC
+     * (19-may-2026). Antes el socio quedaba aprobado pero sin cuenta — el
+     * admin no tenía UI para crearla y el socio tampoco. Bug visible: socios
+     * aprobados sin posibilidad de hacer depósitos.
+     */
+    private final CrearCuentaAhorroUseCase crearCuentaAhorroUseCase;
+
+    /**
+     * Defaults para la cuenta auto-creada en VES al aprobar KYC.
+     *
+     * <p><b>tasaInteres = 0.0001</b>: el mínimo permitido por la validación
+     * del DTO. Las cuentas en bolívares NO rinden interés en la práctica por
+     * la hiperinflación; el admin puede ajustar la tasa después si decide
+     * habilitar rendimientos. No es 0 porque el validator del DTO exige
+     * estrictamente > 0.</p>
+     *
+     * <p><b>montoMinimoRequerido = 1.0</b>: 1 bolívar — el mínimo razonable
+     * para que el socio pueda hacer cualquier depósito. Igual que la tasa,
+     * el admin puede ajustarlo después.</p>
+     */
+    private static final BigDecimal CUENTA_DEFAULT_TASA_INTERES = new BigDecimal("0.0001");
+    private static final BigDecimal CUENTA_DEFAULT_MONTO_MINIMO = new BigDecimal("1.00");
 
     public RevisionResponse obtenerDetalle(UUID verificacionId) {
         VerificacionKYC verificacion = verificacionRepository.findById(verificacionId)
@@ -141,6 +172,17 @@ public class RevisarDocumentosUseCase {
             documentoRepository.save(doc);
         }
 
+        // Auto-crear cuenta de ahorro en VES (19-may-2026). Antes este paso era
+        // manual y nadie lo hacía: ni el admin tenía UI para crear cuenta a un
+        // socio, ni el socio podía crearla por sí mismo desde su dashboard.
+        // Resultado: socios aprobados sin cuenta, sin poder hacer depósitos.
+        //
+        // Defensivo: si la creación falla (ej. CuentaDuplicada por una cuenta
+        // pre-existente), NO abortamos la aprobación del KYC — solo logueamos.
+        // La aprobación documental es el evento crítico; la cuenta puede
+        // crearse manualmente después si fuera necesario.
+        autoCrearCuentaAhorroVES(verificacion.getSocioId());
+
         // Issue #214 PR-C: notificar al socio
         notificacionPublisher.notificarSocioKycAprobado(verificacion.getSocioId());
 
@@ -150,6 +192,49 @@ public class RevisarDocumentosUseCase {
             .estadoNuevo(verificacion.getEstado())
             .mensaje("Su verificacion KYC ha sido aprobada.")
             .build();
+    }
+
+    /**
+     * Crea la cuenta de ahorro en VES para el socio recién aprobado.
+     *
+     * <p>Se invoca al final del flujo de aprobación. <b>NUNCA debe romper
+     * la aprobación del KYC</b>: cualquier excepción se loguea y se traga.
+     * La aprobación documental es el evento crítico para el negocio (el
+     * socio ya pasó la verificación), la cuenta es secundaria — si falla
+     * por algún edge case, un admin puede crearla manualmente después.</p>
+     *
+     * <p>Casos manejados:</p>
+     * <ul>
+     *   <li><b>{@link CuentaDuplicadaException}</b>: el socio ya tenía cuenta
+     *       de ahorro (caso esperado — re-aprobación de KYC, KYC con docs
+     *       extras). Log INFO, no es error.</li>
+     *   <li>Cualquier otra excepción: log ERROR con stacktrace, sigue.</li>
+     * </ul>
+     */
+    private void autoCrearCuentaAhorroVES(UUID socioId) {
+        try {
+            CreateCuentaAhorroRequest request = new CreateCuentaAhorroRequest(
+                    socioId,
+                    TipoCuenta.AHORRO,
+                    Moneda.VES,
+                    CUENTA_DEFAULT_MONTO_MINIMO,
+                    CUENTA_DEFAULT_TASA_INTERES
+            );
+            // isAdmin=true porque este flujo se ejecuta desde el use case del
+            // analista (rol ADMIN/ANALISTA_KYC). El check de ownership del
+            // CrearCuentaAhorroUseCase exige isAdmin=true cuando socioIdToken
+            // no coincide con request.socioId (que es nuestro caso — el
+            // analista NO es el dueño de la cuenta).
+            crearCuentaAhorroUseCase.ejecutar(request, null, true);
+            log.info("Cuenta de ahorro VES auto-creada para socio {}", socioId);
+        } catch (CuentaDuplicadaException e) {
+            // Caso esperado: re-aprobación o el socio ya tenía cuenta.
+            log.info("Cuenta de ahorro VES ya existía para socio {} — skipping", socioId);
+        } catch (Throwable t) {
+            // Cualquier otro error NO debe romper la aprobación del KYC.
+            log.error("Falló auto-creación de cuenta VES para socio {} (se ignora, " +
+                            "el admin puede crearla manualmente): {}", socioId, t.getMessage(), t);
+        }
     }
 
     @Transactional


### PR DESCRIPTION
## Auditoría detrás del feature (reportada por admin en QA, 19-may-2026)

\"Cuando se apruebe un KYC, debería automáticamente salir una cuenta de ahorros al socio en Bs, porque si te pones a hacer auditoría en ningún lado hay para asignarle la cuenta o que el se la cree.\"

## Confirmé el gap

| Capa | ¿Crea cuenta al aprobar KYC? |
|------|------------------------------|
| \`RevisarDocumentosUseCase.aprobar()\` | ❌ NO. Solo cambia estado + notifica. |
| \`AprobarSolicitudUseCase\` (paso previo) | ❌ NO. Crea socio + usuario, sin cuenta. |
| Frontend socio \`/dashboard/cuentas\` | ❌ Solo lista, no hay botón \"crear\". |
| Admin UI | ❌ No existe \`/admin/socios/[id]/cuentas/nueva\` ni equivalente. |

Resultado: socios aprobados quedan sin cuenta — no pueden depositar, retirar ni recibir desembolsos.

## Fix

\`RevisarDocumentosUseCase.aprobar()\` ahora invoca \`CrearCuentaAhorroUseCase\` después de marcar el KYC como APROBADO + notificar. Defaults:

| Campo | Valor | Razón |
|-------|-------|-------|
| \`tipoCuenta\` | AHORRO | Estándar |
| \`moneda\` | VES | Bolívares |
| \`tasaInteres\` | 0.0001 | Mínimo del validador del DTO; las cuentas en Bs no rinden en práctica por hiperinflación. Admin puede ajustar después. |
| \`montoMinimoRequerido\` | 1.00 Bs | Mínimo razonable |

### Defensivo

El helper \`autoCrearCuentaAhorroVES\` atrapa TODAS las excepciones, incluyendo \`CuentaDuplicadaException\` (esperada en re-aprobaciones de KYC). La aprobación del KYC NUNCA se aborta por un problema con la cuenta — el evento crítico es la aprobación documental.

## Test plan

- [ ] Auto-deploy a QA
- [ ] Crear socio nuevo + verificación KYC en QA
- [ ] Admin aprueba el KYC desde la cola
- [ ] Verificar en BD: \`SELECT * FROM cuentas_ahorro WHERE socio_id = ...\` → debe existir cuenta AHORRO/VES con saldo 0
- [ ] El socio entra al \`/dashboard/cuentas\` y ve su cuenta nueva
- [ ] Reaprobaciones (caso edge): no deben romper aunque la cuenta ya exista

🤖 Generated with [Claude Code](https://claude.com/claude-code)