### PR TITLE
release: 9ª promoción — scraper BCV cada 2h + catch-up al arrancar + botón sync manual

### DIFF
--- a/backend/src/main/java/com/tufondo/tipocambio/infrastructure/scraper/BcvSyncService.java
+++ b/backend/src/main/java/com/tufondo/tipocambio/infrastructure/scraper/BcvSyncService.java
@@ -99,6 +99,23 @@ public class BcvSyncService {
     /**
      * Lógica del catch-up. Separado del @PostConstruct para que el thread
      * acceda al método @Transactional vía proxy Spring correctamente.
+     *
+     * <p>Estrategia: <b>scrapear SIEMPRE al arrancar</b>, sin condición de
+     * "fresca". El use case ya es idempotente — si ya existe tasa para la
+     * fecha valor que devuelve el BCV, simplemente loguea "ya existía" y
+     * no inserta duplicado. Esto:</p>
+     *
+     * <ul>
+     *   <li>Evita el bug 20-may-2026: comparaba {@code ultima.getFecha()}
+     *       (fecha valor BCV) contra hoy, y como BCV publica el día anterior
+     *       la tasa del día siguiente, "fecha valor = hoy" no significaba
+     *       "scrapeada hoy". Resultado: catch-up decía "fresca, skip" cuando
+     *       en realidad llevábamos 3 días sin scrapear.</li>
+     *   <li>Garantiza que cada deploy actualiza la tasa, sin importar la
+     *       hora.</li>
+     *   <li>No tiene costo: BCV es HTML público, 1 request extra al arrancar
+     *       es despreciable.</li>
+     * </ul>
      */
     public void ejecutarCatchUpStartup() {
         try {
@@ -106,30 +123,19 @@ public class BcvSyncService {
             // (HikariCP, etc.) — evita race conditions en logs muy tempranos.
             Thread.sleep(5_000);
 
-            LocalDate hoy = LocalDate.now(ZoneId.of("America/Caracas"));
             Optional<TipoCambio> ultima = tipoCambioRepository.buscarTasaActual();
-
-            boolean necesitaCatchUp;
-            if (ultima.isEmpty()) {
-                log.info("Catch-up BCV al arrancar: no hay ninguna tasa en BD, scrapeando…");
-                necesitaCatchUp = true;
+            if (ultima.isPresent()) {
+                LocalDate hoy = LocalDate.now(ZoneId.of("America/Caracas"));
+                long diasFechaValor = ChronoUnit.DAYS.between(ultima.get().getFecha(), hoy);
+                log.info("Catch-up BCV al arrancar: última fecha valor={} (Δ{}d vs hoy Caracas={}), " +
+                                "scrapeando para garantizar tasa fresca…",
+                        ultima.get().getFecha(), diasFechaValor, hoy);
             } else {
-                long diasSinActualizar = ChronoUnit.DAYS.between(ultima.get().getFecha(), hoy);
-                if (diasSinActualizar >= 1) {
-                    log.info("Catch-up BCV al arrancar: última tasa es de {} ({} días), scrapeando…",
-                            ultima.get().getFecha(), diasSinActualizar);
-                    necesitaCatchUp = true;
-                } else {
-                    log.info("Catch-up BCV al arrancar: última tasa es de {} (fresca), skip.",
-                            ultima.get().getFecha());
-                    necesitaCatchUp = false;
-                }
+                log.info("Catch-up BCV al arrancar: no hay ninguna tasa en BD, scrapeando…");
             }
 
-            if (necesitaCatchUp) {
-                SincronizacionResultado r = sincronizarDesdeBcv();
-                log.info("Catch-up BCV al arrancar completado: {}", r);
-            }
+            SincronizacionResultado r = sincronizarDesdeBcv();
+            log.info("Catch-up BCV al arrancar completado: {}", r);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } catch (Exception e) {

--- a/backend/src/main/java/com/tufondo/tipocambio/infrastructure/scraper/BcvSyncService.java
+++ b/backend/src/main/java/com/tufondo/tipocambio/infrastructure/scraper/BcvSyncService.java
@@ -2,6 +2,7 @@ package com.tufondo.tipocambio.infrastructure.scraper;
 
 import com.tufondo.tipocambio.domain.model.TipoCambio;
 import com.tufondo.tipocambio.domain.repository.TipoCambioRepository;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -9,6 +10,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 /**
@@ -34,18 +38,103 @@ public class BcvSyncService {
     private final TipoCambioRepository tipoCambioRepository;
 
     /**
-     * Job programado: 08:30 AM hora Venezuela, todos los días.
-     * El BCV usualmente publica la tasa del día entre 6 y 8 AM.
+     * Job programado: cada 2 horas entre 8 AM y 6 PM hora Venezuela
+     * (8, 10, 12, 14, 16, 18 → 6 ejecuciones/día).
+     *
+     * <p>Antes corría 1 vez al día (08:30 Caracas). Problemas observados en PROD:
+     * <ul>
+     *   <li>Si el backend estaba reiniciándose a esa hora (deploy nocturno),
+     *       se perdía el cron y la tasa quedaba 24h+ stale.</li>
+     *   <li>BCV publica usualmente entre 6-8 AM pero ocasionalmente actualiza
+     *       más tarde — una sola ejecución no captura ese caso.</li>
+     * </ul>
+     * Solución: scrapear cada 2h en horario laboral del BCV. Es idempotente
+     * (si la tasa ya existe para esa fecha valor, no se duplica), así que las
+     * ejecuciones extra solo loguean "ya existía" y no afectan al BCV ni a la
+     * BD. 6 requests/día al sitio del BCV es muy razonable, sin riesgo de
+     * rate-limit.</p>
      */
-    @Scheduled(cron = "0 30 8 * * *", zone = "America/Caracas")
+    @Scheduled(cron = "0 0 8-18/2 * * *", zone = "America/Caracas")
     public void ejecutarJobDiario() {
-        log.info("Iniciando job programado de sincronización BCV");
+        log.debug("Iniciando job programado de sincronización BCV");
         try {
             SincronizacionResultado resultado = sincronizarDesdeBcv();
-            log.info("Job BCV diario completado: {}", resultado);
+            // Solo log INFO si se insertó algo nuevo; las re-ejecuciones idempotentes
+            // se loguean en DEBUG para no inundar logs con "ya existía" 6 veces al día.
+            if (resultado.insertada()) {
+                log.info("Job BCV insertó tasa nueva: {}", resultado);
+            } else {
+                log.debug("Job BCV idempotente (ya existía): {}", resultado);
+            }
         } catch (Exception e) {
             // CRÍTICO: el job nunca debe lanzar excepción (rompería el scheduler).
             log.error("Error en job programado BCV — la tasa anterior se preserva: {}",
+                    e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Catch-up al arrancar el backend: si la última tasa en BD es vieja
+     * (> 1 día desde la última fecha de valor) o no hay ninguna, dispara
+     * un scrape inmediato.
+     *
+     * <p>Antes (bug observado 19-may-2026): el backend se reiniciaba para un
+     * deploy DESPUÉS de la hora del cron, y la tasa quedaba 24h+ stale hasta
+     * la próxima ejecución programada. Este catch-up cubre ese caso.</p>
+     *
+     * <p>Lo lanzamos en un Thread aparte porque el scrape hace I/O HTTP al BCV
+     * y puede tardar varios segundos — no queremos bloquear el startup del
+     * Spring context. Si el scrape falla, se loguea pero no rompe el arranque
+     * (preferimos un backend vivo con tasa stale que uno apagado).</p>
+     */
+    @PostConstruct
+    public void programarCatchUpAlArrancar() {
+        // Disparamos en otro thread para no bloquear startup ni el bean wiring.
+        // No usamos @Async directo en este método para evitar el típico bug de
+        // self-invocation (Spring AOP no intercepta llamadas desde el propio
+        // bean), preferimos un Thread simple acá.
+        new Thread(this::ejecutarCatchUpStartup, "bcv-startup-catchup").start();
+    }
+
+    /**
+     * Lógica del catch-up. Separado del @PostConstruct para que el thread
+     * acceda al método @Transactional vía proxy Spring correctamente.
+     */
+    public void ejecutarCatchUpStartup() {
+        try {
+            // Esperar 5s para que el resto del Spring context termine de inicializar
+            // (HikariCP, etc.) — evita race conditions en logs muy tempranos.
+            Thread.sleep(5_000);
+
+            LocalDate hoy = LocalDate.now(ZoneId.of("America/Caracas"));
+            Optional<TipoCambio> ultima = tipoCambioRepository.buscarTasaActual();
+
+            boolean necesitaCatchUp;
+            if (ultima.isEmpty()) {
+                log.info("Catch-up BCV al arrancar: no hay ninguna tasa en BD, scrapeando…");
+                necesitaCatchUp = true;
+            } else {
+                long diasSinActualizar = ChronoUnit.DAYS.between(ultima.get().getFecha(), hoy);
+                if (diasSinActualizar >= 1) {
+                    log.info("Catch-up BCV al arrancar: última tasa es de {} ({} días), scrapeando…",
+                            ultima.get().getFecha(), diasSinActualizar);
+                    necesitaCatchUp = true;
+                } else {
+                    log.info("Catch-up BCV al arrancar: última tasa es de {} (fresca), skip.",
+                            ultima.get().getFecha());
+                    necesitaCatchUp = false;
+                }
+            }
+
+            if (necesitaCatchUp) {
+                SincronizacionResultado r = sincronizarDesdeBcv();
+                log.info("Catch-up BCV al arrancar completado: {}", r);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            // Defensivo: NUNCA romper el arranque por un scrape fallido.
+            log.error("Catch-up BCV al arrancar falló — la tasa anterior se preserva: {}",
                     e.getMessage(), e);
         }
     }

--- a/frontend-web/src/app/(admin)/admin/tipos-cambio/page.tsx
+++ b/frontend-web/src/app/(admin)/admin/tipos-cambio/page.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Loader2, Plus, Pencil, Trash2, DollarSign, TrendingUp, TrendingDown, AlertCircle } from 'lucide-react';
+import { Loader2, Plus, Pencil, Trash2, DollarSign, TrendingUp, TrendingDown, AlertCircle, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   Dialog,
@@ -58,6 +58,7 @@ export default function AdminTiposCambioPage() {
   const [form, setForm] = useState<TipoCambioForm>(emptyForm);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [syncingBcv, setSyncingBcv] = useState(false);
 
   const cargarTiposCambio = useCallback(async () => {
     setLoading(true);
@@ -79,6 +80,47 @@ export default function AdminTiposCambioPage() {
   useEffect(() => {
     cargarTiposCambio();
   }, [cargarTiposCambio]);
+
+  /**
+   * Dispara una sincronización inmediata del scraper BCV. Útil cuando el cron
+   * automático no ha corrido todavía (deploy reciente, error de red previo) y
+   * el admin necesita la tasa actualizada YA. El backend es idempotente: si la
+   * tasa para la fecha valor ya existe, no la duplica.
+   */
+  const handleSyncBcv = async () => {
+    setSyncingBcv(true);
+    try {
+      const res = await fetch('/api/admin/tipos-cambio/sync-bcv', {
+        method: 'POST',
+        credentials: 'include',
+        cache: 'no-store',
+      });
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        toast.error(data.mensaje || data.message || 'No pudimos sincronizar con el BCV', {
+          description: data.error || `HTTP ${res.status}`,
+        });
+        return;
+      }
+
+      if (data.insertada) {
+        toast.success('Tasa BCV actualizada', {
+          description: `Fecha ${data.fecha}: Bs ${data.tasa}`,
+        });
+      } else {
+        toast.info('Sin cambios', {
+          description: `La tasa de ${data.fecha} ya estaba en BD (Bs ${data.tasa}).`,
+        });
+      }
+      await cargarTiposCambio();
+    } catch (err) {
+      console.error('Error syncing BCV:', err);
+      toast.error('Error de red al sincronizar BCV');
+    } finally {
+      setSyncingBcv(false);
+    }
+  };
 
   const handleOpenDialog = (tc?: TipoCambio) => {
     if (tc) {
@@ -210,10 +252,25 @@ export default function AdminTiposCambioPage() {
               <DollarSign className="h-5 w-5" />
               Tasas VES/USD
             </CardTitle>
-            <Button onClick={() => handleOpenDialog()}>
-              <Plus className="h-4 w-4 mr-2" />
-              Nueva Tasa
-            </Button>
+            <div className="flex gap-2">
+              <Button
+                onClick={handleSyncBcv}
+                disabled={syncingBcv}
+                variant="outline"
+                title="Forzar consulta inmediata al BCV (sin esperar al cron)"
+              >
+                {syncingBcv ? (
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                ) : (
+                  <RefreshCw className="h-4 w-4 mr-2" />
+                )}
+                Sincronizar BCV ahora
+              </Button>
+              <Button onClick={() => handleOpenDialog()}>
+                <Plus className="h-4 w-4 mr-2" />
+                Nueva Tasa
+              </Button>
+            </div>
           </div>
         </CardHeader>
         <CardContent>

--- a/frontend-web/src/app/api/admin/tipos-cambio/sync-bcv/route.ts
+++ b/frontend-web/src/app/api/admin/tipos-cambio/sync-bcv/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { validateAdminAccess } from '@/lib/auth/admin-validation';
+
+// Sin cache: este endpoint dispara un side effect (scrape al BCV + insert en BD).
+// Si Next.js cacheara la respuesta, el botón parecería "no responder" en clicks
+// sucesivos cuando el admin quiere forzar otro refresh.
+export const dynamic = 'force-dynamic';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:18080';
+
+/**
+ * BFF: dispara una sincronización manual del scraper BCV.
+ *
+ * El backend ya tiene un cron que corre cada 2h en horario laboral del BCV, pero
+ * a veces el admin necesita forzar el scrape (caso real 20-may-2026: el deploy
+ * del backend ocurrió DESPUÉS de la última ejecución del cron del día y la tasa
+ * quedó stale hasta el día siguiente). Este botón cubre ese gap.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const accessToken = request.cookies.get('access_token')?.value;
+    const authResult = validateAdminAccess({ accessToken });
+    if (!authResult.valid) {
+      return NextResponse.json(
+        { message: authResult.message },
+        { status: authResult.status },
+      );
+    }
+
+    const backendResponse = await fetch(
+      `${BACKEND_URL}/api/v1/admin/tipos-cambio/sync-bcv`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        cache: 'no-store',
+      },
+    );
+
+    const data = await backendResponse.json().catch(() => ({}));
+
+    // 502 Bad Gateway del backend → el BCV no respondió o el HTML cambió.
+    // Pasamos el mensaje literal para que el admin sepa qué falló.
+    if (!backendResponse.ok) {
+      return NextResponse.json(data, { status: backendResponse.status });
+    }
+
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    console.error('Admin sync BCV error:', error);
+    return NextResponse.json(
+      { message: 'Error interno del servidor' },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Resumen

Promoción a producción. Solo cambios del módulo de tipo de cambio.

## Lo que va a producción

### PR #310 — Robustez del scraper BCV
- **Cron cada 2h** entre 8 AM y 6 PM hora Caracas (\`0 0 8-18/2 * * *\`). 6 ejecuciones/día.
- **Botón \"Sincronizar BCV ahora\"** en \`/admin/tipos-cambio\`. El endpoint backend ya existía pero el frontend no lo invocaba.
- **BFF** \`POST /api/admin/tipos-cambio/sync-bcv\` con \`cache: 'no-store'\`.

### PR #311 — Fix del catch-up al arrancar
- El catch-up de #310 tenía un bug: comparaba \`fecha valor BCV\` contra \`hoy\` y decía \"fresca, skip\" cuando en realidad llevábamos 3 días sin scrapear (porque BCV publica un día antes la tasa del siguiente, así que \"fecha valor = hoy\" NO significa \"scrapeada hoy\").
- Fix: scrapear **siempre** al arrancar (el use case es idempotente).

### Verificado en QA
- ✅ Backend QA arrancó con la versión nueva
- ✅ Catch-up disparó al arranque y trajo la tasa BCV de hoy
- ✅ Botón \"Sincronizar BCV ahora\" en admin UI funcional

## Riesgo

- **Bajo**: cambios localizados al módulo tipo-cambio. No tocan auth, ahorros, créditos, KYC.
- **Reversible**: rollback a imagen anterior si algo falla.
- Sin migraciones Flyway nuevas.

## Test plan post-deploy prod

- [ ] Verificar log: \`Catch-up BCV al arrancar: ... scrapeando para garantizar tasa fresca…\`
- [ ] Confirmar fila nueva en \`tipos_cambio\` con \`created_at\` reciente
- [ ] Entrar a \`/admin/tipos-cambio\` y verificar que el botón \"Sincronizar BCV ahora\" aparece
- [ ] Click al botón → toast con resultado

🤖 Generated with [Claude Code](https://claude.com/claude-code)