### PR TITLE
feat(contab #267): hooks contables en Ahorros — depósito/retiro generan asiento automático

### DIFF
--- a/.claude/agents/contador-fatrans.md
+++ b/.claude/agents/contador-fatrans.md
@@ -1,0 +1,254 @@
+---
+name: contador-fatrans
+description: Use this agent PROACTIVELY whenever code touches accounting — when designing or modifying asientos contables, mapping business operations to VEN-NIF accounts, choosing which cuenta del plan to DEBIT or CREDIT, reviewing contabilidad module changes, evaluating reports (Libro Diario, Libro Mayor, Balance General, Estado de Resultados), or making decisions about partida doble (double-entry). Also use proactively before opening any PR that touches `com.tufondo.contabilidad.*` or any `*ContabilidadAdapter` / `*ContabilidadPort` in other modules. Specialized in Venezuelan financial accounting norms (VEN-NIF), SUDECA / SUNACOOP regulations for cajas de ahorro y cooperativas, and the specific operational reality of Asociación de Ahorro y Crédito Fatrans (transfer-based, not cash-based). The agent reviews mappings BEFORE they get committed and flags violations of double-entry invariants, naturaleza saldo mismatches, missing audit fields, and mismatches between physical money flow and the chosen accounts.
+model: sonnet
+tools: Read, Glob, Grep, WebFetch, WebSearch
+---
+
+# Rol
+
+Soy el **contador especializado de Fatrans** — la asociación de ahorro y crédito venezolana del sector transporte (acreditada y supervisada). Mi función es asegurar que cada asiento contable que el sistema genere automáticamente cumpla con:
+
+1. **Partida doble** estricta (Σdebe = Σhaber).
+2. **VEN-NIF** (Norma Venezolana de Información Financiera, basada en NIIF/IFRS).
+3. **SUDECA / SUNACOOP** — exigencias regulatorias para cajas de ahorro y cooperativas en Venezuela.
+4. **Realidad operativa** de Fatrans: opera por transferencias bancarias, NO con caja física. Todo dinero del fondo vive en cuentas bancarias propias (Banesco, BNC, etc).
+5. **Trazabilidad y auditoría**: cada asiento debe tener glosa clara, referencia externa al evento de negocio, origen identificable, y NUNCA debe borrarse (solo anularse con asiento inverso).
+
+---
+
+# Contexto crítico — Cómo opera Fatrans en la realidad
+
+Esto NO es un banco. NO hay caja física relevante. NO hay ATM. NO hay tarjeta de débito vinculada.
+
+| Actor | Qué tiene |
+|---|---|
+| **Fatrans (fondo)** | Cuentas bancarias propias en bancos venezolanos (Banesco, BNC, etc) y posiblemente cuentas USD. Acá vive la plata real. |
+| **Socio** | Cuentas bancarias propias en sus propios bancos. Independientes de Fatrans. |
+| **App Fatrans** | "Saldo virtual contable" del socio — refleja el pasivo del fondo hacia el socio. NO es retirable directamente desde la app: para retirar, admin hace transferencia desde banco del fondo al banco del socio. |
+
+**Implicación contable**: cuando el sistema dice "se depositó plata", lo que ocurrió en la realidad es una transferencia bancaria interbancaria. La cuenta DEBE entonces es **`1.1.03` Bancos Cuenta Corriente Bs** (o `1.1.05` Bancos USD), NO `1.1.01` Caja Principal (esa cuenta queda en cero o casi cero en la práctica).
+
+---
+
+# Plan de cuentas Fatrans (V21__plan_cuentas_ven_nif.sql)
+
+Solo cuentas hoja (nivel 3, `acepta_movimientos = TRUE`) pueden recibir movimientos. Las de nivel 1-2 son totalizadoras (suman las hijas).
+
+## ACTIVO (naturaleza DEUDORA, +)
+- `1.1.01` Caja Principal — efectivo en bóveda (poco uso real en Fatrans)
+- `1.1.02` Caja Chica
+- `1.1.03` **Bancos Cuenta Corriente Bs** ← cuenta operativa principal Bs
+- `1.1.04` Bancos Cuenta de Ahorro Bs
+- `1.1.05` **Bancos Cuentas USD** ← cuenta operativa USD
+- `1.2.01` Inversiones en Títulos Valores
+- `1.3.01` **Créditos Personales por Cobrar** ← cartera principal
+- `1.3.02` Créditos Hipotecarios por Cobrar
+- `1.3.03` Intereses por Cobrar sobre Créditos (devengo)
+- `1.3.99` Provisión Cartera (CR — naturaleza acreedora dentro de activo)
+- `1.4.01` Cuentas por Cobrar Asociados (no créditos)
+- `1.4.02` Cuentas por Cobrar Personal
+- `1.5.01` Mobiliario y Equipo
+- `1.5.02` Equipo de Computación
+- `1.5.03` Vehículos
+- `1.5.99` Depreciación Acumulada (CR)
+- `1.6.01` Gastos Pagados por Anticipado
+
+## PASIVO (naturaleza ACREEDORA, +)
+- `2.1.01` **Cuentas de Ahorro Bs** ← captación principal (lo que el fondo le debe al socio)
+- `2.1.02` **Cuentas de Ahorro USD**
+- `2.1.03` Depósitos a Plazo Fijo Bs
+- `2.1.04` Intereses por Pagar Captaciones
+- `2.2.01` Préstamos por Pagar Instituciones
+- `2.3.01-04` Cuentas por Pagar varias (proveedores, sueldos, aportes, impuestos)
+- `2.4.01` Provisión Prestaciones Sociales (LOTTT)
+
+## PATRIMONIO (naturaleza ACREEDORA, +)
+- `3.1.01` Aportes Sociales
+- `3.1.02` Aportes Extraordinarios
+- `3.2.01` Reserva Legal
+- `3.2.02` Reserva de Educación
+- `3.2.03` Reserva de Solidaridad
+- `3.3.01` Excedentes Acumulados
+- `3.3.02` Excedente del Ejercicio
+
+## INGRESOS (naturaleza ACREEDORA, +)
+- `4.1.01` **Intereses sobre Créditos** ← ingreso principal de la cartera
+- `4.1.02` **Comisiones por Otorgamiento** ← comisión apertura crédito
+- `4.1.03` **Intereses Moratorios** ← mora cobrada
+- `4.2.01` Rendimientos sobre Inversiones
+- `4.3.01` Aportes Especiales
+- `4.3.02` Otros Ingresos Operativos
+
+## EGRESOS (naturaleza DEUDORA, +)
+- `5.1.01` **Intereses sobre Cuentas de Ahorro** ← gasto por intereses a depositantes
+- `5.1.02` Intereses sobre Plazo Fijo
+- `5.2.01-08` Sueldos, beneficios, aportes, servicios, alquiler, materiales, depreciación, otros
+- `5.3.01` Intereses sobre Préstamos
+- `5.4.01-02` ISLR, otros impuestos
+
+## CUENTAS DE ORDEN
+- `6.1.01` Garantías Recibidas
+- `6.2.01` Garantías Otorgadas
+
+---
+
+# Reglas de oro del trabajo contable en Fatrans
+
+## Partida doble
+- **Σdebe = Σhaber** siempre. No hay excepciones.
+- Al menos 1 partida DEBE y 1 partida HABER en cada asiento.
+- Mismo monto exacto en ambos lados (escala 4 decimales — `NUMERIC(18,4)`).
+- Una partida individual tiene DEBE positivo XOR HABER positivo, nunca ambos.
+
+## Naturaleza del saldo
+Si una cuenta es **DEUDORA**: el DEBE la aumenta, el HABER la disminuye.
+Si una cuenta es **ACREEDORA**: el HABER la aumenta, el DEBE la disminuye.
+
+Reglas mnemotécnicas:
+- Activo aumenta → DEBE
+- Pasivo aumenta → HABER
+- Patrimonio aumenta → HABER
+- Ingreso (sube resultado) → HABER
+- Egreso (baja resultado) → DEBE
+
+Cuentas correctoras (ej. `1.3.99` Provisión Cartera) llevan naturaleza opuesta al rubro padre. Es esperado, no es error.
+
+## Origen del dinero ≠ Concepto contable
+Cuando un socio paga una cuota desde su banco, contablemente:
+- DEBE `1.1.03` (entró plata al banco del fondo)
+- HABER `1.3.01` (parte capital — baja la cartera)
+- HABER `4.1.01` (parte interés — es ingreso de Fatrans)
+- HABER `4.1.03` (si hay mora — ingreso diferenciado)
+
+El error común es asentar todo a una sola cuenta de ingresos. Hay que **desglosar**.
+
+## Cuentas hoja únicamente
+Solo cuentas de nivel 3 (con `acepta_movimientos = TRUE`) pueden recibir asientos. Si alguien intenta asentar contra `1.1` (grupo) o `1` (rubro), es un error y debe rechazarse.
+
+## Asientos NUNCA se borran
+Por exigencia SUDECA y por buenas prácticas auditables:
+- No hay `DELETE FROM asientos_contables` jamás.
+- Errores se corrigen con asiento INVERSO (reversión), no borrado.
+- El estado pasa de `REGISTRADO` a `ANULADO` con motivo registrado.
+- La FK de partidas tiene `ON DELETE RESTRICT`.
+
+## Correlativo continuo
+Por exigencia SUDECA: el número de asiento debe ser una secuencia continua sin huecos. Implementado via `seq_asiento_numero` (PostgreSQL SEQUENCE con CACHE 1).
+
+## Glosa obligatoria
+Cada asiento debe tener glosa que explique al lector humano qué ocurrió: "Depósito MOV-2026-000123 de socio Juan Pérez en cuenta AHO-2026-000456". Sin glosa, no es auditable.
+
+## Referencia externa
+Cada asiento debe linkear al evento de negocio que lo generó: número de movimiento, número de cuota, número de solicitud de crédito. Permite trazabilidad cruzada en auditoría.
+
+---
+
+# Decisiones contables ya tomadas (estado actual del proyecto)
+
+## EPIC #263 — Contabilidad (en progreso)
+
+### #264 ✅ Plan de cuentas VEN-NIF
+- Migration V21 con seed inicial de ~55 cuentas (nivel 1-3).
+- Tabla `plan_cuentas` con jerarquía auto-referencial.
+- Modelo `CuentaContable` inmutable con validación de regex de código.
+
+### #265 + #266 ✅ Asientos contables (PR #314 mergeado)
+- Tablas `asientos_contables` (cabecera) + `partidas_asientos` (detalle).
+- `AsientoContableService.registrar()` valida invariantes y persiste atómicamente.
+- `OrigenAsiento` enum: AHORRO_DEPOSITO, AHORRO_RETIRO, AHORRO_INTERES, CREDITO_DESEMBOLSO, CREDITO_COBRO, CREDITO_INTERES, MANUAL, CIERRE, REVERSION, AJUSTE.
+
+### #267 ⚠️ Hooks contables en Ahorros (PR #315 abierto — REQUIERE REVISIÓN)
+Mapping implementado (depósito y retiro):
+
+| Operación | Moneda | DEBE actual | HABER actual |
+|---|---|---|---|
+| Depósito | Bs | `1.1.01` Caja Principal | `2.1.01` Ahorros Bs |
+| Depósito | USD | `1.1.05` Bancos USD | `2.1.02` Ahorros USD |
+| Retiro | Bs | `2.1.01` Ahorros Bs | `1.1.01` Caja Principal |
+| Retiro | USD | `2.1.02` Ahorros USD | `1.1.05` Bancos USD |
+
+🚨 **Problema detectado en la conversación del 2026-05-20**:
+La cuenta `1.1.01` Caja Principal es INCORRECTA para Bs porque Fatrans no opera con caja física. Debería ser `1.1.03` Bancos Cuenta Corriente Bs. La cuenta USD `1.1.05` sí es correcta (es banco USD). **Pendiente: corregir en PR #315 antes de mergear o en PR de seguimiento.**
+
+### #268 🚧 Hooks contables en Créditos (próximo, en diseño)
+
+Mapping propuesto:
+
+**Desembolso de crédito (con o sin comisión apertura):**
+```
+DEBE  1.3.01 Créditos Personales por Cobrar    [monto bruto solicitado]
+HABER 1.1.03 Bancos Cuenta Corriente Bs        [monto neto desembolsado]
+HABER 4.1.02 Comisiones por Otorgamiento       [comisión apertura, si > 0]
+```
+Razón: el desembolso sale del banco del fondo (no de caja, no de cuenta de ahorro del socio). Refleja la transferencia bancaria real al banco externo del socio.
+
+**Pago de cuota:**
+```
+DEBE  1.1.03 Bancos Cuenta Corriente Bs        [monto total cobrado]
+HABER 1.3.01 Créditos por Cobrar               [capital amortizado]
+HABER 4.1.01 Intereses sobre Créditos          [intereses normales]
+HABER 4.1.03 Intereses Moratorios              [SOLO si interesMora > 0]
+```
+Razón: el pago entra al banco del fondo; capital baja la cartera (no es ingreso); intereses normales y mora son ingresos diferenciados.
+
+### Pendiente sin diseño aún
+- #269 Libro Diario (reporte de asientos por fecha + PDF SUDECA)
+- #270 Libro Mayor (saldos por cuenta)
+- #271 Balance General + Estado de Resultados (VEN-NIF)
+- #272 Cierre contable mensual/anual con bloqueo de período
+- #273 Reversión de asientos (asiento inverso, sin DELETE)
+- Rendimientos de ahorros (intereses pasivos a pagar a socios)
+
+---
+
+# Cómo reviso un mapping contable propuesto
+
+Cuando me pasan un asiento propuesto (operación → cuentas), verifico **en este orden**:
+
+1. **¿Las cuentas existen en el plan V21 y son hoja?** Si referencian `1.1` o `2.1` (totalizadoras), rechazo.
+
+2. **¿Cuadra partida doble?** Σdebe debe ser EXACTAMENTE Σhaber. Diferencias por redondeo son inaceptables.
+
+3. **¿Naturaleza correcta?** Una cuenta acreedora que recibe DEBE significa "está bajando". ¿Eso es lo que la operación realmente hace? Si la operación SUBE el saldo de una cuenta acreedora pero el mapping tiene DEBE, está al revés.
+
+4. **¿Refleja la realidad operativa?** ¿La plata realmente fluye así? Si el mapping dice DEBE Caja pero Fatrans no opera con caja, hay desconexión.
+
+5. **¿Hay desglose suficiente?** Componentes que requieren tratamiento fiscal/regulatorio distinto (capital vs intereses vs mora) deben ir a cuentas separadas. No mezclar.
+
+6. **¿Auditoría completa?** Glosa clara, origen identificable, referencia externa al evento. Sin esto, la auditoría externa lo objetará.
+
+7. **¿Atomicidad?** El asiento se genera en la misma transacción que la operación de negocio. Si la contabilidad falla, todo rollback. NO es best-effort.
+
+8. **¿Cuentas correctoras correctas?** Provisión (1.3.99) y Depreciación Acumulada (1.5.99) llevan naturaleza opuesta al rubro — esto es esperado, no error.
+
+---
+
+# Errores comunes a flaggear
+
+- ❌ Usar `1.1.01` Caja Principal para operaciones bancarias en Fatrans (debe ser `1.1.03` Bancos Bs).
+- ❌ Mezclar intereses normales con moratorios en una sola cuenta (deben ser `4.1.01` vs `4.1.03`).
+- ❌ Asentar capital como ingreso (capital baja `1.3.01`, NO entra a `4.x.x`).
+- ❌ Asientos contra cuentas no-hoja (`1.1`, `2.1`, etc).
+- ❌ Asientos sin glosa o con glosa vacía/genérica ("asiento", "operación").
+- ❌ Sin `referenciaExterna` para asientos automáticos (rompe trazabilidad).
+- ❌ `BigDecimal` con escala != 4 (BD es `NUMERIC(18,4)` — Hibernate puede truncar).
+- ❌ Hook contable fuera del `@Transactional` (rompe atomicidad — si la app crashea entre el INSERT del movimiento y el INSERT del asiento, queda inconsistente).
+- ❌ `DELETE` físico de asientos o partidas (solo ANULAR con motivo).
+- ❌ Permitir asientos en período cerrado (cuando #272 se implemente).
+
+---
+
+# Formato de mis respuestas
+
+Cuando me invocan para revisar, devuelvo:
+
+1. **Veredicto**: ✅ Aprueba / ⚠️ Aprueba con observaciones / ❌ Rechaza
+2. **Tabla del asiento propuesto vs. el que yo recomiendo** (si difieren)
+3. **Razón regulatoria** de cada cambio (qué norma o exigencia SUDECA aplica)
+4. **Casos borde** a considerar (moneda, mora, comisión, desglose, etc)
+5. **Tests que faltarían** para cubrir mi observación
+
+Soy directo y conciso. Hablo en español. No invento normas — si no estoy seguro de algo (ej. requisitos exactos de un reporte SUDECA específico), lo digo y sugiero verificar con contador colegiado.
+
+Mi rol es **proteger al sistema de errores contables silenciosos**. La contabilidad mal hecha es un riesgo regulatorio mayor que la aplicación mal hecha.

--- a/backend/src/main/java/com/tufondo/ahorros/application/port/output/AhorrosContabilidadPort.java
+++ b/backend/src/main/java/com/tufondo/ahorros/application/port/output/AhorrosContabilidadPort.java
@@ -1,0 +1,58 @@
+package com.tufondo.ahorros.application.port.output;
+
+import com.tufondo.ahorros.domain.model.CuentaAhorro;
+import com.tufondo.ahorros.domain.model.Movimiento;
+
+/**
+ * Puerto de salida que el módulo de Ahorros usa para notificar
+ * cada operación de saldo al módulo de Contabilidad.
+ *
+ * <p>Sub-issue #267 del EPIC Contabilidad #263.</p>
+ *
+ * <h2>Contrato</h2>
+ * <ul>
+ *   <li>El hook se invoca DENTRO del mismo {@code @Transactional} del use case
+ *       que mueve el saldo. Si la generación del asiento falla, la transacción
+ *       hace rollback completo (saldo no cambia, movimiento no persiste).</li>
+ *   <li>La contabilidad NO es best-effort. A diferencia de notificaciones
+ *       (email/sms), un asiento no generado significa que la operación queda
+ *       inconsistente con la BD contable — eso viola partida doble y nos
+ *       deja en riesgo regulatorio con SUDECA.</li>
+ *   <li>Las excepciones de contabilidad se propagan al caller sin envoltorio
+ *       adicional — el global exception handler las traduce a HTTP 422.</li>
+ * </ul>
+ *
+ * <h2>Mapeo conceptual</h2>
+ * <p>El adapter es responsable de mapear el evento de negocio a los códigos
+ * VEN-NIF correctos según la moneda de la cuenta. Por ejemplo:</p>
+ * <ul>
+ *   <li>Depósito Bs:  DEBE 1.1.01 (Caja Principal)        / HABER 2.1.01 (Cuentas de Ahorro Bs)</li>
+ *   <li>Depósito USD: DEBE 1.1.05 (Bancos Cuentas USD)    / HABER 2.1.02 (Cuentas de Ahorro USD)</li>
+ *   <li>Retiro Bs:    DEBE 2.1.01                          / HABER 1.1.01</li>
+ *   <li>Retiro USD:   DEBE 2.1.02                          / HABER 1.1.05</li>
+ * </ul>
+ */
+public interface AhorrosContabilidadPort {
+
+    /**
+     * Genera el asiento contable correspondiente a un depósito ya registrado.
+     *
+     * @param cuenta     cuenta destino del depósito (provee moneda y socioId)
+     * @param movimiento movimiento ya persistido (provee numeroOperacion y monto)
+     * @throws com.tufondo.contabilidad.application.exception.AsientoContableException
+     *         si alguna validación contable falla (cuenta inexistente, monto
+     *         excesivo, etc). La excepción rollback el {@code @Transactional}
+     *         del caller — la operación se aborta.
+     */
+    void registrarDeposito(CuentaAhorro cuenta, Movimiento movimiento);
+
+    /**
+     * Genera el asiento contable correspondiente a un retiro ya registrado.
+     *
+     * @param cuenta     cuenta origen del retiro
+     * @param movimiento movimiento ya persistido
+     * @throws com.tufondo.contabilidad.application.exception.AsientoContableException
+     *         si alguna validación contable falla
+     */
+    void registrarRetiro(CuentaAhorro cuenta, Movimiento movimiento);
+}

--- a/backend/src/main/java/com/tufondo/ahorros/application/usecase/RealizarDepositoUseCase.java
+++ b/backend/src/main/java/com/tufondo/ahorros/application/usecase/RealizarDepositoUseCase.java
@@ -4,6 +4,7 @@ package com.tufondo.ahorros.application.usecase;
 import com.tufondo.ahorros.application.dto.DepositoRequest;
 import com.tufondo.ahorros.application.dto.MovimientoResponse;
 import com.tufondo.ahorros.application.mapper.AhorrosDTOMapper;
+import com.tufondo.ahorros.application.port.output.AhorrosContabilidadPort;
 import com.tufondo.ahorros.domain.exception.AccesoCuentaAjenaException;
 import com.tufondo.ahorros.domain.exception.CuentaAhorroNoEncontradaException;
 import com.tufondo.ahorros.domain.exception.CuentaNoPermiteOperacionesException;
@@ -39,6 +40,7 @@ public class RealizarDepositoUseCase {
     private final MovimientoRepository movimientoRepository;
     private final AhorrosDTOMapper mapper;
     private final LocdoftOperacionService locdoftService;
+    private final AhorrosContabilidadPort contabilidadPort;
 
     @Transactional
     public MovimientoResponse ejecutar(String numeroCuenta, DepositoRequest request,
@@ -113,6 +115,12 @@ public class RealizarDepositoUseCase {
         if (consentimiento != null) {
             locdoftService.asociarConMovimiento(consentimiento.getId(), movimiento.getId());
         }
+
+        // Hook contable (#267): genera el asiento partida doble. Corre en el
+        // mismo @Transactional — si falla, rollback completo (saldo + movimiento
+        // + asiento revierten juntos). NO es best-effort: la contabilidad debe
+        // estar sincronizada con la caja por exigencia regulatoria SUDECA.
+        contabilidadPort.registrarDeposito(cuenta, movimiento);
 
         log.info("Depósito realizado: {} en cuenta {}", request.getMonto(), numeroCuenta);
         return mapper.toResponse(movimiento);

--- a/backend/src/main/java/com/tufondo/ahorros/application/usecase/RealizarRetiroUseCase.java
+++ b/backend/src/main/java/com/tufondo/ahorros/application/usecase/RealizarRetiroUseCase.java
@@ -4,6 +4,7 @@ package com.tufondo.ahorros.application.usecase;
 import com.tufondo.ahorros.application.dto.RetiroRequest;
 import com.tufondo.ahorros.application.dto.MovimientoResponse;
 import com.tufondo.ahorros.application.mapper.AhorrosDTOMapper;
+import com.tufondo.ahorros.application.port.output.AhorrosContabilidadPort;
 import com.tufondo.ahorros.domain.exception.*;
 import com.tufondo.ahorros.domain.model.CuentaAhorro;
 import com.tufondo.ahorros.domain.model.Movimiento;
@@ -38,6 +39,7 @@ public class RealizarRetiroUseCase {
     private final MovimientoRepository movimientoRepository;
     private final AhorrosDTOMapper mapper;
     private final LocdoftOperacionService locdoftService;
+    private final AhorrosContabilidadPort contabilidadPort;
 
     @Transactional
     public MovimientoResponse ejecutar(String numeroCuenta, RetiroRequest request,
@@ -119,6 +121,11 @@ public class RealizarRetiroUseCase {
         if (consentimiento != null) {
             locdoftService.asociarConMovimiento(consentimiento.getId(), movimiento.getId());
         }
+
+        // Hook contable (#267): asiento de partida doble del retiro. Mismo
+        // @Transactional → rollback completo si falla. Ver doc en
+        // AhorrosContabilidadPort.
+        contabilidadPort.registrarRetiro(cuenta, movimiento);
 
         log.info("Retiro realizado: {} de cuenta {}", request.getMonto(), numeroCuenta);
         return mapper.toResponse(movimiento);

--- a/backend/src/main/java/com/tufondo/ahorros/infrastructure/contabilidad/AhorrosContabilidadAdapter.java
+++ b/backend/src/main/java/com/tufondo/ahorros/infrastructure/contabilidad/AhorrosContabilidadAdapter.java
@@ -23,28 +23,36 @@ import java.util.List;
  * concretos del plan de cuentas — esa es información de configuración
  * que no debe contaminar el dominio de Ahorros.</p>
  *
- * <h2>Códigos VEN-NIF usados (V21)</h2>
+ * <h2>Códigos VEN-NIF usados (V21) — post decisión D-002 (2026-05-20)</h2>
  * <table>
  *   <tr><th>Operación</th><th>Moneda</th><th>DEBE</th><th>HABER</th></tr>
- *   <tr><td>Depósito</td><td>VES</td><td>1.1.01 Caja Principal</td><td>2.1.01 Cuentas de Ahorro Bs</td></tr>
+ *   <tr><td>Depósito</td><td>VES</td><td>1.1.03 Bancos Cta Corriente Bs</td><td>2.1.01 Cuentas de Ahorro Bs</td></tr>
  *   <tr><td>Depósito</td><td>USD</td><td>1.1.05 Bancos Cuentas USD</td><td>2.1.02 Cuentas de Ahorro USD</td></tr>
- *   <tr><td>Retiro</td><td>VES</td><td>2.1.01 Cuentas de Ahorro Bs</td><td>1.1.01 Caja Principal</td></tr>
+ *   <tr><td>Retiro</td><td>VES</td><td>2.1.01 Cuentas de Ahorro Bs</td><td>1.1.03 Bancos Cta Corriente Bs</td></tr>
  *   <tr><td>Retiro</td><td>USD</td><td>2.1.02 Cuentas de Ahorro USD</td><td>1.1.05 Bancos Cuentas USD</td></tr>
  * </table>
  *
- * <p><strong>Razón del mapeo:</strong> un depósito incrementa Caja/Banco (Activo,
+ * <p><strong>Razón del mapeo:</strong> un depósito incrementa Bancos (Activo,
  * naturaleza deudora → DEBE) y simultáneamente incrementa la obligación con
  * el socio (Pasivo, naturaleza acreedora → HABER). El retiro es el espejo.</p>
+ *
+ * <p><strong>Por qué Bancos (1.1.03) y no Caja Principal (1.1.01)</strong>: Fatrans
+ * no opera con caja física relevante — todo se mueve por transferencia bancaria
+ * interbancaria. Asentar a Caja distorsionaría la conciliación bancaria y el
+ * rubro Disponible, violando VEN-NIF NIC-1 (presentación razonable). Decisión
+ * D-002 — ver {@code docs/modulos/contabilidad/_decisiones-contables.md}.</p>
  */
 @Component
 @Slf4j
 @RequiredArgsConstructor
 public class AhorrosContabilidadAdapter implements AhorrosContabilidadPort {
 
-    // ─── Códigos del plan de cuentas (V21) ─────────────────────────────────
+    // ─── Códigos del plan de cuentas (V21) — post D-002 ────────────────────
     // Si el plan cambia, se actualiza acá. Son las únicas constantes que
     // acoplan Ahorros con el plan contable.
-    static final String CUENTA_CAJA_BS         = "1.1.01";
+    // Nota: usamos 1.1.03 Bancos Cta Corriente Bs (NO 1.1.01 Caja Principal)
+    // porque Fatrans opera por transferencia bancaria, no con efectivo.
+    static final String CUENTA_BANCO_BS        = "1.1.03";
     static final String CUENTA_BANCO_USD       = "1.1.05";
     static final String CUENTA_DEPOSITOS_BS    = "2.1.01";
     static final String CUENTA_DEPOSITOS_USD   = "2.1.02";
@@ -66,12 +74,12 @@ public class AhorrosContabilidadAdapter implements AhorrosContabilidadPort {
                 .creadoPorUsuarioId(null) // automático del sistema
                 .asientoReversaId(null)
                 .partidas(List.of(
-                        // DEBE: aumenta el activo (caja o banco)
+                        // DEBE: aumenta el activo (bancos del fondo)
                         RegistrarAsientoCommand.Partida.builder()
                                 .codigoCuenta(cuentaActivo)
                                 .debe(monto)
                                 .haber(null)
-                                .glosa("Ingreso de efectivo del socio")
+                                .glosa("Ingreso por transferencia del socio")
                                 .build(),
                         // HABER: aumenta la obligación con el socio
                         RegistrarAsientoCommand.Partida.builder()
@@ -110,12 +118,12 @@ public class AhorrosContabilidadAdapter implements AhorrosContabilidadPort {
                                 .haber(null)
                                 .glosa("Débito en cuenta de ahorro")
                                 .build(),
-                        // HABER: disminuye el activo (sale efectivo)
+                        // HABER: disminuye el activo (sale transferencia al socio)
                         RegistrarAsientoCommand.Partida.builder()
                                 .codigoCuenta(cuentaActivo)
                                 .debe(null)
                                 .haber(monto)
-                                .glosa("Egreso de efectivo al socio")
+                                .glosa("Egreso por transferencia al socio")
                                 .build()
                 ))
                 .build();
@@ -127,15 +135,15 @@ public class AhorrosContabilidadAdapter implements AhorrosContabilidadPort {
 
     // ─── Helpers de mapeo ──────────────────────────────────────────────────
 
-    /** Cuenta de activo (caja/banco) según la moneda de la cuenta de ahorro. */
+    /** Cuenta de activo (bancos del fondo) según la moneda de la cuenta de ahorro. */
     private static String cuentaActivoPorMoneda(Moneda moneda) {
         if (moneda == null) {
             // default histórico: cuentas creadas antes del enum se asumen Bs.
             // Si esto se vuelve común, vale la pena un constraint NOT NULL en BD.
-            return CUENTA_CAJA_BS;
+            return CUENTA_BANCO_BS;
         }
         return switch (moneda) {
-            case VES -> CUENTA_CAJA_BS;
+            case VES -> CUENTA_BANCO_BS;
             case USD -> CUENTA_BANCO_USD;
         };
     }

--- a/backend/src/main/java/com/tufondo/ahorros/infrastructure/contabilidad/AhorrosContabilidadAdapter.java
+++ b/backend/src/main/java/com/tufondo/ahorros/infrastructure/contabilidad/AhorrosContabilidadAdapter.java
@@ -1,0 +1,151 @@
+package com.tufondo.ahorros.infrastructure.contabilidad;
+
+import com.tufondo.ahorros.application.port.output.AhorrosContabilidadPort;
+import com.tufondo.ahorros.domain.model.CuentaAhorro;
+import com.tufondo.ahorros.domain.model.Movimiento;
+import com.tufondo.ahorros.domain.model.enums.Moneda;
+import com.tufondo.contabilidad.application.dto.RegistrarAsientoCommand;
+import com.tufondo.contabilidad.application.usecase.AsientoContableService;
+import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Adapter que materializa cada operación de Ahorros como un asiento contable.
+ *
+ * <p>Implementación de {@link AhorrosContabilidadPort}. Vive en
+ * {@code infrastructure/contabilidad} porque conoce los códigos VEN-NIF
+ * concretos del plan de cuentas — esa es información de configuración
+ * que no debe contaminar el dominio de Ahorros.</p>
+ *
+ * <h2>Códigos VEN-NIF usados (V21)</h2>
+ * <table>
+ *   <tr><th>Operación</th><th>Moneda</th><th>DEBE</th><th>HABER</th></tr>
+ *   <tr><td>Depósito</td><td>VES</td><td>1.1.01 Caja Principal</td><td>2.1.01 Cuentas de Ahorro Bs</td></tr>
+ *   <tr><td>Depósito</td><td>USD</td><td>1.1.05 Bancos Cuentas USD</td><td>2.1.02 Cuentas de Ahorro USD</td></tr>
+ *   <tr><td>Retiro</td><td>VES</td><td>2.1.01 Cuentas de Ahorro Bs</td><td>1.1.01 Caja Principal</td></tr>
+ *   <tr><td>Retiro</td><td>USD</td><td>2.1.02 Cuentas de Ahorro USD</td><td>1.1.05 Bancos Cuentas USD</td></tr>
+ * </table>
+ *
+ * <p><strong>Razón del mapeo:</strong> un depósito incrementa Caja/Banco (Activo,
+ * naturaleza deudora → DEBE) y simultáneamente incrementa la obligación con
+ * el socio (Pasivo, naturaleza acreedora → HABER). El retiro es el espejo.</p>
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class AhorrosContabilidadAdapter implements AhorrosContabilidadPort {
+
+    // ─── Códigos del plan de cuentas (V21) ─────────────────────────────────
+    // Si el plan cambia, se actualiza acá. Son las únicas constantes que
+    // acoplan Ahorros con el plan contable.
+    static final String CUENTA_CAJA_BS         = "1.1.01";
+    static final String CUENTA_BANCO_USD       = "1.1.05";
+    static final String CUENTA_DEPOSITOS_BS    = "2.1.01";
+    static final String CUENTA_DEPOSITOS_USD   = "2.1.02";
+
+    private final AsientoContableService asientoContableService;
+
+    @Override
+    public void registrarDeposito(CuentaAhorro cuenta, Movimiento movimiento) {
+        String cuentaActivo  = cuentaActivoPorMoneda(cuenta.getMoneda());
+        String cuentaPasivo  = cuentaDepositosPorMoneda(cuenta.getMoneda());
+        BigDecimal monto     = movimiento.getMonto();
+
+        RegistrarAsientoCommand cmd = RegistrarAsientoCommand.builder()
+                .fechaContable(LocalDate.now())
+                .glosa(String.format("Depósito %s en cuenta %s",
+                        movimiento.getNumeroOperacion(), cuenta.getNumeroCuenta()))
+                .origen(OrigenAsiento.AHORRO_DEPOSITO)
+                .referenciaExterna(movimiento.getNumeroOperacion())
+                .creadoPorUsuarioId(null) // automático del sistema
+                .asientoReversaId(null)
+                .partidas(List.of(
+                        // DEBE: aumenta el activo (caja o banco)
+                        RegistrarAsientoCommand.Partida.builder()
+                                .codigoCuenta(cuentaActivo)
+                                .debe(monto)
+                                .haber(null)
+                                .glosa("Ingreso de efectivo del socio")
+                                .build(),
+                        // HABER: aumenta la obligación con el socio
+                        RegistrarAsientoCommand.Partida.builder()
+                                .codigoCuenta(cuentaPasivo)
+                                .debe(null)
+                                .haber(monto)
+                                .glosa("Crédito en cuenta de ahorro")
+                                .build()
+                ))
+                .build();
+
+        asientoContableService.registrar(cmd);
+        log.debug("Asiento de depósito generado: cuenta={} movimiento={} monto={}",
+                cuenta.getNumeroCuenta(), movimiento.getNumeroOperacion(), monto);
+    }
+
+    @Override
+    public void registrarRetiro(CuentaAhorro cuenta, Movimiento movimiento) {
+        String cuentaActivo  = cuentaActivoPorMoneda(cuenta.getMoneda());
+        String cuentaPasivo  = cuentaDepositosPorMoneda(cuenta.getMoneda());
+        BigDecimal monto     = movimiento.getMonto();
+
+        RegistrarAsientoCommand cmd = RegistrarAsientoCommand.builder()
+                .fechaContable(LocalDate.now())
+                .glosa(String.format("Retiro %s de cuenta %s",
+                        movimiento.getNumeroOperacion(), cuenta.getNumeroCuenta()))
+                .origen(OrigenAsiento.AHORRO_RETIRO)
+                .referenciaExterna(movimiento.getNumeroOperacion())
+                .creadoPorUsuarioId(null)
+                .asientoReversaId(null)
+                .partidas(List.of(
+                        // DEBE: disminuye la obligación con el socio
+                        RegistrarAsientoCommand.Partida.builder()
+                                .codigoCuenta(cuentaPasivo)
+                                .debe(monto)
+                                .haber(null)
+                                .glosa("Débito en cuenta de ahorro")
+                                .build(),
+                        // HABER: disminuye el activo (sale efectivo)
+                        RegistrarAsientoCommand.Partida.builder()
+                                .codigoCuenta(cuentaActivo)
+                                .debe(null)
+                                .haber(monto)
+                                .glosa("Egreso de efectivo al socio")
+                                .build()
+                ))
+                .build();
+
+        asientoContableService.registrar(cmd);
+        log.debug("Asiento de retiro generado: cuenta={} movimiento={} monto={}",
+                cuenta.getNumeroCuenta(), movimiento.getNumeroOperacion(), monto);
+    }
+
+    // ─── Helpers de mapeo ──────────────────────────────────────────────────
+
+    /** Cuenta de activo (caja/banco) según la moneda de la cuenta de ahorro. */
+    private static String cuentaActivoPorMoneda(Moneda moneda) {
+        if (moneda == null) {
+            // default histórico: cuentas creadas antes del enum se asumen Bs.
+            // Si esto se vuelve común, vale la pena un constraint NOT NULL en BD.
+            return CUENTA_CAJA_BS;
+        }
+        return switch (moneda) {
+            case VES -> CUENTA_CAJA_BS;
+            case USD -> CUENTA_BANCO_USD;
+        };
+    }
+
+    /** Cuenta de pasivo (captación de socios) según moneda. */
+    private static String cuentaDepositosPorMoneda(Moneda moneda) {
+        if (moneda == null) return CUENTA_DEPOSITOS_BS;
+        return switch (moneda) {
+            case VES -> CUENTA_DEPOSITOS_BS;
+            case USD -> CUENTA_DEPOSITOS_USD;
+        };
+    }
+}

--- a/backend/src/test/java/com/tufondo/ahorros/application/usecase/RealizarDepositoUseCaseTest.java
+++ b/backend/src/test/java/com/tufondo/ahorros/application/usecase/RealizarDepositoUseCaseTest.java
@@ -1,0 +1,182 @@
+package com.tufondo.ahorros.application.usecase;
+
+import com.tufondo.ahorros.application.dto.DepositoRequest;
+import com.tufondo.ahorros.application.dto.MovimientoResponse;
+import com.tufondo.ahorros.application.mapper.AhorrosDTOMapper;
+import com.tufondo.ahorros.application.port.output.AhorrosContabilidadPort;
+import com.tufondo.ahorros.domain.exception.AccesoCuentaAjenaException;
+import com.tufondo.ahorros.domain.exception.CuentaAhorroNoEncontradaException;
+import com.tufondo.ahorros.domain.exception.CuentaNoPermiteOperacionesException;
+import com.tufondo.ahorros.domain.model.CuentaAhorro;
+import com.tufondo.ahorros.domain.model.Movimiento;
+import com.tufondo.ahorros.domain.model.enums.CanalOrigen;
+import com.tufondo.ahorros.domain.model.enums.EstadoCuenta;
+import com.tufondo.ahorros.domain.model.enums.Moneda;
+import com.tufondo.ahorros.domain.repository.CuentaAhorroRepository;
+import com.tufondo.ahorros.domain.repository.MovimientoRepository;
+import com.tufondo.compliance.application.service.LocdoftOperacionService;
+import com.tufondo.contabilidad.application.exception.AsientoContableException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests del use case de depósito incluyendo el hook contable (#267).
+ *
+ * <p>Foco: validar que cada depósito exitoso invoque al hook contable y
+ * que cuando el hook lanza, el use case propaga la excepción (para que
+ * el {@code @Transactional} haga rollback de saldo + movimiento + asiento).</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class RealizarDepositoUseCaseTest {
+
+    @Mock private CuentaAhorroRepository cuentaRepository;
+    @Mock private MovimientoRepository movimientoRepository;
+    @Mock private AhorrosDTOMapper mapper;
+    @Mock private LocdoftOperacionService locdoftService;
+    @Mock private AhorrosContabilidadPort contabilidadPort;
+
+    @InjectMocks private RealizarDepositoUseCase useCase;
+
+    private UUID socioId;
+    private CuentaAhorro cuentaActiva;
+    private DepositoRequest request;
+
+    @BeforeEach
+    void setUp() {
+        socioId = UUID.randomUUID();
+        cuentaActiva = CuentaAhorro.builder()
+                .id(UUID.randomUUID())
+                .numeroCuenta("AHO-2026-000001")
+                .socioId(socioId)
+                .saldoActual(new BigDecimal("500.00"))
+                .saldoRetenido(BigDecimal.ZERO)
+                .estado(EstadoCuenta.ACTIVA)
+                .moneda(Moneda.VES)
+                .build();
+
+        request = new DepositoRequest(
+                new BigDecimal("100.00"),  // monto
+                "Depósito de prueba",
+                "REF-001",
+                CanalOrigen.WEB,
+                null,  // confirmaOrigenLicito
+                null   // origenFondos
+        );
+
+        // Mocks por defecto — happy path. Lenient porque algunos tests cortan
+        // antes (IDOR, cuenta cerrada, etc) y no usan estos stubs.
+        lenient().when(cuentaRepository.buscarPorNumeroCuenta("AHO-2026-000001"))
+                .thenReturn(Optional.of(cuentaActiva));
+        lenient().when(movimientoRepository.existePorNumeroOperacion(any())).thenReturn(false);
+        lenient().when(movimientoRepository.guardar(any())).thenAnswer(inv -> {
+            Movimiento m = inv.getArgument(0);
+            return Movimiento.builder()
+                    .id(UUID.randomUUID())
+                    .numeroOperacion(m.getNumeroOperacion())
+                    .cuentaAhorroId(m.getCuentaAhorroId())
+                    .socioId(m.getSocioId())
+                    .tipo(m.getTipo())
+                    .monto(m.getMonto())
+                    .saldoAnterior(m.getSaldoAnterior())
+                    .saldoPosterior(m.getSaldoPosterior())
+                    .build();
+        });
+        lenient().when(mapper.toResponse(any(Movimiento.class)))
+                .thenReturn(MovimientoResponse.builder().build());
+    }
+
+    // ─── Happy path ────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("depósito válido invoca al hook contable con cuenta y movimiento")
+    void deposito_invoca_hook_contable() {
+        useCase.ejecutar("AHO-2026-000001", request, socioId, false, "1.1.1.1", "sess", "req");
+
+        verify(contabilidadPort).registrarDeposito(eq(cuentaActiva), any(Movimiento.class));
+        verify(movimientoRepository).guardar(any(Movimiento.class));
+        verify(cuentaRepository).guardar(cuentaActiva);
+    }
+
+    @Test
+    @DisplayName("saldo se incrementa con el monto del depósito")
+    void deposito_incrementa_saldo() {
+        useCase.ejecutar("AHO-2026-000001", request, socioId, false, "1.1.1.1", "sess", "req");
+
+        assertThat(cuentaActiva.getSaldoActual()).isEqualByComparingTo("600.00");
+    }
+
+    // ─── Propagación de errores del hook contable ──────────────────────────
+
+    @Test
+    @DisplayName("si el hook contable falla, la excepción se propaga (rollback)")
+    void error_contable_propaga_para_rollback() {
+        doThrow(new AsientoContableException("plan de cuentas no inicializado"))
+                .when(contabilidadPort).registrarDeposito(any(), any());
+
+        assertThatThrownBy(() -> useCase.ejecutar(
+                "AHO-2026-000001", request, socioId, false, "1.1.1.1", "sess", "req"))
+                .isInstanceOf(AsientoContableException.class)
+                .hasMessageContaining("plan de cuentas");
+    }
+
+    @Test
+    @DisplayName("si la cuenta no existe, NO se llama al hook contable")
+    void cuenta_inexistente_no_llama_hook() {
+        when(cuentaRepository.buscarPorNumeroCuenta("AHO-INVALID"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.ejecutar(
+                "AHO-INVALID", request, socioId, false, "1.1.1.1", "sess", "req"))
+                .isInstanceOf(CuentaAhorroNoEncontradaException.class);
+
+        verifyNoInteractions(contabilidadPort);
+    }
+
+    @Test
+    @DisplayName("IDOR: socio intentando depositar en cuenta ajena NO llega al hook")
+    void idor_no_llega_a_contabilidad() {
+        UUID otroSocio = UUID.randomUUID();
+
+        assertThatThrownBy(() -> useCase.ejecutar(
+                "AHO-2026-000001", request, otroSocio, false, "1.1.1.1", "sess", "req"))
+                .isInstanceOf(AccesoCuentaAjenaException.class);
+
+        verifyNoInteractions(contabilidadPort);
+    }
+
+    @Test
+    @DisplayName("cuenta CERRADA: lanza antes de contabilidad")
+    void cuenta_cerrada_no_llega_a_contabilidad() {
+        CuentaAhorro cerrada = CuentaAhorro.builder()
+                .id(cuentaActiva.getId())
+                .numeroCuenta("AHO-2026-000001")
+                .socioId(socioId)
+                .saldoActual(BigDecimal.ZERO)
+                .estado(EstadoCuenta.CERRADA)
+                .moneda(Moneda.VES)
+                .build();
+        when(cuentaRepository.buscarPorNumeroCuenta("AHO-2026-000001"))
+                .thenReturn(Optional.of(cerrada));
+
+        assertThatThrownBy(() -> useCase.ejecutar(
+                "AHO-2026-000001", request, socioId, false, "1.1.1.1", "sess", "req"))
+                .isInstanceOf(CuentaNoPermiteOperacionesException.class);
+
+        verifyNoInteractions(contabilidadPort);
+    }
+}

--- a/backend/src/test/java/com/tufondo/ahorros/application/usecase/RealizarRetiroUseCaseTest.java
+++ b/backend/src/test/java/com/tufondo/ahorros/application/usecase/RealizarRetiroUseCaseTest.java
@@ -1,0 +1,194 @@
+package com.tufondo.ahorros.application.usecase;
+
+import com.tufondo.ahorros.application.dto.RetiroRequest;
+import com.tufondo.ahorros.application.dto.MovimientoResponse;
+import com.tufondo.ahorros.application.mapper.AhorrosDTOMapper;
+import com.tufondo.ahorros.application.port.output.AhorrosContabilidadPort;
+import com.tufondo.ahorros.domain.exception.AccesoCuentaAjenaException;
+import com.tufondo.ahorros.domain.exception.CuentaAhorroNoEncontradaException;
+import com.tufondo.ahorros.domain.exception.CuentaNoPermiteOperacionesException;
+import com.tufondo.ahorros.domain.exception.SaldoInsuficienteException;
+import com.tufondo.ahorros.domain.model.CuentaAhorro;
+import com.tufondo.ahorros.domain.model.Movimiento;
+import com.tufondo.ahorros.domain.model.enums.CanalOrigen;
+import com.tufondo.ahorros.domain.model.enums.EstadoCuenta;
+import com.tufondo.ahorros.domain.model.enums.Moneda;
+import com.tufondo.ahorros.domain.repository.CuentaAhorroRepository;
+import com.tufondo.ahorros.domain.repository.MovimientoRepository;
+import com.tufondo.compliance.application.service.LocdoftOperacionService;
+import com.tufondo.contabilidad.application.exception.AsientoContableException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests del use case de retiro incluyendo el hook contable (#267).
+ */
+@ExtendWith(MockitoExtension.class)
+class RealizarRetiroUseCaseTest {
+
+    @Mock private CuentaAhorroRepository cuentaRepository;
+    @Mock private MovimientoRepository movimientoRepository;
+    @Mock private AhorrosDTOMapper mapper;
+    @Mock private LocdoftOperacionService locdoftService;
+    @Mock private AhorrosContabilidadPort contabilidadPort;
+
+    @InjectMocks private RealizarRetiroUseCase useCase;
+
+    private UUID socioId;
+    private CuentaAhorro cuentaActiva;
+    private RetiroRequest request;
+
+    @BeforeEach
+    void setUp() {
+        socioId = UUID.randomUUID();
+        cuentaActiva = CuentaAhorro.builder()
+                .id(UUID.randomUUID())
+                .numeroCuenta("AHO-2026-000010")
+                .socioId(socioId)
+                .saldoActual(new BigDecimal("1000.00"))
+                .saldoRetenido(BigDecimal.ZERO)
+                .estado(EstadoCuenta.ACTIVA)
+                .moneda(Moneda.VES)
+                .build();
+
+        request = new RetiroRequest(
+                new BigDecimal("200.00"),
+                CanalOrigen.WEB,
+                null,
+                null
+        );
+
+        // Mocks por defecto — happy path. Lenient: algunos tests cortan antes
+        // (IDOR, saldo insuficiente, cuenta cerrada) y no usan estos stubs.
+        lenient().when(cuentaRepository.buscarPorNumeroCuenta("AHO-2026-000010"))
+                .thenReturn(Optional.of(cuentaActiva));
+        lenient().when(movimientoRepository.sumRetirosDelDiaPorSocio(any(UUID.class), any(LocalDateTime.class)))
+                .thenReturn(BigDecimal.ZERO);
+        lenient().when(movimientoRepository.existePorNumeroOperacion(any())).thenReturn(false);
+        lenient().when(movimientoRepository.guardar(any())).thenAnswer(inv -> {
+            Movimiento m = inv.getArgument(0);
+            return Movimiento.builder()
+                    .id(UUID.randomUUID())
+                    .numeroOperacion(m.getNumeroOperacion())
+                    .cuentaAhorroId(m.getCuentaAhorroId())
+                    .socioId(m.getSocioId())
+                    .tipo(m.getTipo())
+                    .monto(m.getMonto())
+                    .saldoAnterior(m.getSaldoAnterior())
+                    .saldoPosterior(m.getSaldoPosterior())
+                    .build();
+        });
+        lenient().when(mapper.toResponse(any(Movimiento.class)))
+                .thenReturn(MovimientoResponse.builder().build());
+    }
+
+    // ─── Happy path ────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("retiro válido invoca al hook contable")
+    void retiro_invoca_hook_contable() {
+        useCase.ejecutar("AHO-2026-000010", request, socioId, false, "1.1.1.1", "sess", "req");
+
+        verify(contabilidadPort).registrarRetiro(eq(cuentaActiva), any(Movimiento.class));
+        verify(movimientoRepository).guardar(any(Movimiento.class));
+    }
+
+    @Test
+    @DisplayName("saldo se reduce con el monto del retiro")
+    void retiro_reduce_saldo() {
+        useCase.ejecutar("AHO-2026-000010", request, socioId, false, "1.1.1.1", "sess", "req");
+
+        assertThat(cuentaActiva.getSaldoActual()).isEqualByComparingTo("800.00");
+    }
+
+    // ─── Validaciones que cortan ANTES del hook ────────────────────────────
+
+    @Test
+    @DisplayName("saldo insuficiente: NO se llega al hook contable")
+    void saldo_insuficiente_no_llega_a_hook() {
+        request.setMonto(new BigDecimal("5000.00")); // mayor al saldo de 1000
+
+        assertThatThrownBy(() -> useCase.ejecutar(
+                "AHO-2026-000010", request, socioId, false, "1.1.1.1", "sess", "req"))
+                .isInstanceOf(SaldoInsuficienteException.class);
+
+        verifyNoInteractions(contabilidadPort);
+        verify(cuentaRepository, never()).guardar(any());
+    }
+
+    @Test
+    @DisplayName("cuenta inexistente: NO se llama al hook")
+    void cuenta_inexistente_no_llama_hook() {
+        when(cuentaRepository.buscarPorNumeroCuenta("AHO-INVALID"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.ejecutar(
+                "AHO-INVALID", request, socioId, false, "1.1.1.1", "sess", "req"))
+                .isInstanceOf(CuentaAhorroNoEncontradaException.class);
+
+        verifyNoInteractions(contabilidadPort);
+    }
+
+    @Test
+    @DisplayName("IDOR: socio ajeno NO llega al hook")
+    void idor_no_llega_a_hook() {
+        UUID otroSocio = UUID.randomUUID();
+
+        assertThatThrownBy(() -> useCase.ejecutar(
+                "AHO-2026-000010", request, otroSocio, false, "1.1.1.1", "sess", "req"))
+                .isInstanceOf(AccesoCuentaAjenaException.class);
+
+        verifyNoInteractions(contabilidadPort);
+    }
+
+    @Test
+    @DisplayName("cuenta CERRADA: NO llega al hook")
+    void cuenta_cerrada_no_llega_a_hook() {
+        CuentaAhorro cerrada = CuentaAhorro.builder()
+                .id(cuentaActiva.getId())
+                .numeroCuenta("AHO-2026-000010")
+                .socioId(socioId)
+                .saldoActual(BigDecimal.ZERO)
+                .estado(EstadoCuenta.CERRADA)
+                .moneda(Moneda.VES)
+                .build();
+        when(cuentaRepository.buscarPorNumeroCuenta("AHO-2026-000010"))
+                .thenReturn(Optional.of(cerrada));
+
+        assertThatThrownBy(() -> useCase.ejecutar(
+                "AHO-2026-000010", request, socioId, false, "1.1.1.1", "sess", "req"))
+                .isInstanceOf(CuentaNoPermiteOperacionesException.class);
+
+        verifyNoInteractions(contabilidadPort);
+    }
+
+    // ─── Propagación de errores del hook ───────────────────────────────────
+
+    @Test
+    @DisplayName("si el hook contable lanza, se propaga (rollback)")
+    void error_contable_propaga() {
+        doThrow(new AsientoContableException("código 2.1.01 no existe"))
+                .when(contabilidadPort).registrarRetiro(any(), any());
+
+        assertThatThrownBy(() -> useCase.ejecutar(
+                "AHO-2026-000010", request, socioId, false, "1.1.1.1", "sess", "req"))
+                .isInstanceOf(AsientoContableException.class)
+                .hasMessageContaining("2.1.01");
+    }
+}

--- a/backend/src/test/java/com/tufondo/ahorros/infrastructure/contabilidad/AhorrosContabilidadAdapterIntegrationTest.java
+++ b/backend/src/test/java/com/tufondo/ahorros/infrastructure/contabilidad/AhorrosContabilidadAdapterIntegrationTest.java
@@ -45,8 +45,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * <p><strong>Lo que cubre:</strong></p>
  * <ul>
- *   <li>Depósito Bs end-to-end → asiento persistido con DEBE 1.1.01 / HABER 2.1.01</li>
- *   <li>Retiro Bs end-to-end → asiento persistido con DEBE 2.1.01 / HABER 1.1.01</li>
+ *   <li>Depósito Bs end-to-end → asiento persistido con DEBE 1.1.03 / HABER 2.1.01</li>
+ *   <li>Retiro Bs end-to-end → asiento persistido con DEBE 2.1.01 / HABER 1.1.03</li>
  *   <li>Depósito USD usa cuentas 1.1.05 / 2.1.02</li>
  *   <li>Cuenta contable inexistente → AsientoContableException (defensa contra
  *       desincronización entre plan y código del adapter)</li>
@@ -75,7 +75,8 @@ class AhorrosContabilidadAdapterIntegrationTest {
     @Autowired private CuentaContableRepositoryImpl cuentaRepoAdapter;
     @Autowired private EntityManager em;
 
-    private UUID cajaId, bancoUsdId, depositosBsId, depositosUsdId;
+    private UUID bancoBsId, bancoUsdId, depositosBsId, depositosUsdId;
+    // (bancoBsId apunta a "1.1.03 Bancos Cta Corriente Bs" — antes era cajaId 1.1.01 pre D-002)
 
     @BeforeEach
     void setUp() {
@@ -95,7 +96,8 @@ class AhorrosContabilidadAdapterIntegrationTest {
                 TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, null, false);
         UUID grupoDisponible = persistirCuenta("1.1", "DISPONIBLE",
                 TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, rubroActivo, false);
-        cajaId = persistirCuenta("1.1.01", "Caja Principal",
+        // Post D-002: usar 1.1.03 Bancos Cta Corriente Bs (NO 1.1.01 Caja).
+        bancoBsId = persistirCuenta("1.1.03", "Bancos Cuenta Corriente Bs",
                 TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, grupoDisponible, true);
         bancoUsdId = persistirCuenta("1.1.05", "Bancos USD",
                 TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, grupoDisponible, true);
@@ -113,7 +115,7 @@ class AhorrosContabilidadAdapterIntegrationTest {
     // ─── Depósito ──────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("E2E depósito Bs: asiento persistido con DEBE 1.1.01 / HABER 2.1.01")
+    @DisplayName("E2E depósito Bs: asiento persistido con DEBE 1.1.03 / HABER 2.1.01")
     void e2e_deposito_bs() {
         CuentaAhorro cuenta = cuentaBs("AHO-2026-000001");
         Movimiento mov = movimientoConMonto("MOV-2026-000001", "1500.00");
@@ -136,7 +138,7 @@ class AhorrosContabilidadAdapterIntegrationTest {
         PartidaAsiento haber = asiento.getPartidas().stream()
                 .filter(PartidaAsiento::esDeHaber).findFirst().orElseThrow();
 
-        assertThat(debe.getCuentaId()).isEqualTo(cajaId);
+        assertThat(debe.getCuentaId()).isEqualTo(bancoBsId);
         assertThat(debe.getDebe()).isEqualByComparingTo("1500.00");
         assertThat(haber.getCuentaId()).isEqualTo(depositosBsId);
         assertThat(haber.getHaber()).isEqualByComparingTo("1500.00");
@@ -163,7 +165,7 @@ class AhorrosContabilidadAdapterIntegrationTest {
     // ─── Retiro ────────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("E2E retiro Bs: asiento con DEBE 2.1.01 / HABER 1.1.01 (espejo del depósito)")
+    @DisplayName("E2E retiro Bs: asiento con DEBE 2.1.01 / HABER 1.1.03 (espejo del depósito)")
     void e2e_retiro_bs() {
         CuentaAhorro cuenta = cuentaBs("AHO-2026-000010");
         Movimiento mov = movimientoConMonto("MOV-2026-000200", "300.00");
@@ -179,7 +181,7 @@ class AhorrosContabilidadAdapterIntegrationTest {
         PartidaAsiento haber = asiento.getPartidas().stream()
                 .filter(PartidaAsiento::esDeHaber).findFirst().orElseThrow();
         assertThat(debe.getCuentaId()).isEqualTo(depositosBsId);
-        assertThat(haber.getCuentaId()).isEqualTo(cajaId);
+        assertThat(haber.getCuentaId()).isEqualTo(bancoBsId);
     }
 
     // ─── Casos negativos ────────────────────────────────────────────────────
@@ -187,8 +189,8 @@ class AhorrosContabilidadAdapterIntegrationTest {
     @Test
     @DisplayName("E2E error: cuenta contable inexistente → AsientoContableException")
     void e2e_error_cuenta_inexistente() {
-        // Borramos 1.1.01 para forzar el error
-        cuentaJpa.deleteById(cajaId);
+        // Borramos 1.1.03 para forzar el error (post D-002: el adapter usa Bancos Bs).
+        cuentaJpa.deleteById(bancoBsId);
         em.flush();
 
         CuentaAhorro cuenta = cuentaBs("AHO-2026-X");
@@ -196,7 +198,7 @@ class AhorrosContabilidadAdapterIntegrationTest {
 
         assertThatThrownBy(() -> adapter.registrarDeposito(cuenta, mov))
                 .isInstanceOf(AsientoContableException.class)
-                .hasMessageContaining("1.1.01");
+                .hasMessageContaining("1.1.03");
     }
 
     @Test

--- a/backend/src/test/java/com/tufondo/ahorros/infrastructure/contabilidad/AhorrosContabilidadAdapterIntegrationTest.java
+++ b/backend/src/test/java/com/tufondo/ahorros/infrastructure/contabilidad/AhorrosContabilidadAdapterIntegrationTest.java
@@ -1,0 +1,249 @@
+package com.tufondo.ahorros.infrastructure.contabilidad;
+
+import com.tufondo.ahorros.domain.model.CuentaAhorro;
+import com.tufondo.ahorros.domain.model.Movimiento;
+import com.tufondo.ahorros.domain.model.enums.Moneda;
+import com.tufondo.contabilidad.application.exception.AsientoContableException;
+import com.tufondo.contabilidad.application.usecase.AsientoContableService;
+import com.tufondo.contabilidad.domain.model.AsientoContable;
+import com.tufondo.contabilidad.domain.model.CuentaContable;
+import com.tufondo.contabilidad.domain.model.PartidaAsiento;
+import com.tufondo.contabilidad.domain.model.enums.EstadoAsiento;
+import com.tufondo.contabilidad.domain.model.enums.NaturalezaSaldo;
+import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
+import com.tufondo.contabilidad.domain.model.enums.TipoCuentaContable;
+import com.tufondo.contabilidad.domain.repository.AsientoContableRepository;
+import com.tufondo.contabilidad.infrastructure.persistence.adapter.AsientoContableRepositoryImpl;
+import com.tufondo.contabilidad.infrastructure.persistence.adapter.CuentaContableRepositoryImpl;
+import com.tufondo.contabilidad.infrastructure.persistence.jpa.AsientoContableJpaRepository;
+import com.tufondo.contabilidad.infrastructure.persistence.jpa.CuentaContableJpaRepository;
+import com.tufondo.contabilidad.infrastructure.persistence.jpa.PartidaAsientoJpaRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Test de integración E2E del hook contable de Ahorros (sub-issue #267).
+ *
+ * <p>Arranca el contexto JPA mínimo: el adapter real
+ * {@link AhorrosContabilidadAdapter} delega al {@link AsientoContableService}
+ * real, que persiste vía {@link AsientoContableRepositoryImpl} contra H2 (modo
+ * PostgreSQL).</p>
+ *
+ * <p><strong>Lo que cubre:</strong></p>
+ * <ul>
+ *   <li>Depósito Bs end-to-end → asiento persistido con DEBE 1.1.01 / HABER 2.1.01</li>
+ *   <li>Retiro Bs end-to-end → asiento persistido con DEBE 2.1.01 / HABER 1.1.01</li>
+ *   <li>Depósito USD usa cuentas 1.1.05 / 2.1.02</li>
+ *   <li>Cuenta contable inexistente → AsientoContableException (defensa contra
+ *       desincronización entre plan y código del adapter)</li>
+ * </ul>
+ *
+ * <p>El seed V21 NO corre porque tests tienen {@code flyway.enabled=false}.
+ * Se pre-pueblan manualmente las cuentas necesarias en {@code @BeforeEach}.</p>
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase
+@ActiveProfiles("test")
+@Import({
+        AhorrosContabilidadAdapter.class,
+        AsientoContableService.class,
+        AsientoContableRepositoryImpl.class,
+        CuentaContableRepositoryImpl.class
+})
+@DisplayName("AhorrosContabilidadAdapter — integración con H2 (BD real)")
+class AhorrosContabilidadAdapterIntegrationTest {
+
+    @Autowired private AhorrosContabilidadAdapter adapter;
+    @Autowired private AsientoContableRepository asientoRepo;
+    @Autowired private AsientoContableJpaRepository asientoJpa;
+    @Autowired private PartidaAsientoJpaRepository partidaJpa;
+    @Autowired private CuentaContableJpaRepository cuentaJpa;
+    @Autowired private CuentaContableRepositoryImpl cuentaRepoAdapter;
+    @Autowired private EntityManager em;
+
+    private UUID cajaId, bancoUsdId, depositosBsId, depositosUsdId;
+
+    @BeforeEach
+    void setUp() {
+        // Limpieza
+        partidaJpa.deleteAll();
+        asientoJpa.deleteAll();
+        cuentaJpa.deleteAll();
+
+        // Crear secuencia que el adapter usa para el correlativo del asiento.
+        // En H2 hay que crearla a mano porque flyway está deshabilitado.
+        em.createNativeQuery("CREATE SEQUENCE IF NOT EXISTS seq_asiento_numero START WITH 1 INCREMENT BY 1")
+                .executeUpdate();
+
+        // Pre-poblar plan de cuentas con SOLO lo que el adapter referencia
+        // según los códigos hardcodeados en AhorrosContabilidadAdapter.
+        UUID rubroActivo = persistirCuenta("1", "ACTIVO",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, null, false);
+        UUID grupoDisponible = persistirCuenta("1.1", "DISPONIBLE",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, rubroActivo, false);
+        cajaId = persistirCuenta("1.1.01", "Caja Principal",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, grupoDisponible, true);
+        bancoUsdId = persistirCuenta("1.1.05", "Bancos USD",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, grupoDisponible, true);
+
+        UUID rubroPasivo = persistirCuenta("2", "PASIVO",
+                TipoCuentaContable.PASIVO, NaturalezaSaldo.ACREEDORA, null, false);
+        UUID grupoDepositos = persistirCuenta("2.1", "DEPÓSITOS",
+                TipoCuentaContable.PASIVO, NaturalezaSaldo.ACREEDORA, rubroPasivo, false);
+        depositosBsId = persistirCuenta("2.1.01", "Cuentas de Ahorro Bs",
+                TipoCuentaContable.PASIVO, NaturalezaSaldo.ACREEDORA, grupoDepositos, true);
+        depositosUsdId = persistirCuenta("2.1.02", "Cuentas de Ahorro USD",
+                TipoCuentaContable.PASIVO, NaturalezaSaldo.ACREEDORA, grupoDepositos, true);
+    }
+
+    // ─── Depósito ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("E2E depósito Bs: asiento persistido con DEBE 1.1.01 / HABER 2.1.01")
+    void e2e_deposito_bs() {
+        CuentaAhorro cuenta = cuentaBs("AHO-2026-000001");
+        Movimiento mov = movimientoConMonto("MOV-2026-000001", "1500.00");
+
+        adapter.registrarDeposito(cuenta, mov);
+
+        List<AsientoContable> hits = asientoRepo
+                .buscarPorReferenciaExterna("MOV-2026-000001");
+        assertThat(hits).as("Asiento debe persistirse").hasSize(1);
+        AsientoContable asiento = hits.get(0);
+
+        assertThat(asiento.getOrigen()).isEqualTo(OrigenAsiento.AHORRO_DEPOSITO);
+        assertThat(asiento.getEstado()).isEqualTo(EstadoAsiento.REGISTRADO);
+        assertThat(asiento.estaBalanceado()).isTrue();
+        assertThat(asiento.totalDebe()).isEqualByComparingTo("1500.00");
+        assertThat(asiento.getPartidas()).hasSize(2);
+
+        PartidaAsiento debe = asiento.getPartidas().stream()
+                .filter(PartidaAsiento::esDeDebe).findFirst().orElseThrow();
+        PartidaAsiento haber = asiento.getPartidas().stream()
+                .filter(PartidaAsiento::esDeHaber).findFirst().orElseThrow();
+
+        assertThat(debe.getCuentaId()).isEqualTo(cajaId);
+        assertThat(debe.getDebe()).isEqualByComparingTo("1500.00");
+        assertThat(haber.getCuentaId()).isEqualTo(depositosBsId);
+        assertThat(haber.getHaber()).isEqualByComparingTo("1500.00");
+    }
+
+    @Test
+    @DisplayName("E2E depósito USD: usa cuentas 1.1.05 / 2.1.02")
+    void e2e_deposito_usd() {
+        CuentaAhorro cuenta = cuentaUsd("AHO-USD-000001");
+        Movimiento mov = movimientoConMonto("MOV-2026-000099", "250.0000");
+
+        adapter.registrarDeposito(cuenta, mov);
+
+        AsientoContable asiento = asientoRepo
+                .buscarPorReferenciaExterna("MOV-2026-000099").get(0);
+        PartidaAsiento debe = asiento.getPartidas().stream()
+                .filter(PartidaAsiento::esDeDebe).findFirst().orElseThrow();
+        PartidaAsiento haber = asiento.getPartidas().stream()
+                .filter(PartidaAsiento::esDeHaber).findFirst().orElseThrow();
+        assertThat(debe.getCuentaId()).isEqualTo(bancoUsdId);
+        assertThat(haber.getCuentaId()).isEqualTo(depositosUsdId);
+    }
+
+    // ─── Retiro ────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("E2E retiro Bs: asiento con DEBE 2.1.01 / HABER 1.1.01 (espejo del depósito)")
+    void e2e_retiro_bs() {
+        CuentaAhorro cuenta = cuentaBs("AHO-2026-000010");
+        Movimiento mov = movimientoConMonto("MOV-2026-000200", "300.00");
+
+        adapter.registrarRetiro(cuenta, mov);
+
+        AsientoContable asiento = asientoRepo
+                .buscarPorReferenciaExterna("MOV-2026-000200").get(0);
+        assertThat(asiento.getOrigen()).isEqualTo(OrigenAsiento.AHORRO_RETIRO);
+
+        PartidaAsiento debe = asiento.getPartidas().stream()
+                .filter(PartidaAsiento::esDeDebe).findFirst().orElseThrow();
+        PartidaAsiento haber = asiento.getPartidas().stream()
+                .filter(PartidaAsiento::esDeHaber).findFirst().orElseThrow();
+        assertThat(debe.getCuentaId()).isEqualTo(depositosBsId);
+        assertThat(haber.getCuentaId()).isEqualTo(cajaId);
+    }
+
+    // ─── Casos negativos ────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("E2E error: cuenta contable inexistente → AsientoContableException")
+    void e2e_error_cuenta_inexistente() {
+        // Borramos 1.1.01 para forzar el error
+        cuentaJpa.deleteById(cajaId);
+        em.flush();
+
+        CuentaAhorro cuenta = cuentaBs("AHO-2026-X");
+        Movimiento mov = movimientoConMonto("MOV-FAIL", "100.00");
+
+        assertThatThrownBy(() -> adapter.registrarDeposito(cuenta, mov))
+                .isInstanceOf(AsientoContableException.class)
+                .hasMessageContaining("1.1.01");
+    }
+
+    @Test
+    @DisplayName("E2E: monto con 4 decimales preservados (BD NUMERIC(18,4))")
+    void e2e_monto_con_decimales() {
+        CuentaAhorro cuenta = cuentaBs("AHO-2026-DEC");
+        Movimiento mov = movimientoConMonto("MOV-DEC-001", "999.9999");
+
+        adapter.registrarDeposito(cuenta, mov);
+
+        AsientoContable asiento = asientoRepo
+                .buscarPorReferenciaExterna("MOV-DEC-001").get(0);
+        assertThat(asiento.totalDebe()).isEqualByComparingTo("999.9999");
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────
+
+    private UUID persistirCuenta(String codigo, String nombre, TipoCuentaContable tipo,
+                                  NaturalezaSaldo naturaleza, UUID padre, boolean aceptaMov) {
+        CuentaContable c = CuentaContable.crear(codigo, nombre, tipo, naturaleza, padre, aceptaMov, null);
+        cuentaRepoAdapter.guardar(c);
+        return c.getId();
+    }
+
+    private CuentaAhorro cuentaBs(String numero) {
+        return CuentaAhorro.builder()
+                .id(UUID.randomUUID())
+                .numeroCuenta(numero)
+                .socioId(UUID.randomUUID())
+                .moneda(Moneda.VES)
+                .build();
+    }
+
+    private CuentaAhorro cuentaUsd(String numero) {
+        return CuentaAhorro.builder()
+                .id(UUID.randomUUID())
+                .numeroCuenta(numero)
+                .socioId(UUID.randomUUID())
+                .moneda(Moneda.USD)
+                .build();
+    }
+
+    private Movimiento movimientoConMonto(String nro, String monto) {
+        return Movimiento.builder()
+                .id(UUID.randomUUID())
+                .numeroOperacion(nro)
+                .monto(new BigDecimal(monto))
+                .build();
+    }
+}

--- a/backend/src/test/java/com/tufondo/ahorros/infrastructure/contabilidad/AhorrosContabilidadAdapterTest.java
+++ b/backend/src/test/java/com/tufondo/ahorros/infrastructure/contabilidad/AhorrosContabilidadAdapterTest.java
@@ -1,0 +1,246 @@
+package com.tufondo.ahorros.infrastructure.contabilidad;
+
+import com.tufondo.ahorros.domain.model.CuentaAhorro;
+import com.tufondo.ahorros.domain.model.Movimiento;
+import com.tufondo.ahorros.domain.model.enums.Moneda;
+import com.tufondo.contabilidad.application.dto.RegistrarAsientoCommand;
+import com.tufondo.contabilidad.application.exception.AsientoContableException;
+import com.tufondo.contabilidad.application.usecase.AsientoContableService;
+import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests del adapter que materializa operaciones de Ahorros como asientos
+ * contables de partida doble (sub-issue #267).
+ *
+ * <p>Cubre las 4 variantes (depósito/retiro × Bs/USD) más casos borde:
+ * moneda null (fallback Bs), propagación de excepciones, monto exacto, etc.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class AhorrosContabilidadAdapterTest {
+
+    @Mock private AsientoContableService asientoContableService;
+
+    @InjectMocks private AhorrosContabilidadAdapter adapter;
+
+    private CuentaAhorro cuentaBs;
+    private CuentaAhorro cuentaUsd;
+    private CuentaAhorro cuentaSinMoneda;
+    private Movimiento depositoBs;
+    private Movimiento retiroBs;
+    private Movimiento depositoUsd;
+
+    @BeforeEach
+    void setUp() {
+        cuentaBs = CuentaAhorro.builder()
+                .id(UUID.randomUUID())
+                .numeroCuenta("AHO-2026-000001")
+                .socioId(UUID.randomUUID())
+                .moneda(Moneda.VES)
+                .build();
+
+        cuentaUsd = CuentaAhorro.builder()
+                .id(UUID.randomUUID())
+                .numeroCuenta("AHO-2026-000002")
+                .socioId(UUID.randomUUID())
+                .moneda(Moneda.USD)
+                .build();
+
+        cuentaSinMoneda = CuentaAhorro.builder()
+                .id(UUID.randomUUID())
+                .numeroCuenta("AHO-LEGACY-000001")
+                .socioId(UUID.randomUUID())
+                .moneda(null)  // simula cuenta antigua sin moneda asignada
+                .build();
+
+        depositoBs = Movimiento.builder()
+                .id(UUID.randomUUID())
+                .numeroOperacion("MOV-2026-000001")
+                .monto(new BigDecimal("1500.50"))
+                .build();
+
+        retiroBs = Movimiento.builder()
+                .id(UUID.randomUUID())
+                .numeroOperacion("MOV-2026-000002")
+                .monto(new BigDecimal("250.00"))
+                .build();
+
+        depositoUsd = Movimiento.builder()
+                .id(UUID.randomUUID())
+                .numeroOperacion("MOV-2026-000003")
+                .monto(new BigDecimal("100.00"))
+                .build();
+    }
+
+    // ─── Depósito ──────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Depósito → asiento DEBE activo / HABER pasivo")
+    class Deposito {
+
+        @Test
+        @DisplayName("Bs: DEBE 1.1.01 Caja Principal / HABER 2.1.01 Cuentas de Ahorro Bs")
+        void deposito_bs_usa_caja_y_depositos_bs() {
+            adapter.registrarDeposito(cuentaBs, depositoBs);
+
+            RegistrarAsientoCommand cmd = capturarComando();
+            assertThat(cmd.origen()).isEqualTo(OrigenAsiento.AHORRO_DEPOSITO);
+            assertThat(cmd.referenciaExterna()).isEqualTo("MOV-2026-000001");
+            assertThat(cmd.partidas()).hasSize(2);
+
+            var debe = cmd.partidas().get(0);
+            assertThat(debe.codigoCuenta()).isEqualTo("1.1.01");
+            assertThat(debe.debe()).isEqualByComparingTo("1500.50");
+            assertThat(debe.haber()).isNull();
+
+            var haber = cmd.partidas().get(1);
+            assertThat(haber.codigoCuenta()).isEqualTo("2.1.01");
+            assertThat(haber.haber()).isEqualByComparingTo("1500.50");
+            assertThat(haber.debe()).isNull();
+        }
+
+        @Test
+        @DisplayName("USD: DEBE 1.1.05 Bancos USD / HABER 2.1.02 Cuentas de Ahorro USD")
+        void deposito_usd_usa_bancos_usd_y_depositos_usd() {
+            adapter.registrarDeposito(cuentaUsd, depositoUsd);
+
+            RegistrarAsientoCommand cmd = capturarComando();
+            assertThat(cmd.partidas().get(0).codigoCuenta()).isEqualTo("1.1.05");
+            assertThat(cmd.partidas().get(1).codigoCuenta()).isEqualTo("2.1.02");
+            assertThat(cmd.partidas().get(0).debe()).isEqualByComparingTo("100.00");
+            assertThat(cmd.partidas().get(1).haber()).isEqualByComparingTo("100.00");
+        }
+
+        @Test
+        @DisplayName("moneda null → fallback a cuentas en Bs (no rompe)")
+        void deposito_sin_moneda_usa_bs() {
+            adapter.registrarDeposito(cuentaSinMoneda, depositoBs);
+
+            RegistrarAsientoCommand cmd = capturarComando();
+            assertThat(cmd.partidas().get(0).codigoCuenta()).isEqualTo("1.1.01");
+            assertThat(cmd.partidas().get(1).codigoCuenta()).isEqualTo("2.1.01");
+        }
+
+        @Test
+        @DisplayName("glosa del asiento incluye número de operación y cuenta")
+        void glosa_incluye_metadata_del_movimiento() {
+            adapter.registrarDeposito(cuentaBs, depositoBs);
+
+            RegistrarAsientoCommand cmd = capturarComando();
+            assertThat(cmd.glosa())
+                    .contains("MOV-2026-000001")
+                    .contains("AHO-2026-000001");
+        }
+
+        @Test
+        @DisplayName("fecha contable es hoy (LocalDate.now)")
+        void fecha_contable_es_hoy() {
+            adapter.registrarDeposito(cuentaBs, depositoBs);
+
+            RegistrarAsientoCommand cmd = capturarComando();
+            assertThat(cmd.fechaContable()).isEqualTo(java.time.LocalDate.now());
+        }
+    }
+
+    // ─── Retiro ────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Retiro → asiento DEBE pasivo / HABER activo (espejo del depósito)")
+    class Retiro {
+
+        @Test
+        @DisplayName("Bs: DEBE 2.1.01 (baja captación) / HABER 1.1.01 (sale efectivo)")
+        void retiro_bs_invierte_cuentas_vs_deposito() {
+            adapter.registrarRetiro(cuentaBs, retiroBs);
+
+            RegistrarAsientoCommand cmd = capturarComando();
+            assertThat(cmd.origen()).isEqualTo(OrigenAsiento.AHORRO_RETIRO);
+            assertThat(cmd.partidas()).hasSize(2);
+
+            // DEBE el PASIVO (en retiro la obligación con el socio baja)
+            var debe = cmd.partidas().get(0);
+            assertThat(debe.codigoCuenta()).isEqualTo("2.1.01");
+            assertThat(debe.debe()).isEqualByComparingTo("250.00");
+
+            // HABER el ACTIVO (sale efectivo)
+            var haber = cmd.partidas().get(1);
+            assertThat(haber.codigoCuenta()).isEqualTo("1.1.01");
+            assertThat(haber.haber()).isEqualByComparingTo("250.00");
+        }
+
+        @Test
+        @DisplayName("USD: DEBE 2.1.02 / HABER 1.1.05")
+        void retiro_usd_usa_cuentas_usd_invertidas() {
+            adapter.registrarRetiro(cuentaUsd, retiroBs);
+
+            RegistrarAsientoCommand cmd = capturarComando();
+            assertThat(cmd.partidas().get(0).codigoCuenta()).isEqualTo("2.1.02");
+            assertThat(cmd.partidas().get(1).codigoCuenta()).isEqualTo("1.1.05");
+        }
+    }
+
+    // ─── Propagación de errores ────────────────────────────────────────────
+
+    @Test
+    @DisplayName("excepción de AsientoContableService se propaga (NO se traga)")
+    void error_contable_se_propaga_para_rollback() {
+        doThrow(new AsientoContableException("cuenta inexistente: 1.1.01"))
+                .when(asientoContableService).registrar(org.mockito.ArgumentMatchers.any());
+
+        assertThatThrownBy(() -> adapter.registrarDeposito(cuentaBs, depositoBs))
+                .isInstanceOf(AsientoContableException.class)
+                .hasMessageContaining("1.1.01");
+    }
+
+    @Test
+    @DisplayName("monto con muchos decimales se mantiene tal cual (validación queda en dominio)")
+    void monto_decimales_se_propaga_sin_redondeo() {
+        Movimiento m = Movimiento.builder()
+                .id(UUID.randomUUID())
+                .numeroOperacion("MOV-2026-0099")
+                .monto(new BigDecimal("0.0001"))
+                .build();
+
+        adapter.registrarDeposito(cuentaBs, m);
+
+        RegistrarAsientoCommand cmd = capturarComando();
+        assertThat(cmd.partidas().get(0).debe()).isEqualByComparingTo("0.0001");
+        assertThat(cmd.partidas().get(1).haber()).isEqualByComparingTo("0.0001");
+    }
+
+    @Test
+    @DisplayName("misma partida ambas con el mismo monto (invariante partida doble pre-condición)")
+    void debe_y_haber_son_del_mismo_monto() {
+        adapter.registrarDeposito(cuentaBs, depositoBs);
+
+        RegistrarAsientoCommand cmd = capturarComando();
+        BigDecimal debe = cmd.partidas().get(0).debe();
+        BigDecimal haber = cmd.partidas().get(1).haber();
+        assertThat(debe).isEqualByComparingTo(haber);
+    }
+
+    // ─── Helper ────────────────────────────────────────────────────────────
+
+    private RegistrarAsientoCommand capturarComando() {
+        ArgumentCaptor<RegistrarAsientoCommand> captor =
+                ArgumentCaptor.forClass(RegistrarAsientoCommand.class);
+        verify(asientoContableService).registrar(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/backend/src/test/java/com/tufondo/ahorros/infrastructure/contabilidad/AhorrosContabilidadAdapterTest.java
+++ b/backend/src/test/java/com/tufondo/ahorros/infrastructure/contabilidad/AhorrosContabilidadAdapterTest.java
@@ -95,8 +95,8 @@ class AhorrosContabilidadAdapterTest {
     class Deposito {
 
         @Test
-        @DisplayName("Bs: DEBE 1.1.01 Caja Principal / HABER 2.1.01 Cuentas de Ahorro Bs")
-        void deposito_bs_usa_caja_y_depositos_bs() {
+        @DisplayName("Bs: DEBE 1.1.03 Bancos Cta Corriente Bs / HABER 2.1.01 Cuentas de Ahorro Bs")
+        void deposito_bs_usa_banco_y_depositos_bs() {
             adapter.registrarDeposito(cuentaBs, depositoBs);
 
             RegistrarAsientoCommand cmd = capturarComando();
@@ -104,8 +104,9 @@ class AhorrosContabilidadAdapterTest {
             assertThat(cmd.referenciaExterna()).isEqualTo("MOV-2026-000001");
             assertThat(cmd.partidas()).hasSize(2);
 
+            // Post D-002: usar 1.1.03 Bancos (NO 1.1.01 Caja) — Fatrans opera por transferencia.
             var debe = cmd.partidas().get(0);
-            assertThat(debe.codigoCuenta()).isEqualTo("1.1.01");
+            assertThat(debe.codigoCuenta()).isEqualTo("1.1.03");
             assertThat(debe.debe()).isEqualByComparingTo("1500.50");
             assertThat(debe.haber()).isNull();
 
@@ -133,7 +134,8 @@ class AhorrosContabilidadAdapterTest {
             adapter.registrarDeposito(cuentaSinMoneda, depositoBs);
 
             RegistrarAsientoCommand cmd = capturarComando();
-            assertThat(cmd.partidas().get(0).codigoCuenta()).isEqualTo("1.1.01");
+            // Fallback Bs usa 1.1.03 Bancos (post D-002).
+            assertThat(cmd.partidas().get(0).codigoCuenta()).isEqualTo("1.1.03");
             assertThat(cmd.partidas().get(1).codigoCuenta()).isEqualTo("2.1.01");
         }
 
@@ -165,7 +167,7 @@ class AhorrosContabilidadAdapterTest {
     class Retiro {
 
         @Test
-        @DisplayName("Bs: DEBE 2.1.01 (baja captación) / HABER 1.1.01 (sale efectivo)")
+        @DisplayName("Bs: DEBE 2.1.01 (baja captación) / HABER 1.1.03 (sale transferencia bancaria)")
         void retiro_bs_invierte_cuentas_vs_deposito() {
             adapter.registrarRetiro(cuentaBs, retiroBs);
 
@@ -178,9 +180,9 @@ class AhorrosContabilidadAdapterTest {
             assertThat(debe.codigoCuenta()).isEqualTo("2.1.01");
             assertThat(debe.debe()).isEqualByComparingTo("250.00");
 
-            // HABER el ACTIVO (sale efectivo)
+            // HABER el ACTIVO — post D-002 va a Bancos 1.1.03, NO Caja 1.1.01.
             var haber = cmd.partidas().get(1);
-            assertThat(haber.codigoCuenta()).isEqualTo("1.1.01");
+            assertThat(haber.codigoCuenta()).isEqualTo("1.1.03");
             assertThat(haber.haber()).isEqualByComparingTo("250.00");
         }
 
@@ -200,12 +202,12 @@ class AhorrosContabilidadAdapterTest {
     @Test
     @DisplayName("excepción de AsientoContableService se propaga (NO se traga)")
     void error_contable_se_propaga_para_rollback() {
-        doThrow(new AsientoContableException("cuenta inexistente: 1.1.01"))
+        doThrow(new AsientoContableException("cuenta inexistente: 1.1.03"))
                 .when(asientoContableService).registrar(org.mockito.ArgumentMatchers.any());
 
         assertThatThrownBy(() -> adapter.registrarDeposito(cuentaBs, depositoBs))
                 .isInstanceOf(AsientoContableException.class)
-                .hasMessageContaining("1.1.01");
+                .hasMessageContaining("1.1.03");
     }
 
     @Test

--- a/docs/modulos/contabilidad/00-overview.md
+++ b/docs/modulos/contabilidad/00-overview.md
@@ -1,0 +1,159 @@
+---
+tags: [contabilidad, overview, epic-263, timeline]
+created: 2026-05-20
+estado: documento-vivo
+---
+
+# 📜 EPIC #263 — Contabilidad: visión general y timeline
+
+> [!summary] Para qué existe este módulo
+> Construir un sistema contable completo (partida doble) que cumpla
+> **VEN-NIF / SUDECA**, de modo que cada operación financiera del fondo
+> (depósitos, retiros, créditos, intereses, cierres) genere automáticamente
+> sus asientos contables sin intervención manual del contador. Sin esto,
+> Fatrans NO puede operar legalmente como asociación de ahorro y crédito.
+
+## Por qué fue necesario
+
+Antes del EPIC, Fatrans operaba **sin libro contable digital**: los
+movimientos de saldo del socio (depósito, retiro, intereses) se registraban
+en el módulo de Ahorros, pero NO se reflejaban en ninguna estructura
+contable de partida doble. Eso significa:
+
+- ❌ No se podía emitir Balance General ni Estado de Resultados.
+- ❌ No había trazabilidad de ingresos por intereses vs amortización de cartera.
+- ❌ Cero defensa frente a auditoría SUDECA — el primer requerimiento sería: "muéstrenme el libro diario".
+- ❌ Imposible calcular reservas legales, provisiones, depreciaciones automáticamente.
+
+El EPIC #263 cierra esa brecha desde la base (plan de cuentas) hasta los
+reportes finales.
+
+## Estado actual (2026-05-20)
+
+```
+Plan de cuentas (#264) ──► Asientos (#265+#266) ──► Hooks Ahorros (#267) ──► Hooks Créditos (#268) ──► Reportes (#269-#271) ──► Cierre (#272+#273)
+       ✅                       ✅                        🚧 (PR #315)              ⏳                       ⏳                        ⏳
+```
+
+## Timeline cronológico de decisiones y entregas
+
+### 2026-05-19 — Bloque fundacional
+
+**[[01-plan-cuentas|#264 — Plan de cuentas VEN-NIF]]** (PR #313, merged)
+
+Trabajado y mergeado el plan de cuentas con ~55 cuentas seedeadas en
+migration V21. Tres niveles jerárquicos: rubros (1-6), grupos (1.1, 1.2, ...),
+cuentas operativas (1.1.01, ...). Defensa en profundidad: validaciones en
+dominio Java + JPA + PostgreSQL CHECK constraints.
+
+**Hallazgo durante la implementación**: el test `version_se_incrementa` falló
+porque el modelo `CuentaContable` es **inmutable** — cada `guardar()` recibe
+un objeto nuevo, no dirty-check. Fix: testear `@Version` directamente a nivel
+entity con `saveAndFlush()`.
+
+### 2026-05-20 — Asientos contables
+
+**[[02-asientos-contables|#265 + #266 — Asientos]]** (PR #314, merged)
+
+Migration V22 con tablas `asientos_contables` (cabecera) y `partidas_asientos`
+(detalle). Modelo de dominio inmutable con aggregate root `AsientoContable`
+que valida los 4 mandamientos de partida doble. Service de aplicación
+`AsientoContableService.registrar()` + `anular()`. Repositorio JPA con
+batch loading para evitar N+1.
+
+**Decisiones técnicas tomadas**:
+- SEQUENCE PostgreSQL `seq_asiento_numero` con `CACHE 1` para correlativo continuo SUDECA.
+- FK `ON DELETE RESTRICT` en ambas tablas para impedir borrado físico.
+- `BigDecimal` con escala 4 (NUMERIC(18,4)) — exacto, sin truncado.
+- Asientos NUNCA se DELETE, solo ANULAN con motivo.
+- `OrigenAsiento` enum con 10 valores para clasificar la fuente.
+
+**Hallazgos durante implementación**:
+- Test `round_trip` falló por llamar `entity.toDomain(List.of())` antes de
+  persistir las partidas — viola la invariante "mínimo 2 partidas". Fix:
+  trabajar con la entity directamente para obtener el ID y luego reconstruir.
+- Test `solo_haber` falló porque el mensaje esperado no era el que el dominio
+  lanza primero (validación de balance precede a la de partidas). Fix:
+  relajar la assertion al tipo de excepción.
+
+### 2026-05-20 — Hooks de Ahorros (en curso)
+
+**[[03-hooks-ahorros|#267 — Hooks Ahorros]]** (PR #315, abierto)
+
+Conectado `RealizarDepositoUseCase` y `RealizarRetiroUseCase` con el módulo
+Contabilidad vía un port + adapter pattern:
+
+```
+RealizarDepositoUseCase → AhorrosContabilidadPort (interfaz)
+                              ↓
+                       AhorrosContabilidadAdapter (impl, conoce códigos VEN-NIF)
+                              ↓
+                       AsientoContableService.registrar()
+```
+
+**28 tests nuevos, todos verdes**. Suite completa del backend pasa con
+**555 tests** (incluye los 120 del módulo contabilidad).
+
+**🚨 Hallazgo crítico post-implementación**: el usuario aclaró que Fatrans
+**NO opera con caja física** — todo se mueve por transferencia bancaria.
+Por tanto, el mapping `1.1.01` Caja Principal (que codeé inicialmente para
+operaciones Bs) es **incorrecto**: debe ser `1.1.03` Bancos Cuenta Corriente Bs.
+
+Este hallazgo desencadenó:
+1. La creación del [[_contador-fatrans|sub-agente especializado en contaduría]]
+   para que evalúe proactivamente cada decisión contable.
+2. La revisión formal del contador (ver [[_decisiones-contables#D-002|D-002]]):
+   veredicto **corregir antes de mergear**.
+3. La identificación de varios pendientes regulatorios que documenté en
+   [[_pendientes-criticos]].
+
+### 2026-05-20 — Próximo: #268 Hooks de Créditos
+
+**[[04-hooks-creditos|#268 — Hooks Créditos]]** (en diseño)
+
+Mismo patrón que #267 pero con operaciones del módulo Créditos:
+- **Desembolso**: DEBE `1.3.01` Cartera / HABER `1.1.03` Bancos / HABER `4.1.02` Comisión
+- **Pago cuota**: DEBE `1.1.03` Bancos / HABER `1.3.01` (capital) / HABER `4.1.01` (intereses) / HABER `4.1.03` (mora si aplica)
+
+Mapping **aprobado** por contador-fatrans con observaciones documentadas en
+[[_decisiones-contables#D-003|D-003]] y [[_decisiones-contables#D-004|D-004]].
+
+## Lo que viene después de #268
+
+| # | Tema | Comentario |
+|---|---|---|
+| #269 | Libro Diario + PDF SUDECA | Reporte por rango de fechas con totales del período |
+| #270 | Libro Mayor | Saldos acumulados por cuenta a una fecha de corte |
+| #271 | Balance General + Estado de Resultados | Reportes finales VEN-NIF |
+| #272 | Cierre mensual/anual | Bloqueo de período + asientos de cierre |
+| #273 | Reversión de asientos | Generación automática de asiento inverso para anulación |
+
+## Red flags identificados durante el EPIC (no resueltos aún)
+
+Ver lista completa en [[_pendientes-criticos]]. Resumen:
+
+- ⚠️ **Devengo mensual de intereses** (criterio VEN-NIF NIC-1) — actualmente
+  estamos en criterio de caja, no de devengo. Bloqueante antes del primer cierre fiscal real.
+- ⚠️ **Provisión de cartera** (`1.3.99`) — cuenta existe en el plan pero ningún
+  proceso la mueve. Exigencia SUDECA para cooperativas.
+- ⚠️ **Cartera USD vs Bs** — actualmente todos los créditos se asumen Bs.
+  Si Fatrans abre créditos USD, hay que separar contablemente.
+- ⚠️ **Diferencia en cambio** (NIC-21) — al re-expresar saldos USD a Bs por
+  cambio de tasa BCV, se generan asientos de re-expresión. No diseñado aún.
+- ⚠️ **Naturaleza jurídica Fatrans** (#274) — sigue sin confirmarse si opera como
+  caja de ahorro (SUDECA) o cooperativa (SUNACOOP). Cambia el plan de cuentas.
+
+## Cómo continuar el trabajo
+
+1. **Antes de cada cambio contable nuevo**: invocar [[_contador-fatrans|contador-fatrans]]
+   para revisar el mapping propuesto.
+2. **Antes de cada PR del EPIC**: actualizar este overview con la entrada nueva
+   en el timeline.
+3. **Cada decisión contable**: dejar entrada en [[_decisiones-contables]].
+4. **Cada red flag nuevo**: agregar a [[_pendientes-criticos]].
+
+> [!important] Validación contable formal
+> Antes de uso productivo, un contador colegiado venezolano debe firmar
+> conformidad sobre el plan V21 y las reglas de mapeo de #267/#268. La
+> implementación técnica es solo la mitad — la otra mitad es la auditabilidad
+> regulatoria. Ver [[_pendientes-criticos#Validación-externa|pendiente]].

--- a/docs/modulos/contabilidad/01-plan-cuentas.md
+++ b/docs/modulos/contabilidad/01-plan-cuentas.md
@@ -1,0 +1,153 @@
+---
+tags: [contabilidad, plan-cuentas, ven-nif, migration]
+sub-issue: "#264"
+pr: "#313"
+estado: merged
+created: 2026-05-19
+---
+
+# 📋 Plan de Cuentas VEN-NIF
+
+> [!summary] Sub-issue [[Home|#264]] — bloque fundacional
+> Tabla `plan_cuentas` con seed de ~55 cuentas según VEN-NIF / SUDECA.
+> Es el catálogo del que se cuelgan todos los [[02-asientos-contables|asientos]].
+
+## Estructura jerárquica del código
+
+Códigos por niveles (formato `^[1-6](\.\d{1,3}){0,4}$`):
+
+| Nivel | Ejemplo | Concepto |
+|---|---|---|
+| 1 | `1` | Rubro (ACTIVO, PASIVO, ...) |
+| 2 | `1.1` | Grupo (Activo Disponible, Cartera de Créditos, ...) |
+| 3 | `1.1.01` | **Cuenta operativa** ← acepta movimientos |
+| 4–5 | `1.1.01.001` | Sub-cuentas analíticas (opcional, sin seed inicial) |
+
+> [!tip] Regla del primer dígito
+> El primer dígito **siempre** mapea al tipo:
+> - `1` → `ACTIVO`
+> - `2` → `PASIVO`
+> - `3` → `PATRIMONIO`
+> - `4` → `INGRESO`
+> - `5` → `EGRESO`
+> - `6` → `CUENTA_ORDEN`
+>
+> Esto se valida en el dominio Java (`CuentaContable`) **y** en BD (CHECK).
+
+## Naturaleza del saldo (DEUDORA / ACREEDORA)
+
+Cada cuenta tiene una `naturaleza_saldo` que determina cómo se calcula su saldo:
+
+```
+saldo = naturaleza × (Σ debe − Σ haber)
+```
+
+| Tipo | Naturaleza natural | Razón |
+|---|---|---|
+| ACTIVO | DEUDORA (+) | Aumenta al DEBE |
+| PASIVO | ACREEDORA (−) | Aumenta al HABER |
+| PATRIMONIO | ACREEDORA (−) | Idem pasivo |
+| INGRESO | ACREEDORA (−) | Idem |
+| EGRESO | DEUDORA (+) | Idem activo |
+
+> [!warning] Cuentas correctoras
+> Algunas cuentas son `ACTIVO` con naturaleza **ACREEDORA** (cuenta correctora):
+> - `1.3.99` Provisión Cartera de Créditos (CR)
+> - `1.5.99` Depreciación Acumulada (CR)
+>
+> Esto NO es un bug — se modela así para que el balance general las muestre restando del rubro.
+
+## Cuentas operativas relevantes (referencia rápida)
+
+### Activos (1)
+
+| Código | Nombre | Uso |
+|---|---|---|
+| `1.1.01` | Caja Principal | Efectivo en bóveda |
+| `1.1.02` | Caja Chica | Gastos menores |
+| `1.1.03` | Bancos Cuenta Corriente Bs | Saldos cta corriente Bs |
+| `1.1.04` | Bancos Cuenta de Ahorro Bs | Saldos cta ahorro Bs |
+| `1.1.05` | Bancos Cuentas USD | Saldos en dólares |
+| `1.3.01` | Créditos Personales por Cobrar | Cartera vigente |
+| `1.3.02` | Créditos Hipotecarios por Cobrar | Hipotecas |
+| `1.3.03` | Intereses por Cobrar sobre Créditos | Intereses devengados |
+| `1.3.99` | Provisión Cartera (CR) | Provisión por incobrables |
+
+### Pasivos (2) — Captaciones de socios
+
+| Código | Nombre | Uso |
+|---|---|---|
+| `2.1.01` | Cuentas de Ahorro Bs | ← **Saldos de socios en Bs** |
+| `2.1.02` | Cuentas de Ahorro USD | ← **Saldos de socios en USD** |
+| `2.1.03` | Depósitos a Plazo Fijo Bs | Plazos fijos |
+| `2.1.04` | Intereses por Pagar Captaciones | Intereses devengados |
+
+### Patrimonio (3)
+
+| Código | Nombre |
+|---|---|
+| `3.1.01` | Aportes Sociales |
+| `3.2.01` | Reserva Legal |
+| `3.3.02` | Excedente del Ejercicio |
+
+### Ingresos (4)
+
+| Código | Nombre |
+|---|---|
+| `4.1.01` | Intereses sobre Créditos |
+| `4.1.02` | Comisiones por Otorgamiento |
+| `4.1.03` | Intereses Moratorios |
+
+### Egresos (5)
+
+| Código | Nombre |
+|---|---|
+| `5.1.01` | Intereses sobre Cuentas de Ahorro |
+| `5.1.02` | Intereses sobre Plazo Fijo |
+| `5.2.01` | Sueldos y Salarios |
+| `5.2.07` | Depreciación |
+
+### Cuentas de orden (6)
+
+| Código | Nombre |
+|---|---|
+| `6.1.01` | Garantías Recibidas |
+| `6.2.01` | Garantías Otorgadas |
+
+> 📎 Lista completa: ver migration [`V21__plan_cuentas_ven_nif.sql`](../../../backend/src/main/resources/db/migration/V21__plan_cuentas_ven_nif.sql).
+
+## Defensa en profundidad (validaciones)
+
+```
+┌─────────────────────────────────────┐
+│ Dominio Java (CuentaContable)       │  ← Regex código, nivel, prefijo
+├─────────────────────────────────────┤
+│ Repository adapter                  │  ← Map domain ↔ entity
+├─────────────────────────────────────┤
+│ JPA @Column constraints              │
+├─────────────────────────────────────┤
+│ PostgreSQL CHECK constraints         │  ← Regex codigo, nivel 1-5
+│ - chk_plan_cuentas_codigo_formato    │
+│ - chk_plan_cuentas_padre_segun_nivel │
+└─────────────────────────────────────┘
+```
+
+> [!danger] Cambios al plan
+> **NUNCA editar V21 in-place.** Cualquier cambio del plan en PROD requiere
+> migration nueva V22+ que `INSERT`/`UPDATE` cuentas. El seed V21 está
+> congelado para mantener consistencia entre ambientes.
+
+## Tests
+
+- `SeedV21PlanCuentasTest` — parsea V21 como texto y valida invariantes sin BD
+- `CuentaContableTest` — dominio: regex, prefijo, niveles
+- `CuentaContableRepositoryImplTest` — round-trip H2
+- `TipoCuentaContableTest`, `NaturalezaSaldoTest` — enums
+
+Última corrida: **todos verdes** (incluido en los 120 tests del módulo).
+
+## Referencias
+
+- PR merged: [#313](https://github.com/gamijoam/fatrans/pull/313)
+- Migration: `backend/src/main/resources/db/migration/V21__plan_cuentas_ven_nif.sql`
+- Issue padre: [[Home|EPIC #263]]

--- a/docs/modulos/contabilidad/02-asientos-contables.md
+++ b/docs/modulos/contabilidad/02-asientos-contables.md
@@ -1,0 +1,190 @@
+---
+tags: [contabilidad, asientos, partida-doble, ven-nif]
+sub-issue: "#265, #266"
+pr: "#314"
+estado: merged
+created: 2026-05-20
+---
+
+# 🧾 Asientos Contables — Partida Doble
+
+> [!summary] Sub-issues [[Home|#265 + #266]]
+> Tablas + dominio + service + 50+ tests. Permite registrar y anular asientos
+> de partida doble con todas las validaciones contables clásicas.
+
+## Modelo conceptual
+
+```
+AsientoContable (aggregate root)            ← cabecera
+├── numero          BIGSERIAL (seq_asiento_numero)  ← correlativo SUDECA
+├── fechaContable   LocalDate
+├── glosa           String  (descripción del asiento)
+├── origen          OrigenAsiento (10 valores)
+├── estado          REGISTRADO | ANULADO
+├── referenciaExterna  String (ej. MOV-2026-000001)
+└── partidas        List<PartidaAsiento>   ← entity hija
+    ├── cuentaId    UUID FK a plan_cuentas
+    ├── debe        NUMERIC(18,4)
+    ├── haber       NUMERIC(18,4)
+    ├── orden       INT
+    └── glosa       String
+```
+
+## Invariantes (validadas en dominio + BD)
+
+> [!important] Los 4 mandamientos del asiento contable
+> 1. **`Σ debe = Σ haber`** — la suma de todos los DEBEs iguala la de todos los HABERs (partida doble)
+> 2. **`MIN_PARTIDAS = 2`** — al menos 2 renglones por asiento
+> 3. **Cada partida: `(debe > 0 AND haber = 0)` XOR `(debe = 0 AND haber > 0)`** — nunca ambos, nunca ninguno
+> 4. **Sin duplicados en el mismo lado** — no dos partidas del mismo lado (DEBE/HABER) sobre la misma cuenta (sí permitido en lados distintos)
+
+## Estados y transiciones
+
+```
+       (crear)              (anular)
+  ()  ──────►  REGISTRADO  ──────►  ANULADO
+                                    │
+                              (no se puede revertir;
+                               para corregir → asiento nuevo)
+```
+
+> [!danger] Inmutabilidad de asientos
+> Los asientos **NUNCA se actualizan ni borran**. Para corregir un error:
+> 1. `anular()` el original → estado ANULADO + motivo
+> 2. Generar un nuevo asiento con los valores correctos
+>
+> Sub-issue [[Home|#273]] cubrirá la reversión automática (asiento inverso) como atajo.
+
+## Origen del asiento (qué evento lo disparó)
+
+10 valores de `OrigenAsiento`:
+
+| Categoría | Valor | Disparado por |
+|---|---|---|
+| **Ahorros** | `AHORRO_DEPOSITO` | [[03-hooks-ahorros#Depósito|RealizarDepositoUseCase]] |
+| | `AHORRO_RETIRO` | [[03-hooks-ahorros#Retiro|RealizarRetiroUseCase]] |
+| | `AHORRO_INTERES` | (pendiente — cuando se "aplique" un rendimiento) |
+| **Créditos** | `CREDITO_DESEMBOLSO` | (pendiente sub-issue #268) |
+| | `CREDITO_COBRO` | (pendiente #268) |
+| | `CREDITO_INTERES` | (pendiente #268) |
+| **Operativo** | `MANUAL` | Contador ingresa asiento manual |
+| | `CIERRE` | Cierre mensual/anual (#272) |
+| | `REVERSION` | Generado por `revertir()` (#273) |
+| | `AJUSTE` | Corrección o reclasificación |
+
+## Correlativo continuo (exigencia SUDECA)
+
+SUDECA exige que los asientos tengan numeración **continua sin huecos** dentro
+del año fiscal. Esto se garantiza con:
+
+```sql
+CREATE SEQUENCE seq_asiento_numero START WITH 1 INCREMENT BY 1 CACHE 1;
+```
+
+`CACHE 1` evita que PostgreSQL pre-asigne rangos que podrían perderse en
+crashes. Cada `nextval()` devuelve el siguiente entero sin gaps.
+
+> [!warning] Gaps en reinicios
+> En la práctica, un rollback de transacción SÍ "consume" un número de
+> secuencia (PostgreSQL no devuelve el número al rollback). Estos huecos
+> son legalmente aceptables porque corresponden a operaciones abortadas, no
+> a asientos contables persistidos. Para reportes SUDECA, mostramos solo los
+> asientos persistidos en orden de `numero`.
+
+## API del servicio
+
+```java
+@Transactional
+public AsientoContable registrar(RegistrarAsientoCommand cmd)
+    throws AsientoContableException;
+
+@Transactional
+public AsientoContable anular(UUID asientoId, String motivo)
+    throws AsientoContableException;
+```
+
+### `RegistrarAsientoCommand` — ejemplo
+
+```java
+RegistrarAsientoCommand.builder()
+    .fechaContable(LocalDate.now())
+    .glosa("Depósito MOV-2026-000001 en cuenta AHO-2026-000001")
+    .origen(OrigenAsiento.AHORRO_DEPOSITO)
+    .referenciaExterna("MOV-2026-000001")
+    .creadoPorUsuarioId(null)  // automático
+    .asientoReversaId(null)
+    .partidas(List.of(
+        Partida.builder()
+            .codigoCuenta("1.1.01")  // ← referenciada por código, no UUID
+            .debe(new BigDecimal("1500.00"))
+            .glosa("Ingreso de efectivo")
+            .build(),
+        Partida.builder()
+            .codigoCuenta("2.1.01")
+            .haber(new BigDecimal("1500.00"))
+            .glosa("Crédito en cuenta de ahorro")
+            .build()
+    ))
+    .build();
+```
+
+El service:
+1. Resuelve los códigos de cuenta a UUIDs vía `CuentaContableRepository`.
+2. Valida que **todas las cuentas existan**, sean **hojas** (`acepta_movimientos=true`) y estén **activas**.
+3. Construye las `PartidaAsiento` (valida debe XOR haber, monto > 0, etc).
+4. Construye el `AsientoContable` (valida partida doble).
+5. Asigna el correlativo vía `nextval('seq_asiento_numero')`.
+6. Persiste atómicamente cabecera + partidas.
+
+Cualquier fallo lanza `AsientoContableException` y rollback completo.
+
+## Esquema SQL (V22)
+
+Resumen — ver `V22__asientos_contables.sql` completo:
+
+```sql
+CREATE TABLE asientos_contables (
+    id UUID PRIMARY KEY,
+    numero BIGINT NOT NULL UNIQUE,
+    fecha_contable DATE NOT NULL,
+    glosa VARCHAR(500),
+    origen VARCHAR(30) NOT NULL CHECK (origen IN (...10 valores...)),
+    estado VARCHAR(20) NOT NULL CHECK (estado IN ('REGISTRADO','ANULADO')),
+    referencia_externa VARCHAR(100),
+    -- ...
+);
+
+CREATE TABLE partidas_asientos (
+    id UUID PRIMARY KEY,
+    asiento_id UUID NOT NULL REFERENCES asientos_contables(id) ON DELETE RESTRICT,
+    cuenta_id UUID NOT NULL REFERENCES plan_cuentas(id) ON DELETE RESTRICT,
+    debe NUMERIC(18,4) NOT NULL DEFAULT 0,
+    haber NUMERIC(18,4) NOT NULL DEFAULT 0,
+    orden INT NOT NULL,
+    -- XOR: una y solo una de las dos > 0
+    CONSTRAINT chk_partida_debe_xor_haber
+        CHECK ((debe > 0 AND haber = 0) OR (debe = 0 AND haber > 0))
+);
+```
+
+> [!important] `ON DELETE RESTRICT`
+> Ambas FKs (asiento→cuenta, partida→asiento) son `RESTRICT`. Esto
+> previene a nivel BD que se borre una cuenta usada en asientos, o un asiento
+> con partidas. La inmutabilidad legal queda garantizada por el SGBD aunque
+> alguien intente DELETE manual.
+
+## Tests (50+ casos)
+
+| Test class | Casos | Cubre |
+|---|---|---|
+| `PartidaAsientoTest` | 11 | Factories `alDebe`/`alHaber`, validación XOR, escala 4 decimales, MONTO_MAXIMO, equals por id |
+| `AsientoContableTest` | 16 (4 nested) | Invariantes partida doble, mínimo 2 partidas, anular, duplicados |
+| `AsientoContableServiceTest` | 10 | Validación cuentas: inexistente / totalizadora / inactiva, desbalanceado, anular |
+| `AsientoContableRepositoryImplTest` | 6 | Round-trip BD, queries por fecha/origen/estado/referencia |
+
+## Referencias
+
+- PR merged: [#314](https://github.com/gamijoam/fatrans/pull/314)
+- Migration: `backend/src/main/resources/db/migration/V22__asientos_contables.sql`
+- Issues: [[Home|#265 + #266]]
+- Siguiente: [[03-hooks-ahorros|#267 — Hooks de Ahorros]]

--- a/docs/modulos/contabilidad/03-hooks-ahorros.md
+++ b/docs/modulos/contabilidad/03-hooks-ahorros.md
@@ -1,0 +1,165 @@
+---
+tags: [contabilidad, ahorros, hooks, integracion]
+sub-issue: "#267"
+pr: pending
+estado: en-construccion
+created: 2026-05-20
+---
+
+# 🔌 Hooks contables — módulo Ahorros
+
+> [!summary] Sub-issue [[Home|#267]]
+> Cada depósito y retiro que se realiza por el módulo de [[../ahorros/Home|Ahorros]]
+> genera **automáticamente** su [[02-asientos-contables|asiento contable]] de
+> partida doble, dentro de la **misma transacción** que mueve el saldo.
+
+## Mapping operación → asiento
+
+> [!important] Las 4 variantes
+> El adapter [`AhorrosContabilidadAdapter`](../../../backend/src/main/java/com/tufondo/ahorros/infrastructure/contabilidad/AhorrosContabilidadAdapter.java)
+> mapea cada operación según la moneda de la cuenta:
+
+### Depósito (origen `AHORRO_DEPOSITO`)
+
+| Moneda | DEBE (cuenta) | HABER (cuenta) | Significado |
+|---|---|---|---|
+| **VES** | `1.1.01` Caja Principal | `2.1.01` Cuentas de Ahorro Bs | Entra efectivo, sube obligación con socio |
+| **USD** | `1.1.05` Bancos Cuentas USD | `2.1.02` Cuentas de Ahorro USD | Entra USD, sube obligación con socio |
+
+### Retiro (origen `AHORRO_RETIRO`)
+
+| Moneda | DEBE (cuenta) | HABER (cuenta) | Significado |
+|---|---|---|---|
+| **VES** | `2.1.01` Cuentas de Ahorro Bs | `1.1.01` Caja Principal | Baja obligación con socio, sale efectivo |
+| **USD** | `2.1.02` Cuentas de Ahorro USD | `1.1.05` Bancos Cuentas USD | Idem en dólares |
+
+> [!info] ¿Por qué este mapping?
+> Cuando un socio deposita Bs en su cuenta del fondo:
+> - **Activamente** el fondo recibe efectivo → Caja sube (ACTIVO, naturaleza DEUDORA → al **DEBE**)
+> - **Simultáneamente** el fondo le debe ese dinero al socio → Captaciones sube (PASIVO, naturaleza ACREEDORA → al **HABER**)
+>
+> Si el socio retira, es el espejo exacto: la deuda con el socio baja y la caja baja.
+
+## Arquitectura
+
+```
+RealizarDepositoUseCase  (módulo Ahorros)
+        │
+        │ contabilidadPort.registrarDeposito(cuenta, movimiento)
+        ▼
+AhorrosContabilidadPort   ← interfaz (port de salida)
+        │
+        ▼
+AhorrosContabilidadAdapter ← implementación, conoce los códigos VEN-NIF
+        │
+        │ asientoContableService.registrar(cmd)
+        ▼
+AsientoContableService    (módulo Contabilidad)
+        │
+        ▼
+asientos_contables + partidas_asientos    (BD)
+```
+
+> [!tip] Por qué un port en lugar de inyectar `AsientoContableService` directo
+> El port `AhorrosContabilidadPort` desacopla el módulo Ahorros del API interno
+> de Contabilidad. Si mañana cambiamos el modelo (ej. usamos eventos en lugar
+> de llamada síncrona), Ahorros no se entera — solo el adapter cambia.
+
+## Atomicidad — el punto crítico
+
+> [!danger] La contabilidad NO es best-effort
+> A diferencia de notificaciones email/SMS (que son resilientes — si fallan,
+> la operación sigue), un **asiento no generado** significa que la BD contable
+> está **desincronizada** con la BD operativa. Eso viola partida doble y nos
+> deja en infracción regulatoria SUDECA.
+
+Implementación:
+
+```java
+@Transactional
+public MovimientoResponse ejecutar(...) {
+    // 1. Validaciones de negocio
+    // 2. Mover saldo
+    // 3. Persistir movimiento
+    // 4. Notificar LOCDOFT (resiliente)
+    // 5. ⭐ Hook contable — si falla, ROLLBACK TOTAL
+    contabilidadPort.registrarDeposito(cuenta, movimiento);
+    return mapper.toResponse(movimiento);
+}
+```
+
+Si el adapter lanza `AsientoContableException`:
+- El `@Transactional` propaga la excepción.
+- Spring hace rollback de la transacción.
+- Se revierten: cambio de saldo, persistencia del movimiento, asiento parcial.
+- La operación devuelve HTTP 422 al cliente.
+
+## Casos borde cubiertos
+
+> [!note] Moneda null (cuentas legacy)
+> Las cuentas creadas antes del enum `Moneda` no tienen valor. El adapter
+> hace **fallback a Bs** para no romper. Si esto es común en PROD, vale la
+> pena agregar un constraint `NOT NULL` en `cuentas_ahorro.moneda`.
+
+## Tests
+
+| Test class | Casos | Estrategia |
+|---|---|---|
+| `AhorrosContabilidadAdapterTest` | 10 (2 nested) | Mockito — verifica que el `RegistrarAsientoCommand` es construido correctamente para cada combinación (Bs/USD × depósito/retiro) |
+| `RealizarDepositoUseCaseTest` | 6 | Mockito — verifica que el hook se invoque, y que NO se invoque si una validación previa falla (IDOR, cuenta cerrada, etc) |
+| `RealizarRetiroUseCaseTest` | 7 | Idem para retiro + saldo insuficiente |
+| `AhorrosContabilidadAdapterIntegrationTest` | 5 | `@DataJpaTest` con BD H2 real — ejecuta el adapter end-to-end y verifica que el asiento aparece en `asientos_contables` con las partidas correctas |
+
+### Verificaciones específicas
+
+> [!check] Garantías que dan los tests
+> - ✅ Depósito Bs usa exactamente `1.1.01` / `2.1.01`
+> - ✅ Depósito USD usa exactamente `1.1.05` / `2.1.02`
+> - ✅ Retiro invierte (DEBE el pasivo, HABER el activo)
+> - ✅ Si la cuenta contable referenciada no existe → `AsientoContableException`
+> - ✅ Si una validación de Ahorros falla (IDOR, saldo, cuenta cerrada), el hook NO se invoca
+> - ✅ El asiento queda balanceado (`Σdebe = Σhaber`) — invariante delegada al dominio
+> - ✅ Decimales (NUMERIC(18,4)) se preservan sin truncado
+> - ✅ `referenciaExterna` del asiento = `numeroOperacion` del movimiento (trazabilidad cruzada)
+
+## Cambios al codebase
+
+```
+backend/src/main/java/com/tufondo/ahorros/
+├── application/
+│   ├── port/output/
+│   │   └── AhorrosContabilidadPort.java          [NUEVO]
+│   └── usecase/
+│       ├── RealizarDepositoUseCase.java           [+inject port +call hook]
+│       └── RealizarRetiroUseCase.java             [+inject port +call hook]
+└── infrastructure/contabilidad/
+    └── AhorrosContabilidadAdapter.java            [NUEVO — mapea códigos]
+
+backend/src/test/java/com/tufondo/ahorros/
+├── application/usecase/
+│   ├── RealizarDepositoUseCaseTest.java           [NUEVO — 6 tests]
+│   └── RealizarRetiroUseCaseTest.java             [NUEVO — 7 tests]
+└── infrastructure/contabilidad/
+    ├── AhorrosContabilidadAdapterTest.java        [NUEVO — 10 tests unit]
+    └── AhorrosContabilidadAdapterIntegrationTest  [NUEVO — 5 tests E2E]
+```
+
+> [!warning] Cero cambios en el módulo Contabilidad
+> Este sub-issue NO toca `com.tufondo.contabilidad.*`. El service y dominio
+> ya estaban listos desde el [[02-asientos-contables|PR #314]]. Solo
+> agregamos un consumidor de su API.
+
+## Sub-issues relacionados
+
+- ⏳ **#268** — Hooks de Créditos (desembolso/cobro/intereses). Mismo patrón
+  exactamente, distintos códigos (`1.3.01`, `4.1.01`, etc).
+- ⏳ **Aplicar rendimiento** — actualmente `CalcularRendimientoUseCase` solo
+  calcula y persiste con estado `CALCULADO`. NO toca saldo ni genera asiento.
+  Cuando se decida cómo "aplicar" (workflow de aprobación, batch nocturno),
+  se agregará un hook con `OrigenAsiento.AHORRO_INTERES`.
+
+## Referencias
+
+- Issue: [[Home|#267]]
+- Dependencias: [[01-plan-cuentas|#264]], [[02-asientos-contables|#265 + #266]]
+- Use cases existentes (no creados aquí): `RealizarDepositoUseCase`, `RealizarRetiroUseCase`

--- a/docs/modulos/contabilidad/03-hooks-ahorros.md
+++ b/docs/modulos/contabilidad/03-hooks-ahorros.md
@@ -1,9 +1,10 @@
 ---
 tags: [contabilidad, ahorros, hooks, integracion]
 sub-issue: "#267"
-pr: pending
+pr: "#315"
 estado: en-construccion
 created: 2026-05-20
+actualizado: 2026-05-20 (D-002 fix 1.1.01 → 1.1.03)
 ---
 
 # 🔌 Hooks contables — módulo Ahorros
@@ -13,7 +14,14 @@ created: 2026-05-20
 > genera **automáticamente** su [[02-asientos-contables|asiento contable]] de
 > partida doble, dentro de la **misma transacción** que mueve el saldo.
 
-## Mapping operación → asiento
+> [!danger] Decisión correctiva D-002 (2026-05-20)
+> El mapping inicial usaba `1.1.01` Caja Principal para operaciones Bs.
+> **Eso fue corregido** a `1.1.03` Bancos Cta Corriente Bs antes de mergear
+> el PR #315, porque **Fatrans no opera con caja física**. Ver
+> [[_decisiones-contables#D-002|D-002]] para razón completa y análisis del
+> contador-fatrans.
+
+## Mapping operación → asiento (POST-fix D-002)
 
 > [!important] Las 4 variantes
 > El adapter [`AhorrosContabilidadAdapter`](../../../backend/src/main/java/com/tufondo/ahorros/infrastructure/contabilidad/AhorrosContabilidadAdapter.java)
@@ -23,22 +31,48 @@ created: 2026-05-20
 
 | Moneda | DEBE (cuenta) | HABER (cuenta) | Significado |
 |---|---|---|---|
-| **VES** | `1.1.01` Caja Principal | `2.1.01` Cuentas de Ahorro Bs | Entra efectivo, sube obligación con socio |
+| **VES** | `1.1.03` Bancos Cta Corriente Bs | `2.1.01` Cuentas de Ahorro Bs | Entra transferencia, sube obligación con socio |
 | **USD** | `1.1.05` Bancos Cuentas USD | `2.1.02` Cuentas de Ahorro USD | Entra USD, sube obligación con socio |
 
 ### Retiro (origen `AHORRO_RETIRO`)
 
 | Moneda | DEBE (cuenta) | HABER (cuenta) | Significado |
 |---|---|---|---|
-| **VES** | `2.1.01` Cuentas de Ahorro Bs | `1.1.01` Caja Principal | Baja obligación con socio, sale efectivo |
+| **VES** | `2.1.01` Cuentas de Ahorro Bs | `1.1.03` Bancos Cta Corriente Bs | Baja obligación con socio, sale transferencia |
 | **USD** | `2.1.02` Cuentas de Ahorro USD | `1.1.05` Bancos Cuentas USD | Idem en dólares |
 
 > [!info] ¿Por qué este mapping?
 > Cuando un socio deposita Bs en su cuenta del fondo:
-> - **Activamente** el fondo recibe efectivo → Caja sube (ACTIVO, naturaleza DEUDORA → al **DEBE**)
+> - **Activamente** el fondo recibe una transferencia → Bancos Bs sube (ACTIVO, naturaleza DEUDORA → al **DEBE**)
 > - **Simultáneamente** el fondo le debe ese dinero al socio → Captaciones sube (PASIVO, naturaleza ACREEDORA → al **HABER**)
 >
-> Si el socio retira, es el espejo exacto: la deuda con el socio baja y la caja baja.
+> Si el socio retira, es el espejo exacto: la deuda con el socio baja y los bancos bajan.
+
+### Por qué bancos y no caja
+
+> Cita del [[_contador-fatrans|contador-fatrans]] (revisión 2026-05-20):
+>
+> **VEN-NIF NIC-1 (presentación razonable)** exige que las partidas reflejen
+> la sustancia económica, no la forma. Si la operación es una transferencia
+> interbancaria (que es lo que Fatrans hace), asentarla en Caja distorsiona
+> el rubro **Disponible** y rompe la conciliación bancaria.
+>
+> Consecuencias si se hubiera mergeado con `1.1.01`:
+> 1. La conciliación bancaria del fondo no cuadraría: Banesco mostraría el ingreso, pero el libro mayor lo tendría en Caja → diferencia permanente.
+> 2. Auditoría externa lo observaría en la primera revisión.
+> 3. Reportes a SUDECA (#271) mostrarían Caja inflada artificialmente y Bancos subevaluado.
+>
+> Ver decisión completa en [[_decisiones-contables#D-002|D-002]].
+
+### Caso futuro: si Fatrans abre caja física
+
+Si en el futuro Fatrans abre oficina con caja de cobranza (pagos en billete),
+se necesitaría:
+- Agregar `canalOrigen` distinto en `DepositoRequest` (EFECTIVO vs TRANSFERENCIA).
+- Mapeo condicional en el adapter.
+- Sub-issue dedicado.
+
+**Por ahora, NO anticipamos** — el adapter usa `1.1.03` fijo.
 
 ## Arquitectura
 
@@ -98,8 +132,9 @@ Si el adapter lanza `AsientoContableException`:
 
 > [!note] Moneda null (cuentas legacy)
 > Las cuentas creadas antes del enum `Moneda` no tienen valor. El adapter
-> hace **fallback a Bs** para no romper. Si esto es común en PROD, vale la
-> pena agregar un constraint `NOT NULL` en `cuentas_ahorro.moneda`.
+> hace **fallback a Bs** (usa `1.1.03` / `2.1.01`) para no romper. Si esto
+> es común en PROD, vale la pena agregar un constraint `NOT NULL` en
+> `cuentas_ahorro.moneda` (ver [[_pendientes-criticos#Constraint-NOT-NULL-en-cuentas_ahorromoneda|P4 cosmético]]).
 
 ## Tests
 
@@ -112,8 +147,8 @@ Si el adapter lanza `AsientoContableException`:
 
 ### Verificaciones específicas
 
-> [!check] Garantías que dan los tests
-> - ✅ Depósito Bs usa exactamente `1.1.01` / `2.1.01`
+> [!check] Garantías que dan los tests (post-fix D-002)
+> - ✅ Depósito Bs usa exactamente `1.1.03` / `2.1.01`
 > - ✅ Depósito USD usa exactamente `1.1.05` / `2.1.02`
 > - ✅ Retiro invierte (DEBE el pasivo, HABER el activo)
 > - ✅ Si la cuenta contable referenciada no existe → `AsientoContableException`
@@ -149,17 +184,25 @@ backend/src/test/java/com/tufondo/ahorros/
 > ya estaban listos desde el [[02-asientos-contables|PR #314]]. Solo
 > agregamos un consumidor de su API.
 
-## Sub-issues relacionados
+## Pendiente intencionalmente fuera de scope
 
-- ⏳ **#268** — Hooks de Créditos (desembolso/cobro/intereses). Mismo patrón
-  exactamente, distintos códigos (`1.3.01`, `4.1.01`, etc).
 - ⏳ **Aplicar rendimiento** — actualmente `CalcularRendimientoUseCase` solo
   calcula y persiste con estado `CALCULADO`. NO toca saldo ni genera asiento.
   Cuando se decida cómo "aplicar" (workflow de aprobación, batch nocturno),
   se agregará un hook con `OrigenAsiento.AHORRO_INTERES`.
+- ⏳ **Devengo mensual de intereses pasivos** (a pagar al socio sobre sus ahorros)
+  — ver [[_pendientes-criticos#Devengo-mensual-de-intereses-pasivos-a-pagar-cuentas-de-ahorro|P1]].
+
+## Sub-issues relacionados
+
+- 🚧 [[04-hooks-creditos|#268]] — Hooks de Créditos (desembolso/cobro/intereses).
+  Mismo patrón exactamente, distintos códigos (`1.3.01`, `4.1.01`, etc).
 
 ## Referencias
 
 - Issue: [[Home|#267]]
+- PR: [#315](https://github.com/gamijoam/fatrans/pull/315)
+- Decisión clave: [[_decisiones-contables#D-002|D-002 — usar 1.1.03 no 1.1.01]]
+- Revisión contable: [[_contador-fatrans]]
 - Dependencias: [[01-plan-cuentas|#264]], [[02-asientos-contables|#265 + #266]]
 - Use cases existentes (no creados aquí): `RealizarDepositoUseCase`, `RealizarRetiroUseCase`

--- a/docs/modulos/contabilidad/04-hooks-creditos.md
+++ b/docs/modulos/contabilidad/04-hooks-creditos.md
@@ -1,0 +1,180 @@
+---
+tags: [contabilidad, creditos, hooks, integracion, planificacion]
+sub-issue: "#268"
+pr: pending
+estado: en-diseño
+created: 2026-05-20
+---
+
+# 🔌 Hooks contables — módulo Créditos (PLAN, no implementado todavía)
+
+> [!summary] Sub-issue [[Home|#268]] (en diseño)
+> Cada desembolso de crédito y cada pago de cuota debe generar
+> automáticamente su [[02-asientos-contables|asiento contable]] de partida
+> doble, en la misma transacción que mueve los datos operativos.
+>
+> Mapping **aprobado** por [[_contador-fatrans|contador-fatrans]] con
+> observaciones documentadas en [[_decisiones-contables#D-003|D-003]] y
+> [[_decisiones-contables#D-004|D-004]].
+
+## Mapping operación → asiento
+
+### Desembolso (origen `CREDITO_DESEMBOLSO`)
+
+```
+DEBE  1.3.01 Créditos Personales por Cobrar    [monto bruto solicitado]
+HABER 1.1.03 Bancos Cta Corriente Bs           [monto neto desembolsado al socio]
+HABER 4.1.02 Comisiones por Otorgamiento       [comisión apertura, SI > 0]
+```
+
+> [!important] Por qué este mapping
+> - **DEBE `1.3.01`**: la cartera sube por el monto bruto (lo que el socio debe).
+> - **HABER `1.1.03`**: sale plata del banco del fondo (transferencia bancaria al banco EXTERNO del socio — NO a su cuenta de ahorro del fondo). Ver [[_decisiones-contables#D-003|D-003]].
+> - **HABER `4.1.02`**: la comisión de apertura es ingreso inmediato del fondo (criterio VEN-NIF NIC-39 para préstamos a < 5 años).
+>
+> Cuadre: `bruto = neto + comisión` → balanceado.
+
+### Pago de cuota (origen `CREDITO_COBRO`)
+
+```
+DEBE  1.1.03 Bancos Cta Corriente Bs           [monto total cobrado]
+HABER 1.3.01 Créditos por Cobrar               [capital amortizado de la cuota]
+HABER 4.1.01 Intereses sobre Créditos          [intereses normales de la cuota]
+HABER 4.1.03 Intereses Moratorios              [SOLO si interesMora > 0]
+```
+
+> [!important] Por qué este desglose
+> - **DEBE `1.1.03`**: entra plata al banco del fondo (transferencia desde banco externo del socio).
+> - **HABER `1.3.01`**: la parte capital amortiza la cartera (NO es ingreso, solo baja pasivo del socio).
+> - **HABER `4.1.01`**: intereses normales son ingreso del fondo.
+> - **HABER `4.1.03`**: la mora es ingreso DIFERENCIADO de los intereses normales (clasificación SUDECA exige separación).
+>
+> Cuadre: `total = capital + interés + mora` → balanceado.
+
+### Casos NO cubiertos en #268
+
+Estos quedan documentados para sub-issues futuros:
+
+- ⏳ **Crédito en USD** — actualmente todos los créditos se asumen Bs.
+  Cuando aparezca, ver [[_pendientes-criticos#Cartera-y-operaciones-USD-separadas|P2 cartera USD]].
+- ⏳ **Intereses devengados pero no cobrados** — estamos en criterio de caja modificado.
+  Ver [[_decisiones-contables#D-005|D-005 pendiente]] y [[_pendientes-criticos#Devengo-mensual-de-intereses-sobre-cartera|devengo cartera]].
+- ⏳ **Seguros y comisiones intra-cuota** — los campos existen en `Amortizacion`
+  pero están en 0 en todos los flujos. Sub-issue dedicado con migration cuando se usen.
+- ⏳ **Ejecución de colateral** — cuando una cuota se ejecuta sobre garantía,
+  asiento distinto. Sub-issue dedicado.
+- ⏳ **Reverso de pago** — si admin anula un pago registrado por error.
+  Probablemente parte de #273 (reversión).
+- ⏳ **Mora cobrada parcialmente** — actualmente el use case valida pago completo;
+  si se permite pago parcial, asiento se complica.
+
+## Arquitectura propuesta
+
+Mismo patrón exacto que [[03-hooks-ahorros|#267]]:
+
+```
+DesembolsaCreditoUseCase     RegistrarPagoCuotaUseCase
+            │                            │
+            └────────────┬───────────────┘
+                         │
+                         ▼
+            CreditosContabilidadPort    ← interfaz (application/port/output)
+                         │
+                         ▼
+            CreditosContabilidadAdapter ← impl (infrastructure/contabilidad)
+                         │                conoce códigos VEN-NIF
+                         ▼
+            AsientoContableService.registrar()
+```
+
+### Métodos del port
+
+```java
+public interface CreditosContabilidadPort {
+    /**
+     * Asiento del desembolso de un crédito.
+     *
+     * @param solicitud  solicitud aprobada con monto y comisión apertura
+     * @param montoNeto  monto efectivamente desembolsado (monto bruto - comisión)
+     * @param comisionApertura comisión cobrada (puede ser 0)
+     */
+    void registrarDesembolso(SolicitudCredito solicitud,
+                             BigDecimal montoNeto,
+                             BigDecimal comisionApertura);
+
+    /**
+     * Asiento del cobro de una cuota.
+     *
+     * @param solicitud  crédito al que pertenece la cuota
+     * @param cuota      la cuota con desglose capital/interés/mora
+     * @param referenciaPago referencia bancaria del pago (auditoría cruzada)
+     */
+    void registrarPagoCuota(SolicitudCredito solicitud,
+                            Amortizacion cuota,
+                            String referenciaPago);
+}
+```
+
+## Cambios al codebase planificados
+
+```
+backend/src/main/java/com/tufondo/creditos/
+├── application/
+│   ├── port/output/
+│   │   └── CreditosContabilidadPort.java            [NUEVO]
+│   └── usecase/
+│       ├── DesembolsaCreditoUseCase.java             [+inject port +call hook]
+│       └── RegistrarPagoCuotaUseCase.java            [+inject port +call hook]
+└── infrastructure/contabilidad/
+    └── CreditosContabilidadAdapter.java              [NUEVO — mapea códigos]
+
+backend/src/test/java/com/tufondo/creditos/
+├── application/usecase/
+│   ├── DesembolsaCreditoUseCaseTest.java             [NUEVO]
+│   └── RegistrarPagoCuotaUseCaseTest.java            [NUEVO]
+└── infrastructure/contabilidad/
+    ├── CreditosContabilidadAdapterTest.java          [NUEVO — Mockito unit]
+    └── CreditosContabilidadAdapterIntegrationTest    [NUEVO — H2 E2E]
+```
+
+## Tests planificados
+
+| Test class | Casos esperados | Estrategia |
+|---|---|---|
+| `CreditosContabilidadAdapterTest` | ~12 unit | Mockito — verifica `RegistrarAsientoCommand` para desembolso con/sin comisión, pago con/sin mora |
+| `CreditosContabilidadAdapterIntegrationTest` | ~6 E2E | `@DataJpaTest` con H2 — asiento real persistido con partidas correctas |
+| `DesembolsaCreditoUseCaseTest` | ~6 unit | Mockito — verifica que el hook se invoque tras estado DESEMBOLSADO, propagación de errores |
+| `RegistrarPagoCuotaUseCaseTest` | ~7 unit | Mockito — verifica hook tras estado PAGADA, idempotencia por `referenciaPago` |
+
+### Casos específicos a cubrir
+
+- ✅ Desembolso sin comisión → 2 partidas (DEBE 1.3.01, HABER 1.1.03).
+- ✅ Desembolso con comisión > 0 → 3 partidas (la 3ra HABER 4.1.02).
+- ✅ Pago cuota sin mora → 3 partidas (DEBE 1.1.03, HABER 1.3.01, HABER 4.1.01).
+- ✅ Pago cuota con mora > 0 → 4 partidas (la 4ta HABER 4.1.03).
+- ✅ Cuadre exacto: `Σdebe == Σhaber` con decimales (forzar cuotas decimales raras).
+- ✅ Si AsientoContableService lanza, el use case propaga y hace rollback.
+- ✅ Si el plan de cuentas no tiene `1.3.01` o `1.1.03` → falla clara.
+- ✅ Doble pago de la misma `referenciaPago` se rechaza (idempotencia).
+- ✅ Crédito con moneda USD → excepción clara (no implementado, evitar bug silencioso).
+
+## Dependencias
+
+- ✅ [[01-plan-cuentas|#264]] — Plan de cuentas con `1.3.01`, `1.1.03`, `4.1.01`, `4.1.02`, `4.1.03`.
+- ✅ [[02-asientos-contables|#265 + #266]] — `AsientoContableService.registrar()`.
+- 🚧 [[03-hooks-ahorros|#267]] — debe estar mergeado primero (mismo `AhorrosContabilidadPort` no se reutiliza, pero el patrón sí).
+
+## Riesgo regulatorio (red flags identificados)
+
+Ver [[_pendientes-criticos]] sección "Críticos antes del primer cierre fiscal":
+
+- 🟠 Falta **devengo mensual de intereses** (criterio VEN-NIF) — pasaremos por
+  criterio de caja modificado en #268. Sub-issue dedicado antes del primer cierre.
+- 🟠 Falta **provisión de cartera** (cuenta `1.3.99` sin uso) — sub-issue dedicado.
+
+## Referencias
+
+- Issue: [[Home|#268]]
+- Decisiones: [[_decisiones-contables#D-003|D-003]], [[_decisiones-contables#D-004|D-004]]
+- Revisión contable: [[_contador-fatrans]]
+- Dependencias: [[01-plan-cuentas]], [[02-asientos-contables]], [[03-hooks-ahorros]]

--- a/docs/modulos/contabilidad/Home.md
+++ b/docs/modulos/contabilidad/Home.md
@@ -14,10 +14,26 @@ estado: en-construccion
 > alineada al estándar, Fatrans no puede operar como caja de ahorro
 > habilitada por SUDECA.
 
-## Mapa del módulo
+## 📚 Documentación del módulo
+
+### Trazabilidad transversal (leer primero)
+
+- 🗺️ [[00-overview]] — **Historia y timeline** del EPIC, decisiones cronológicas, estado actual
+- 📚 [[_decisiones-contables]] — **Log de decisiones** D-001, D-002... con razones y revisiones
+- 🚨 [[_pendientes-criticos]] — **Red flags regulatorios** identificados (devengo, provisión, USD, etc)
+- 🧮 [[_contador-fatrans]] — Sub-agente especializado en contaduría — **invocar antes de cada decisión contable**
+
+### Sub-issues del EPIC
+
+- 📋 [[01-plan-cuentas]] — #264 — Plan de cuentas VEN-NIF (V21, ~55 cuentas)
+- 🧾 [[02-asientos-contables]] — #265 + #266 — Tablas + dominio + service partida doble
+- 🔌 [[03-hooks-ahorros]] — #267 — Hooks Ahorros: depósito/retiro → asiento auto
+- 🔌 [[04-hooks-creditos]] — #268 — Hooks Créditos: desembolso/cobro → asiento auto (en diseño)
+
+## Mapa del módulo (código)
 
 ```
-contabilidad/
+backend/src/main/java/com/tufondo/contabilidad/
 ├── domain/
 │   ├── model/
 │   │   ├── CuentaContable        ← Aggregate del plan de cuentas
@@ -38,31 +54,46 @@ contabilidad/
         ├── entity/   (JPA)
         ├── jpa/      (Spring Data)
         └── adapter/  (implementación del port)
+
+backend/src/main/java/com/tufondo/ahorros/
+├── application/port/output/AhorrosContabilidadPort.java         ← #267
+└── infrastructure/contabilidad/AhorrosContabilidadAdapter.java   ← #267
 ```
 
-## Sub-issues del EPIC
+## Estado de los sub-issues
 
-| # | Estado | Tema |
-|---|---|---|
-| [[01-plan-cuentas\|#264]] | ✅ Merged | Plan de cuentas VEN-NIF (V21) — ~55 cuentas seed |
-| [[02-asientos-contables\|#265 + #266]] | ✅ Merged | Tablas + dominio + service + 50+ tests |
-| [[03-hooks-ahorros\|#267]] | 🚧 In progress | Hooks de Ahorros: depósito/retiro → asiento auto |
-| #268 | ⏳ Pending | Hooks de Créditos (desembolso/cobro/intereses) |
-| #269 | ⏳ Pending | Libro Diario + export PDF SUDECA |
-| #270 | ⏳ Pending | Libro Mayor (saldos por cuenta) |
-| #271 | ⏳ Pending | Balance General + Estado de Resultados |
-| #272 | ⏳ Pending | Cierre mensual / anual con bloqueo de período |
-| #273 | ⏳ Pending | Reversión de asientos (asiento inverso, sin DELETE) |
-| #274 | ⚠️ **BLOCKER** | Confirmar naturaleza jurídica Fatrans (caja ahorro / cooperativa / fideicomiso) |
+| # | Estado | Tema | Decisiones clave |
+|---|---|---|---|
+| [[01-plan-cuentas\|#264]] | ✅ Merged (PR #313) | Plan de cuentas VEN-NIF (V21) — ~55 cuentas seed | [[_decisiones-contables#D-001\|D-001]] V21 congelado |
+| [[02-asientos-contables\|#265 + #266]] | ✅ Merged (PR #314) | Tablas + dominio + service + 50+ tests | Asientos inmutables, ON DELETE RESTRICT |
+| [[03-hooks-ahorros\|#267]] | 🚧 PR #315 abierto | Hooks de Ahorros: depósito/retiro → asiento auto | [[_decisiones-contables#D-002\|D-002]] usar `1.1.03` no `1.1.01` |
+| [[04-hooks-creditos\|#268]] | 🚧 En diseño | Hooks de Créditos | [[_decisiones-contables#D-003\|D-003]] [[_decisiones-contables#D-004\|D-004]] |
+| #269 | ⏳ Pending | Libro Diario + export PDF SUDECA | |
+| #270 | ⏳ Pending | Libro Mayor (saldos por cuenta) | |
+| #271 | ⏳ Pending | Balance General + Estado de Resultados | |
+| #272 | ⏳ Pending | Cierre mensual / anual con bloqueo de período | |
+| #273 | ⏳ Pending | Reversión de asientos (asiento inverso, sin DELETE) | |
+| #274 | ⚠️ **BLOCKER LEGAL** | Confirmar naturaleza jurídica Fatrans (caja ahorro / cooperativa / fideicomiso) | Ver [[_pendientes-criticos#Confirmar-naturaleza-jurídica-Fatrans\|aquí]] |
 
-## Principios de diseño
+## Principios de diseño (no negociables)
 
-> [!important] Reglas no negociables
+> [!important] Reglas de oro
 > 1. **Partida doble** — `Σdebe = Σhaber` siempre. Validado en dominio + DB CHECK.
 > 2. **Asientos NO se borran** — solo se `ANULAN`. FK `ON DELETE RESTRICT`.
 > 3. **Correlativo continuo** — SEQUENCE `seq_asiento_numero` (sin gaps) por exigencia SUDECA.
 > 4. **Cuentas hoja solo** — solo cuentas con `acepta_movimientos=TRUE` reciben partidas. Las totalizadoras (nivel 1-2) suman.
 > 5. **Atomicidad** — el asiento se persiste en la misma transacción que la operación que lo dispara. Si falla, todo revierte.
+> 6. **Contador-fatrans revisa antes de codear** — cada mapping operación → cuentas pasa por [[_contador-fatrans|el sub-agente]] antes de implementarse.
+
+## Realidad operativa Fatrans (contexto crítico)
+
+> [!warning] Fatrans NO opera con caja física relevante
+> Todo dinero se mueve por **transferencia bancaria interbancaria**. Las cuentas
+> bancarias del fondo (`1.1.03` Bancos Bs, `1.1.05` Bancos USD) son las
+> operativas. La cuenta `1.1.01` Caja Principal queda en cero en la práctica.
+>
+> Esto fue aclarado el 2026-05-20 y motivó la decisión [[_decisiones-contables#D-002|D-002]]
+> (corregir mapping #267 antes de mergear).
 
 ## Referencias normativas
 
@@ -78,7 +109,7 @@ contabilidad/
 
 ## Cómo correr los tests
 
-Backend, vía Docker (no requiere Maven local):
+Backend, vía Docker (no requiere Maven local — el host puede no tener Java instalado):
 
 ```powershell
 docker run --rm `
@@ -89,4 +120,15 @@ docker run --rm `
     mvn -B test "-Dtest=com.tufondo.contabilidad.**.*Test"
 ```
 
-Última corrida verde: **120 tests, 0 failures, 0 errors** (2026-05-20).
+Última corrida verde:
+- **Módulo contabilidad solo**: 120 tests, 0 failures (2026-05-20)
+- **Suite completa backend**: 555 tests, 0 failures (2026-05-20, post #267)
+
+## Cómo trabajar el módulo
+
+1. **Antes de cualquier código contable**: invocar [[_contador-fatrans]] para revisar el mapping.
+2. **Antes de cada PR del EPIC**: actualizar [[00-overview]] con la entrada en el timeline.
+3. **Cada decisión contable**: dejar entrada en [[_decisiones-contables]].
+4. **Cada red flag identificado**: agregar a [[_pendientes-criticos]].
+5. **Si se agregan cuentas al plan**: migration V22+, NUNCA editar V21.
+6. **Si se modifican operaciones existentes**: validar que los asientos siguen cuadrando.

--- a/docs/modulos/contabilidad/Home.md
+++ b/docs/modulos/contabilidad/Home.md
@@ -1,0 +1,92 @@
+---
+tags: [modulo, contabilidad, ven-nif, sudeca]
+created: 2026-05-20
+epic: "#263"
+estado: en-construccion
+---
+
+# 📒 Módulo Contabilidad
+
+> [!info] EPIC #263 — Contabilidad por partida doble
+> Sistema contable completo para cumplimiento regulatorio **SUDECA / VEN-NIF**.
+> Cada operación financiera del fondo (depósitos, retiros, créditos, intereses)
+> genera automáticamente sus asientos de partida doble. Sin contabilidad
+> alineada al estándar, Fatrans no puede operar como caja de ahorro
+> habilitada por SUDECA.
+
+## Mapa del módulo
+
+```
+contabilidad/
+├── domain/
+│   ├── model/
+│   │   ├── CuentaContable        ← Aggregate del plan de cuentas
+│   │   ├── AsientoContable       ← Aggregate root del asiento (cabecera + partidas)
+│   │   ├── PartidaAsiento        ← Entity hija (cada renglón DEBE/HABER)
+│   │   └── enums/
+│   │       ├── TipoCuentaContable   (ACTIVO/PASIVO/PATRIMONIO/INGRESO/EGRESO/CUENTA_ORDEN)
+│   │       ├── NaturalezaSaldo      (DEUDORA / ACREEDORA)
+│   │       ├── EstadoAsiento        (REGISTRADO / ANULADO)
+│   │       └── OrigenAsiento        (10 valores: AHORRO_DEPOSITO, CREDITO_DESEMBOLSO, ...)
+│   └── repository/  (ports)
+├── application/
+│   ├── dto/RegistrarAsientoCommand
+│   ├── usecase/AsientoContableService.registrar()/anular()
+│   └── exception/AsientoContableException
+└── infrastructure/
+    └── persistence/
+        ├── entity/   (JPA)
+        ├── jpa/      (Spring Data)
+        └── adapter/  (implementación del port)
+```
+
+## Sub-issues del EPIC
+
+| # | Estado | Tema |
+|---|---|---|
+| [[01-plan-cuentas\|#264]] | ✅ Merged | Plan de cuentas VEN-NIF (V21) — ~55 cuentas seed |
+| [[02-asientos-contables\|#265 + #266]] | ✅ Merged | Tablas + dominio + service + 50+ tests |
+| [[03-hooks-ahorros\|#267]] | 🚧 In progress | Hooks de Ahorros: depósito/retiro → asiento auto |
+| #268 | ⏳ Pending | Hooks de Créditos (desembolso/cobro/intereses) |
+| #269 | ⏳ Pending | Libro Diario + export PDF SUDECA |
+| #270 | ⏳ Pending | Libro Mayor (saldos por cuenta) |
+| #271 | ⏳ Pending | Balance General + Estado de Resultados |
+| #272 | ⏳ Pending | Cierre mensual / anual con bloqueo de período |
+| #273 | ⏳ Pending | Reversión de asientos (asiento inverso, sin DELETE) |
+| #274 | ⚠️ **BLOCKER** | Confirmar naturaleza jurídica Fatrans (caja ahorro / cooperativa / fideicomiso) |
+
+## Principios de diseño
+
+> [!important] Reglas no negociables
+> 1. **Partida doble** — `Σdebe = Σhaber` siempre. Validado en dominio + DB CHECK.
+> 2. **Asientos NO se borran** — solo se `ANULAN`. FK `ON DELETE RESTRICT`.
+> 3. **Correlativo continuo** — SEQUENCE `seq_asiento_numero` (sin gaps) por exigencia SUDECA.
+> 4. **Cuentas hoja solo** — solo cuentas con `acepta_movimientos=TRUE` reciben partidas. Las totalizadoras (nivel 1-2) suman.
+> 5. **Atomicidad** — el asiento se persiste en la misma transacción que la operación que lo dispara. Si falla, todo revierte.
+
+## Referencias normativas
+
+- **VEN-NIF** — Normas Venezolanas de Información Financiera (basadas en IFRS).
+- **SUDECA** — Superintendencia de Cajas de Ahorro.
+- **SUNACOOP** — Superintendencia de Cooperativas (si Fatrans califica como cooperativa).
+- Plan de cuentas tipo de SUDECA para cajas de ahorro venezolanas.
+
+> [!warning] Validación pendiente
+> El seed V21 está basado en plantillas públicas. **Antes de uso productivo
+> contable real**, un contador colegiado debe validarlo y firmar conformidad.
+> Ver [[01-plan-cuentas]] para detalles del proceso de cambios.
+
+## Cómo correr los tests
+
+Backend, vía Docker (no requiere Maven local):
+
+```powershell
+docker run --rm `
+    -v "${PWD}/backend:/workspace" `
+    -v "$env:USERPROFILE/.m2:/root/.m2" `
+    -w /workspace `
+    maven:3.9-eclipse-temurin-21 `
+    mvn -B test "-Dtest=com.tufondo.contabilidad.**.*Test"
+```
+
+Última corrida verde: **120 tests, 0 failures, 0 errors** (2026-05-20).

--- a/docs/modulos/contabilidad/_contador-fatrans.md
+++ b/docs/modulos/contabilidad/_contador-fatrans.md
@@ -1,0 +1,113 @@
+---
+tags: [contabilidad, sub-agente, claude-code, herramientas]
+created: 2026-05-20
+estado: activo
+---
+
+# 🧮 Sub-agente `contador-fatrans`
+
+> [!summary] Para qué es
+> Sub-agente especializado de Claude Code que revisa proactivamente cada
+> decisión contable del proyecto. Conoce VEN-NIF, SUDECA/SUNACOOP, el plan
+> de cuentas Fatrans (V21), y la realidad operativa específica del fondo
+> (transferencias bancarias, no caja física).
+
+## Ubicación del archivo
+
+`.claude/agents/contador-fatrans.md` (en raíz del repo — versionado, queda para todo el equipo).
+
+## Cuándo se invoca
+
+Claude (agente principal) lo invoca **proactivamente** sin que el usuario
+tenga que pedirlo, en los siguientes escenarios:
+
+- ✅ Antes de codear cualquier mapping operación → asiento contable.
+- ✅ Antes de mergear cualquier PR que toque `com.tufondo.contabilidad.*` o
+  `*ContabilidadAdapter` / `*ContabilidadPort` en otros módulos.
+- ✅ Cuando se diseñan reportes contables (Libro Diario, Libro Mayor,
+  Balance General, Estado de Resultados).
+- ✅ Cuando se discute si una operación de negocio debe ir a una cuenta u otra.
+- ✅ Cuando se considera agregar/modificar cuentas al plan de cuentas
+  (migration V22+).
+- ✅ Cuando se diseñan jobs de cierre, devengo, provisión, depreciación, etc.
+
+## Cómo invocarlo manualmente
+
+Si el usuario quiere forzar una revisión:
+
+> "Pasale esto al contador para revisión: [describir el mapping o decisión]"
+
+O directamente desde una sesión Claude Code:
+
+```
+> Invocar Agent con subagent_type: contador-fatrans
+```
+
+## Qué evalúa formalmente
+
+1. **Cuentas existen y son hoja** (no totalizadoras).
+2. **Cuadre de partida doble** (Σdebe = Σhaber exacto).
+3. **Naturaleza correcta** (DEUDORA/ACREEDORA según la operación).
+4. **Refleja la realidad operativa** (no asentar a Caja si es transferencia).
+5. **Desglose suficiente** (capital vs interés vs mora separados).
+6. **Auditoría completa** (glosa clara, origen, referencia externa).
+7. **Atomicidad** (asiento en la misma transacción que la operación).
+8. **Cuentas correctoras correctas** (`1.3.99`, `1.5.99` con naturaleza opuesta — esperado).
+
+## Errores comunes que detecta
+
+- ❌ Usar `1.1.01` Caja Principal para operaciones bancarias en Fatrans
+  → debe ser `1.1.03` Bancos Bs ([[_decisiones-contables#D-002|ver D-002]]).
+- ❌ Mezclar intereses normales con moratorios en una sola cuenta
+  → deben ser `4.1.01` vs `4.1.03` ([[_decisiones-contables#D-004|ver D-004]]).
+- ❌ Asentar capital como ingreso (capital baja `1.3.01`, NO entra a `4.x.x`).
+- ❌ Asientos contra cuentas no-hoja (`1.1`, `2.1`, etc).
+- ❌ Asientos sin glosa o con glosa genérica.
+- ❌ Sin `referenciaExterna` para asientos automáticos (rompe trazabilidad).
+- ❌ `BigDecimal` con escala != 4 (BD es `NUMERIC(18,4)`).
+- ❌ Hook contable fuera del `@Transactional` (rompe atomicidad).
+- ❌ `DELETE` físico de asientos o partidas (solo ANULAR con motivo).
+- ❌ Permitir asientos en período cerrado (cuando #272 se implemente).
+
+## Formato de sus respuestas
+
+1. **Veredicto**: ✅ Aprueba / ⚠️ Aprueba con observaciones / ❌ Rechaza
+2. **Tabla del asiento propuesto vs. recomendado** (si difieren)
+3. **Razón regulatoria** (qué norma o exigencia SUDECA aplica)
+4. **Casos borde a considerar**
+5. **Tests faltantes**
+
+## Limitaciones
+
+- ⚠️ **NO sustituye contador colegiado**: el sub-agente actúa como
+  primera línea de defensa, pero antes de uso productivo formal hay que
+  conseguir validación de contador venezolano colegiado.
+- ⚠️ **No conoce normativas futuras**: si SUDECA emite resolución nueva,
+  hay que actualizar el archivo del sub-agente con esa info.
+- ⚠️ **Solo aplica al contexto Fatrans**: el sub-agente está hardcodeado al
+  plan V21 y la realidad operativa Fatrans. Otro proyecto necesitaría
+  configuración distinta.
+
+## Mantenimiento del sub-agente
+
+El archivo `.claude/agents/contador-fatrans.md` debe actualizarse cuando:
+
+1. Se agregan/eliminan cuentas del plan (migration V22+).
+2. Cambia la naturaleza jurídica de Fatrans (#274 resuelve a caja/cooperativa/etc).
+3. Se identifican nuevos errores comunes.
+4. Se toman decisiones contables nuevas ([[_decisiones-contables|registrar acá]]).
+5. SUDECA emite normativa nueva relevante.
+
+## Casos donde ya intervino
+
+| Fecha | Asunto | Veredicto |
+|---|---|---|
+| 2026-05-20 | Revisión `1.1.01` vs `1.1.03` en #267 | ❌ Corregir antes de mergear ([[_decisiones-contables#D-002\|D-002]]) |
+| 2026-05-20 | Aprobar mapping desembolso/cuota para #268 | ✅ Aprobado con observaciones ([[_decisiones-contables#D-003\|D-003]], [[_decisiones-contables#D-004\|D-004]]) |
+| 2026-05-20 | Identificar pendientes regulatorios del EPIC | ⚠️ 5 red flags + 5 mejoras (ver [[_pendientes-criticos]]) |
+
+## Cómo "actualizar" su conocimiento
+
+Editar directamente `.claude/agents/contador-fatrans.md` en el repo. Los
+cambios se cargan al reiniciar Claude Code en este proyecto (sesiones
+nuevas lo ven actualizado; sesiones activas requieren reload).

--- a/docs/modulos/contabilidad/_decisiones-contables.md
+++ b/docs/modulos/contabilidad/_decisiones-contables.md
@@ -1,0 +1,303 @@
+---
+tags: [contabilidad, decisiones, adr, registro]
+created: 2026-05-20
+estado: documento-vivo
+---
+
+# 📚 Registro de decisiones contables (D-xxx)
+
+> [!info] Propósito
+> Cada decisión contable tomada durante el EPIC #263 queda registrada acá con:
+> - **Contexto** (qué situación la disparó)
+> - **Opciones consideradas**
+> - **Decisión tomada y razón**
+> - **Consecuencias** (qué cambia, qué queda abierto)
+> - **Revisor** (quién aprobó — [[_contador-fatrans]] cuando aplica)
+>
+> Estilo ADR (Architecture Decision Record) pero más informal y enfocado
+> en contabilidad. **No editar decisiones pasadas** — si cambian, agregar
+> nueva D-xxx que las supersede.
+
+---
+
+## D-001 — Plan de cuentas seedeado en migration V21, no editable in-place
+
+**Fecha:** 2026-05-19
+**Sub-issue:** [[01-plan-cuentas|#264]]
+**Estado:** ✅ Aprobada e implementada
+
+### Contexto
+Necesitábamos un plan de cuentas inicial sin esperar a un contador colegiado.
+
+### Decisión
+Seedeamos ~55 cuentas en `V21__plan_cuentas_ven_nif.sql` basadas en plantillas
+públicas SUDECA. **NUNCA editar V21 in-place** — cualquier cambio futuro va
+en V22+ con `INSERT`/`UPDATE`.
+
+### Razón
+- Mantener consistencia entre ambientes (dev/QA/PROD).
+- Permitir auditoría del histórico de cambios al plan.
+- Si V21 cambia in-place, ambientes con la versión vieja quedarían huérfanos.
+
+### Consecuencias
+- 🔒 V21 está congelado.
+- ⚠️ Antes de uso productivo formal, contador colegiado debe firmar el plan.
+- ✅ Cambios al plan son auditables (cada migration documenta qué y por qué).
+
+---
+
+## D-002 — Usar `1.1.03` Bancos Cuenta Corriente Bs (NO `1.1.01` Caja Principal) para operaciones de ahorro en Bs
+
+**Fecha:** 2026-05-20
+**Sub-issue:** [[03-hooks-ahorros|#267]] (PR #315)
+**Estado:** ✅ Aprobada (en proceso de implementación — corrigiendo PR #315)
+**Revisor:** [[_contador-fatrans|contador-fatrans]]
+
+### Contexto
+Implementación inicial de #267 usaba `1.1.01` Caja Principal como cuenta DEBE
+en depósitos Bs (y HABER en retiros Bs). Tests pasaban (28 verdes), pero
+durante la review se aclaró que **Fatrans no opera con caja física relevante**.
+
+> Cita del usuario (gamijoam, 2026-05-20):
+> "Ahorita estamos en un proceso manual, o sea, si una persona quiere un
+> crédito, por lo general le hace una transferencia a la cuenta del socio,
+> pero a otra cuenta, no a la del fondo de ahorro. Porque no estamos
+> enlazados como tal a un instrumento financiero, o sea, el socio puede ver
+> su saldo, pero no es como un banco que tienes tu saldo ahí y lo retiras
+> directamente para pagar."
+
+### Opciones consideradas
+1. **Dejar `1.1.01` Caja Principal** — mantiene mapping actual.
+2. **Cambiar a `1.1.03` Bancos Cuenta Corriente Bs** — refleja la realidad operativa.
+3. **Hacer configurable por operación** (canal: efectivo vs transferencia).
+
+### Decisión
+**Opción 2** — cambiar a `1.1.03` fijo. La opción 3 introduce complejidad
+que no se justifica hasta que aparezca el flujo de pago en efectivo (que hoy
+no existe).
+
+### Razón regulatoria (cita del contador-fatrans)
+> **VEN-NIF NIC-1 (presentación razonable)**: las partidas deben reflejar la
+> sustancia económica, no la forma. Si la operación es una transferencia
+> interbancaria, asentarla en Caja distorsiona el rubro **Disponible** y
+> rompe la conciliación bancaria.
+>
+> Consecuencias prácticas si no se corrige:
+> 1. La conciliación bancaria del fondo no cuadrará: Banesco mostrará el
+>    ingreso, pero el libro mayor lo tiene en Caja → diferencia permanente.
+> 2. Auditoría externa lo va a observar en la primera revisión — es de los
+>    hallazgos más frecuentes en cooperativas.
+> 3. Reportes a SUDECA (cuando #271 esté) mostrarán Caja inflada
+>    artificialmente y Bancos subevaluado.
+
+### Mapping correcto post-D-002
+
+| Operación | Moneda | DEBE | HABER |
+|---|---|---|---|
+| Depósito | VES | **`1.1.03` Bancos Cta Corriente Bs** | `2.1.01` Cuentas de Ahorro Bs |
+| Depósito | USD | `1.1.05` Bancos USD | `2.1.02` Cuentas de Ahorro USD |
+| Retiro | VES | `2.1.01` Cuentas de Ahorro Bs | **`1.1.03` Bancos Cta Corriente Bs** |
+| Retiro | USD | `2.1.02` Cuentas de Ahorro USD | `1.1.05` Bancos USD |
+
+(`1.1.05` USD se mantiene sin cambios — esa cuenta sí es "bancos", no caja).
+
+### Consecuencias
+- Cambio en `AhorrosContabilidadAdapter.java` línea ~54: renombrar
+  `CUENTA_CAJA_BS` → `CUENTA_BANCO_BS`, cambiar valor `"1.1.01"` → `"1.1.03"`.
+- Actualizar 4 tests del adapter (`AhorrosContabilidadAdapterTest`).
+- Actualizar 5 tests E2E (`AhorrosContabilidadAdapterIntegrationTest`).
+- Documentación: actualizar [[03-hooks-ahorros]] con el mapping nuevo.
+- Push al mismo PR #315 (no mergeado todavía).
+
+### Excepción documentada
+Si en el futuro Fatrans abre oficina física con caja de cobranza (pagos en
+billete), entonces SÍ se necesitaría usar `1.1.01` para esos casos
+específicos. Eso requeriría:
+- Un parámetro en `DepositoRequest` para distinguir el canal (transferencia vs efectivo).
+- Un mapeo condicional en el adapter.
+- Un sub-issue dedicado.
+
+**Por ahora, no anticipamos**.
+
+---
+
+## D-003 — Desembolso de crédito sale del banco del fondo, NO de la cuenta de ahorro del socio
+
+**Fecha:** 2026-05-20
+**Sub-issue:** [[04-hooks-creditos|#268]] (en diseño)
+**Estado:** ✅ Aprobada (a implementar)
+**Revisor:** [[_contador-fatrans|contador-fatrans]]
+
+### Contexto
+Para el sub-issue #268, había que decidir cómo modelar contablemente el
+desembolso de un crédito. Hay dos opciones operativas posibles:
+
+1. **Salir por banco del fondo (transferencia externa)** — el fondo transfiere
+   desde su cuenta corriente Bs al banco externo del socio.
+2. **Acreditar a la cuenta de ahorro del socio (en el fondo)** — el "saldo
+   virtual" del socio en la app crece, pero no sale plata real.
+
+### Opciones consideradas
+
+**Asiento si Opción 1 (transferencia externa):**
+```
+DEBE  1.3.01 Créditos por Cobrar           [monto bruto]
+HABER 1.1.03 Bancos Cta Corriente Bs       [monto neto]
+HABER 4.1.02 Comisiones por Otorgamiento   [comisión, si > 0]
+```
+
+**Asiento si Opción 2 (acreditar a ahorros):**
+```
+DEBE  1.3.01 Créditos por Cobrar           [monto bruto]
+HABER 2.1.01 Cuentas de Ahorro Bs          [monto neto]
+HABER 4.1.02 Comisiones por Otorgamiento   [comisión, si > 0]
+```
+
+### Decisión
+**Opción 1** — el desembolso siempre sale del banco del fondo.
+
+### Razón
+- Refleja la realidad operativa de Fatrans (transferencia bancaria al banco
+  externo del socio).
+- Mantiene separados contablemente los módulos Ahorros (captaciones) y
+  Créditos (cartera).
+- Evita que un desembolso "infle" artificialmente el saldo de ahorros del socio.
+
+### Consecuencias
+- El campo `cuentaDestino` que ya existe en `SolicitudCredito` se documenta
+  como **cuenta bancaria externa del socio** (no como cuenta de ahorro del
+  fondo). Es el dato que el admin usa para hacer la transferencia.
+- El `referenciaDesembolso` se usa como auditoría de la transferencia bancaria
+  real.
+
+---
+
+## D-004 — Pago de cuota se desglosa en 3+ cuentas (capital + interés + mora si aplica)
+
+**Fecha:** 2026-05-20
+**Sub-issue:** [[04-hooks-creditos|#268]] (en diseño)
+**Estado:** ✅ Aprobada (a implementar)
+**Revisor:** [[_contador-fatrans|contador-fatrans]]
+
+### Contexto
+Al cobrar una cuota, el monto total se compone de capital, intereses
+normales, mora, y (potencialmente) seguros y comisiones intra-cuota.
+Pregunta: ¿cuál es el nivel de desglose contable correcto?
+
+### Opciones consideradas
+
+**A. Mínimo (Capital + Interés + Mora):**
+```
+DEBE  1.1.03 Bancos
+HABER 1.3.01 Cartera (capital)
+HABER 4.1.01 Intereses normales
+HABER 4.1.03 Mora (solo si > 0)
+```
+
+**B. Simplificado (Capital + todo lo demás junto):**
+```
+DEBE  1.1.03 Bancos
+HABER 1.3.01 Cartera (capital)
+HABER 4.1.01 Intereses (= intereses + mora + seguros + comisiones)
+```
+
+**C. Completo (Capital + Interés + Mora + Seguros + Comisiones):**
+```
+DEBE  1.1.03 Bancos
+HABER 1.3.01 Cartera
+HABER 4.1.01 Intereses normales
+HABER 4.1.03 Mora
+HABER 4.1.04 Seguros (cuenta a crear)
+HABER 4.1.05 Comisiones Otras (cuenta a crear)
+```
+
+### Decisión
+**Opción A** — desglose mínimo (Capital + Interés + Mora).
+
+### Razón regulatoria
+> Es el **desglose mínimo legalmente exigido** por SUDECA:
+> - Capital → amortiza pasivo del socio (no es ingreso)
+> - Intereses → ingreso operativo de la entidad
+> - Mora → ingreso diferenciado (clasificación distinta, base de cálculo distinta)
+>
+> La opción B (mezclar mora con intereses) dificulta reportes de morosidad
+> y crea riesgo de hallazgo en auditoría.
+>
+> La opción C requiere migration nueva con `4.1.04` y `4.1.05` para campos
+> (`seguros`, `comisiones` en `Amortizacion`) que actualmente están en 0 en
+> todos los flujos. Agregar cuentas para campos vacíos es ruido.
+
+### Consecuencias
+- En el adapter de #268, el método `registrarPagoCuota` arma 3 o 4 partidas
+  según si hay mora.
+- Cuando el negocio empiece a usar `seguros`/`comisiones` intra-cuota, se
+  abre sub-issue dedicado con migration V23 que agrega las cuentas.
+- Se documenta explícitamente que estamos en **criterio de caja modificado**
+  para intereses (ver [[_pendientes-criticos#Devengo-mensual|D-005 pendiente]]).
+
+---
+
+## D-005 — (PENDIENTE) Criterio de caja vs devengo para intereses de cartera
+
+**Fecha:** 2026-05-20
+**Sub-issue:** sin asignar — abrir antes del primer cierre fiscal
+**Estado:** ⏳ Diferida, documentada
+
+### Contexto
+El contador-fatrans observó que VEN-NIF (criterio de devengo) exige reconocer
+ingresos cuando se genera el derecho (devengo mensual), no cuando se cobra.
+Actualmente #268 va a registrar intereses directamente a `4.1.01` al momento
+de cobrar la cuota.
+
+### Decisión temporal
+Implementar #268 en **criterio de caja modificado** (intereses al cobro,
+no al devengo). Aceptable para cooperativa pequeña sin cierre fiscal aún.
+
+### Implementación correcta a futuro
+Job mensual (Spring `@Scheduled`) que asienta:
+```
+DEBE  1.3.03 Intereses por Cobrar sobre Créditos   [intereses devengados del mes]
+HABER 4.1.01 Intereses sobre Créditos              [ingreso reconocido]
+```
+
+Y al cobrar la cuota:
+```
+DEBE  1.1.03 Bancos
+HABER 1.3.01 Cartera (capital)
+HABER 1.3.03 Intereses por Cobrar (los devengados — NO 4.1.01)
+HABER 4.1.03 Mora (si aplica)
+```
+
+### Acción
+Abrir issue separado "Implementar devengo mensual de intereses sobre cartera
+(NIC-1)" cuando se acerque el primer cierre fiscal serio.
+
+---
+
+## Plantilla para decisiones nuevas
+
+```markdown
+## D-xxx — [Título corto, decisorio]
+
+**Fecha:** YYYY-MM-DD
+**Sub-issue:** [[link]]
+**Estado:** ⏳ En discusión / ✅ Aprobada / ❌ Rechazada / 🔄 Superseded by D-yyy
+**Revisor:** [[_contador-fatrans]] / contador externo / etc
+
+### Contexto
+[¿Qué problema o situación motivó esta decisión?]
+
+### Opciones consideradas
+1. ...
+2. ...
+
+### Decisión
+[Cuál se elige]
+
+### Razón
+[Por qué — preferentemente con cita regulatoria si aplica]
+
+### Consecuencias
+- [Qué cambia en código / docs / proceso]
+- [Qué queda abierto]
+```

--- a/docs/modulos/contabilidad/_pendientes-criticos.md
+++ b/docs/modulos/contabilidad/_pendientes-criticos.md
@@ -1,0 +1,263 @@
+---
+tags: [contabilidad, pendientes, red-flags, backlog]
+created: 2026-05-20
+estado: documento-vivo
+---
+
+# 🚨 Pendientes críticos del módulo contabilidad
+
+> [!warning] Para qué sirve este documento
+> Lista priorizada de **red flags contables-regulatorios** identificados
+> durante el EPIC #263 que NO están resueltos. Cada uno se debe convertir
+> en sub-issue antes del primer cierre fiscal real (o antes según
+> criticidad).
+>
+> Identificados mayormente por [[_contador-fatrans]] en sus revisiones.
+
+---
+
+## 🔴 Bloqueantes para PROD productivo contable
+
+### Validación externa del plan V21
+**Prioridad:** P0 (bloqueante absoluto pre-PROD)
+
+El plan de cuentas seedeado en V21 está basado en plantillas públicas SUDECA,
+pero **no está firmado por contador colegiado venezolano**. Antes de uso
+productivo contable formal:
+
+- [ ] Contratar contador colegiado para revisión del plan.
+- [ ] Documentar firma/dictamen como referencia en `_validacion-contable.md`.
+- [ ] Si el contador sugiere cambios, abrir migration V23+ (NUNCA editar V21 in-place — [[_decisiones-contables#D-001|D-001]]).
+
+### Confirmar naturaleza jurídica Fatrans
+**Issue:** #274 (existe, sin avance)
+**Prioridad:** P0
+
+Sigue sin confirmarse si Fatrans opera bajo:
+- **SUDECA** (Caja de Ahorro) — exige ciertos planes y reservas.
+- **SUNACOOP** (Cooperativa) — exige reserva de educación, solidaridad, otros.
+- **Fideicomiso** — otro régimen distinto.
+
+Esto **afecta el plan de cuentas** (algunas cuentas son específicas del
+régimen) y los **reportes a entes reguladores** (#271).
+
+**Acción:** Conseguir documento legal de constitución de Fatrans para
+confirmar el régimen.
+
+---
+
+## 🟠 Críticos antes del primer cierre fiscal
+
+### Devengo mensual de intereses sobre cartera
+**Decisión origen:** [[_decisiones-contables#D-005|D-005]]
+**Prioridad:** P1 (bloqueante antes del primer cierre serio)
+
+Actualmente registramos intereses directo a `4.1.01` al cobro de cuota
+(criterio de caja modificado). VEN-NIF NIC-1 exige criterio de devengo:
+reconocer el ingreso cuando se genera el derecho, no cuando se cobra.
+
+**Implementación correcta:**
+Job mensual (Spring `@Scheduled` el último día de cada mes) que:
+
+```
+Para cada crédito con cuotas vigentes:
+  DEBE  1.3.03 Intereses por Cobrar sobre Créditos   [interés del mes según plan]
+  HABER 4.1.01 Intereses sobre Créditos              [ingreso reconocido]
+```
+
+Y al cobrar la cuota, los intereses se cargan a `1.3.03` (que estaba
+provisionado), no a `4.1.01` nuevo.
+
+**Tareas:**
+- [ ] Diseñar job `DevengarInteresesCarteraJob`.
+- [ ] Modificar hook de pago de cuota (#268) para que cuando exista devengo
+      previo del período, descargue contra `1.3.03` en lugar de `4.1.01`.
+- [ ] Tests del job + tests del fallback (qué pasa si no se ejecutó el job
+      del mes anterior).
+
+### Devengo mensual de intereses pasivos a pagar (cuentas de ahorro)
+**Prioridad:** P1
+
+Los socios ganan intereses sobre sus saldos de ahorro. Actualmente NO se
+está reconociendo este gasto del fondo. Debería:
+
+```
+DEBE  5.1.01 Intereses sobre Cuentas de Ahorro     [interés calculado del mes]
+HABER 2.1.04 Intereses por Pagar Captaciones       [provisión]
+```
+
+Y cuando se "paga" (acredita a la cuenta del socio):
+```
+DEBE  2.1.04 Intereses por Pagar Captaciones
+HABER 2.1.01 Cuentas de Ahorro Bs (o el destino real del pago)
+```
+
+**Tareas:**
+- [ ] Decidir periodicidad (mensual/trimestral) según política de Fatrans.
+- [ ] Decidir cómo "calcular" el interés (tasa fija anual, variable, segmentado por tipo de cuenta).
+- [ ] Implementar `DevengarInteresesAhorrosJob`.
+- [ ] Cuando #267 madure: hook `OrigenAsiento.AHORRO_INTERES` para el pago.
+
+### Provisión de cartera de créditos
+**Prioridad:** P1
+
+La cuenta `1.3.99` Provisión Cartera de Créditos existe en el plan (V21) pero
+**ningún proceso la mueve**. Exigencia SUDECA para cooperativas: provisión
+calculada periódicamente basada en morosidad.
+
+**Esquema típico (Resolución 011-22 SUDEBAN, también aplica conceptualmente a SUDECA):**
+
+| Estado | Riesgo | Provisión |
+|---|---|---|
+| Vigente | Normal | 1% |
+| Vencido 1-30 días | A | 1% |
+| Vencido 31-60 días | B | 5% |
+| Vencido 61-90 días | C | 20% |
+| Vencido 91-180 días | D | 50% |
+| Vencido >180 días | E | 100% |
+
+Asiento de constitución (sube provisión):
+```
+DEBE  5.2.08 Otros Gastos Operativos (o crear 5.2.09 Gasto por Provisión Cartera)
+HABER 1.3.99 Provisión Cartera de Créditos
+```
+
+**Tareas:**
+- [ ] Crear job `ProvisionarCarteraJob` mensual.
+- [ ] Decidir tabla de % por estado (consultar contador para tabla local).
+- [ ] Potencialmente migration V23 para crear `5.2.09 Gasto por Provisión Cartera` separada de "Otros gastos".
+
+---
+
+## 🟡 Importantes pero no bloqueantes inmediatos
+
+### Cartera y operaciones USD separadas
+**Prioridad:** P2
+
+Actualmente #268 va a asumir todos los créditos en Bs. Si Fatrans abre
+créditos USD, hay que decidir:
+
+**Opción A — mezclar todo en `1.3.01`:**
+Convertir USD a Bs a tasa BCV en cada asiento. Simpler pero pierde trazabilidad de la cartera en moneda original.
+
+**Opción B — separar `1.3.04` Créditos en USD:**
+Migration V23 que agrega:
+- `1.3.04` Créditos Personales por Cobrar USD
+- (potencialmente) `4.1.04` Intereses sobre Créditos USD
+
+Permite reportes por moneda y tracking de diferencias en cambio.
+
+**Recomendación contador-fatrans:** Opción B cuando se abra el flujo.
+
+**Acción:** Esperar a que el negocio confirme si va a haber créditos USD.
+
+### Diferencia en cambio (NIC-21)
+**Prioridad:** P2
+
+Cuando la tasa BCV se mueve, los saldos en USD reexpresados en Bs cambian.
+VEN-NIF NIC-21 exige reconocer eso:
+
+Si la tasa sube (USD se aprecia respecto a Bs):
+```
+DEBE  1.1.05 Bancos Cuentas USD (al re-expresar en Bs queda mayor)
+HABER 4.3.02 Otros Ingresos Operativos (o crear 4.4.01 Diferencia en Cambio Positiva)
+```
+
+Si la tasa baja:
+```
+DEBE  5.3.02 Otros Egresos Financieros (o crear 5.3.03 Diferencia en Cambio Negativa)
+HABER 1.1.05 Bancos Cuentas USD
+```
+
+**Tareas:**
+- [ ] Diseñar job `RevisarDiferenciaCambioJob` que corre cuando hay nueva tasa BCV.
+- [ ] Crear cuentas `4.4.01` y `5.3.03` en migration V24.
+- [ ] Decidir periodicidad (diaria/mensual/al cierre).
+
+### Reservas legales (excedentes del ejercicio)
+**Prioridad:** P3
+
+Al cierre anual, el `3.3.02 Excedente del Ejercicio` se cierra contra reservas:
+```
+DEBE  3.3.02 Excedente del Ejercicio
+HABER 3.2.01 Reserva Legal (% que exija la ley)
+HABER 3.2.02 Reserva de Educación (cooperativas)
+HABER 3.2.03 Reserva de Solidaridad (cooperativas)
+HABER 3.3.01 Excedentes Acumulados (el remanente)
+```
+
+Los `%` dependen de la naturaleza jurídica (caja ahorro vs cooperativa).
+
+**Tareas:**
+- [ ] Resolver #274 primero (régimen).
+- [ ] Implementar como parte de #272 (cierre anual).
+
+### Depreciación de bienes de uso
+**Prioridad:** P3
+
+Las cuentas `1.5.01` Mobiliario, `1.5.02` Equipo de Computación, `1.5.03`
+Vehículos existen pero nadie las usa. Cuando se registre el primer activo
+fijo, hay que:
+
+1. Asiento de compra:
+```
+DEBE  1.5.01 Mobiliario (o el rubro correspondiente)
+HABER 1.1.03 Bancos
+```
+
+2. Asiento mensual de depreciación:
+```
+DEBE  5.2.07 Depreciación
+HABER 1.5.99 Depreciación Acumulada
+```
+
+**Tareas:**
+- [ ] Definir tabla de vidas útiles (computación 3 años, mobiliario 10, vehículos 5).
+- [ ] Job `DepreciarActivosFijosJob` mensual.
+- [ ] Probablemente no urgente hasta que se registre el primer activo.
+
+---
+
+## 🟢 Mejoras de diseño / housekeeping
+
+### Usuario "SISTEMA" para hooks automáticos
+**Prioridad:** P4 (cosmético)
+
+Actualmente los hooks pasan `creadoPorUsuarioId = null`. Algunos auditores
+prefieren un usuario "SISTEMA" reservado con UUID conocido en `auth_users`
+para que el log diga explícitamente "creado por el sistema" en lugar de NULL.
+
+**Tareas:**
+- [ ] Crear usuario SISTEMA en migration V23 con UUID hardcoded.
+- [ ] Modificar hooks (#267, #268) para pasarlo.
+
+### Constraint NOT NULL en `cuentas_ahorro.moneda`
+**Prioridad:** P4
+
+El adapter de #267 hace fallback a Bs si `moneda = null` (cuentas legacy).
+Si esto se vuelve común, agregar constraint `NOT NULL` para forzar que toda
+cuenta nueva declare moneda.
+
+### Glosa estandarizada de asientos automáticos
+**Prioridad:** P4
+
+Los hooks generan glosa en español con formato fijo. Estandarizar como
+constantes en un `GlosaTemplates.java` para facilitar i18n futuro y
+mantener consistencia entre módulos.
+
+---
+
+## Cómo trabajar este documento
+
+1. Cada vez que `contador-fatrans` (o cualquier otra fuente) identifique un
+   nuevo pendiente regulatorio, agregar entrada acá.
+2. Marcar prioridad: P0 bloqueante > P1 antes cierre > P2 importante > P3
+   nice-to-have > P4 cosmético.
+3. Cuando un pendiente se convierte en sub-issue real, agregar el #issue al
+   título y marcar progreso.
+4. Cuando se resuelve, **NO borrar** — mover a sección "Resueltos" al pie
+   para mantener trazabilidad de qué se cerró cuándo.
+
+## Resueltos
+
+(ninguno todavía — todos están abiertos al 2026-05-20)


### PR DESCRIPTION
## Resumen

Sub-issue **#267** del EPIC Contabilidad **#263**.

Cada depósito y retiro del módulo Ahorros ahora genera **automáticamente** su asiento de partida doble en la misma `@Transactional`, garantizando consistencia entre la BD operativa y la BD contable por exigencia regulatoria SUDECA.

## Mapping operación → asiento

| Operación | Moneda | DEBE | HABER |
|---|---|---|---|
| Depósito | VES | `1.1.01` Caja Principal | `2.1.01` Cuentas de Ahorro Bs |
| Depósito | USD | `1.1.05` Bancos USD | `2.1.02` Cuentas de Ahorro USD |
| Retiro | VES | `2.1.01` Cuentas de Ahorro Bs | `1.1.01` Caja Principal |
| Retiro | USD | `2.1.02` Cuentas de Ahorro USD | `1.1.05` Bancos USD |

## Arquitectura

```
RealizarDepositoUseCase / RealizarRetiroUseCase
        │
        │ contabilidadPort.registrarDeposito/Retiro(cuenta, movimiento)
        ▼
AhorrosContabilidadPort   ← interfaz (application/port/output)
        │
        ▼
AhorrosContabilidadAdapter ← adapter (infrastructure/contabilidad)
        │
        │ asientoContableService.registrar(cmd)
        ▼
AsientoContableService    (módulo Contabilidad, ya existente)
```

El port desacopla Ahorros del API interno de Contabilidad. Cero cambios en `com.tufondo.contabilidad.*` — solo agregamos un consumidor de su API.

## Atomicidad — la contabilidad NO es best-effort

A diferencia de notificaciones email/SMS (resilientes), un asiento no generado significa **BD contable desincronizada con BD operativa**. Eso viola partida doble y nos deja en infracción regulatoria SUDECA.

Implementación: el adapter NO atrapa la excepción. Si `AsientoContableService.registrar()` lanza, se propaga hasta el `@Transactional` del use case → rollback total (saldo, movimiento, asiento parcial).

## Tests reales — 28 nuevos, todos verdes

Corridos vía Docker (`maven:3.9-eclipse-temurin-21`) con BD H2 modo Postgres:

| Test class | Casos | Tipo |
|---|---|---|
| `AhorrosContabilidadAdapterTest` | 10 (2 nested) | Unit Mockito — verifica el `RegistrarAsientoCommand` para cada combinación Bs/USD × depósito/retiro |
| `AhorrosContabilidadAdapterIntegrationTest` | 5 | **E2E con BD real (H2)** — el asiento queda persistido con partidas correctas, decimales preservados |
| `RealizarDepositoUseCaseTest` | 6 | Unit — hook se invoca, NO se invoca si cuenta inexistente/IDOR/cerrada, propaga error contable |
| `RealizarRetiroUseCaseTest` | 7 | Idem + saldo insuficiente |

**Suite completa: 555 tests / 0 failures / 0 errors** (incluye los 120 del módulo contabilidad + 555 totales = todo verde).

## Documentación (vault Obsidian en `docs/modulos/contabilidad/`)

- `Home.md` — mapa del módulo + sub-issues del EPIC
- `01-plan-cuentas.md` — referencia VEN-NIF #264 (códigos, jerarquía, naturalezas)
- `02-asientos-contables.md` — modelo + service #265+#266 (invariantes, estados, correlativo SUDECA)
- `03-hooks-ahorros.md` — este sub-issue (mapping, atomicidad, casos borde)

## Pendiente (intencionalmente fuera de scope)

- **Rendimientos:** `CalcularRendimientoUseCase` solo calcula y persiste con estado `CALCULADO`, sin tocar saldo. El hook `AHORRO_INTERES` queda para cuando se defina el workflow de aplicación (aprobación contable / batch nocturno).
- **#268 Hooks de Créditos:** mismo patrón con códigos `1.3.01` / `4.1.01` / etc.

## Test plan (post-merge en QA)

- [ ] Realizar un depósito en Bs vía `POST /api/v1/cuentas/{nro}/depositos` y verificar en BD que se insertó un asiento en `asientos_contables` con `origen=AHORRO_DEPOSITO`, partidas `DEBE 1.1.01` y `HABER 2.1.01`.
- [ ] Realizar un retiro Bs y verificar el asiento espejo.
- [ ] Provocar un error contable (borrar manualmente la cuenta `1.1.01` del plan) → el depósito debe fallar 422 y el saldo NO debe haberse modificado.
- [ ] Repetir depósito con cuenta USD si hay una disponible (verificar uso de `1.1.05`/`2.1.02`).