### PR TITLE
feat(contab #268): hooks contables en Créditos — desembolso/pago cuota generan asiento automático

### DIFF
--- a/backend/src/main/java/com/tufondo/creditos/application/port/output/CreditosContabilidadPort.java
+++ b/backend/src/main/java/com/tufondo/creditos/application/port/output/CreditosContabilidadPort.java
@@ -1,0 +1,81 @@
+package com.tufondo.creditos.application.port.output;
+
+import com.tufondo.creditos.domain.model.Amortizacion;
+import com.tufondo.creditos.domain.model.SolicitudCredito;
+
+import java.math.BigDecimal;
+
+/**
+ * Puerto de salida que el módulo de Créditos usa para notificar
+ * cada operación crediticia al módulo de Contabilidad.
+ *
+ * <p>Sub-issue #268 del EPIC Contabilidad #263.</p>
+ *
+ * <h2>Contrato</h2>
+ * <ul>
+ *   <li>El hook se invoca DENTRO del mismo {@code @Transactional} del use case
+ *       que ejecuta la operación. Si la generación del asiento falla, la
+ *       transacción hace rollback completo.</li>
+ *   <li>La contabilidad NO es best-effort: un asiento no generado significa
+ *       BD contable desincronizada con la cartera, violación VEN-NIF y
+ *       exposición regulatoria SUDECA.</li>
+ *   <li>Las excepciones se propagan al caller sin envoltorio adicional.</li>
+ * </ul>
+ *
+ * <h2>Mapping contable (post decisiones D-003 + D-004)</h2>
+ *
+ * <h3>Desembolso (origen {@code CREDITO_DESEMBOLSO})</h3>
+ * <pre>
+ * DEBE  1.3.01 Créditos Personales por Cobrar    [monto bruto = neto + comisión]
+ * HABER 1.1.03 Bancos Cta Corriente Bs           [monto neto al socio]
+ * HABER 4.1.02 Comisiones por Otorgamiento       [comisión, si &gt; 0]
+ * </pre>
+ *
+ * <h3>Pago de cuota (origen {@code CREDITO_COBRO})</h3>
+ * <pre>
+ * DEBE  1.1.03 Bancos Cta Corriente Bs           [monto total cobrado]
+ * HABER 1.3.01 Créditos por Cobrar               [capital amortizado]
+ * HABER 4.1.01 Intereses sobre Créditos          [intereses normales]
+ * HABER 4.1.03 Intereses Moratorios              [SI mora &gt; 0]
+ * </pre>
+ *
+ * <p>Razón completa de los códigos en
+ * {@code docs/modulos/contabilidad/_decisiones-contables.md}
+ * (D-003 desembolso, D-004 pago cuota).</p>
+ *
+ * <p><strong>Asunción de moneda</strong>: todos los créditos actualmente son
+ * en bolívares. Si Fatrans abre créditos USD en el futuro, requiere agregar
+ * campo {@code moneda} a {@link SolicitudCredito} y variante del mapping
+ * (cuentas {@code 1.3.04} / {@code 1.1.05}). Ver pendiente P2 en
+ * {@code _pendientes-criticos.md}.</p>
+ */
+public interface CreditosContabilidadPort {
+
+    /**
+     * Genera el asiento contable del desembolso de un crédito.
+     *
+     * @param solicitud         la solicitud aprobada (provee numeroSolicitud, montoSolicitado=bruto, etc)
+     * @param montoNeto         monto efectivamente transferido al socio (bruto - comisión)
+     * @param comisionApertura  comisión cobrada al desembolsar (puede ser {@link BigDecimal#ZERO})
+     * @throws com.tufondo.contabilidad.application.exception.AsientoContableException
+     *         si alguna validación contable falla — rollback de la operación
+     */
+    void registrarDesembolso(SolicitudCredito solicitud,
+                              BigDecimal montoNeto,
+                              BigDecimal comisionApertura);
+
+    /**
+     * Genera el asiento contable del cobro de una cuota.
+     *
+     * @param solicitud       el crédito al que pertenece la cuota (provee socioId y numeroSolicitud)
+     * @param cuota           la cuota cobrada (provee desglose capital + interés + mora)
+     * @param montoCobrado    monto total efectivamente cobrado del socio
+     * @param referenciaPago  referencia bancaria/operativa para auditoría cruzada
+     * @throws com.tufondo.contabilidad.application.exception.AsientoContableException
+     *         si alguna validación contable falla — rollback de la operación
+     */
+    void registrarPagoCuota(SolicitudCredito solicitud,
+                            Amortizacion cuota,
+                            BigDecimal montoCobrado,
+                            String referenciaPago);
+}

--- a/backend/src/main/java/com/tufondo/creditos/application/usecase/DesembolsaCreditoUseCase.java
+++ b/backend/src/main/java/com/tufondo/creditos/application/usecase/DesembolsaCreditoUseCase.java
@@ -3,6 +3,7 @@ package com.tufondo.creditos.application.usecase;
 
 import com.tufondo.creditos.application.dto.DesembolsaRequest;
 import com.tufondo.creditos.application.mapper.CreditosDTOMapper;
+import com.tufondo.creditos.application.port.output.CreditosContabilidadPort;
 import com.tufondo.creditos.domain.exception.CreditoNoEncontradoException;
 import com.tufondo.creditos.domain.exception.EstadoCreditoInvalidoException;
 import com.tufondo.creditos.domain.model.PlanAmortizacion;
@@ -39,6 +40,8 @@ public class DesembolsaCreditoUseCase {
     private final CreditosDTOMapper mapper;
     // Issue #214 PR-C
     private final NotificacionPublisher notificacionPublisher;
+    // Issue #268 — hook contable (mismo @Transactional, propagación de errores)
+    private final CreditosContabilidadPort contabilidadPort;
 
     @Transactional
     public Map<String, Object> ejecutar(String numeroSolicitud, DesembolsaRequest request, String ipOrigen) {
@@ -87,6 +90,12 @@ public class DesembolsaCreditoUseCase {
 
         log.info("Crédito desembolsado: {} - Monto: {} - Comision: {} - IP: {}",
             numeroSolicitud, montoNeto, comisionApertura, ipOrigen);
+
+        // Issue #268: hook contable — asiento de partida doble del desembolso.
+        // Mismo @Transactional: si falla, rollback completo (plan + solicitud +
+        // asiento parcial). NO best-effort — la contabilidad debe estar
+        // sincronizada con la cartera por exigencia regulatoria SUDECA.
+        contabilidadPort.registrarDesembolso(solicitud, montoNeto, comisionApertura);
 
         // Issue #214 PR-C: notificar al socio del desembolso
         notificacionPublisher.notificarSocioCreditoDesembolsado(

--- a/backend/src/main/java/com/tufondo/creditos/application/usecase/RegistrarPagoCuotaUseCase.java
+++ b/backend/src/main/java/com/tufondo/creditos/application/usecase/RegistrarPagoCuotaUseCase.java
@@ -4,6 +4,7 @@ package com.tufondo.creditos.application.usecase;
 import com.tufondo.creditos.application.dto.PagoCuotaRequest;
 import com.tufondo.creditos.application.dto.PagoCuotaResponse;
 import com.tufondo.creditos.application.mapper.CreditosDTOMapper;
+import com.tufondo.creditos.application.port.output.CreditosContabilidadPort;
 import com.tufondo.creditos.domain.exception.*;
 import com.tufondo.creditos.domain.model.Amortizacion;
 import com.tufondo.creditos.domain.model.PlanAmortizacion;
@@ -39,6 +40,8 @@ public class RegistrarPagoCuotaUseCase {
     private final SolicitudCreditoRepository solicitudRepository;
     private final CuentaGarantiaRepository cuentaGarantiaRepository;
     private final CreditosDTOMapper mapper;
+    // Issue #268 — hook contable (mismo @Transactional)
+    private final CreditosContabilidadPort contabilidadPort;
 
     @Transactional
     public PagoCuotaResponse ejecutar(UUID cuotaId, PagoCuotaRequest request,
@@ -102,32 +105,38 @@ public class RegistrarPagoCuotaUseCase {
         plan.registrarPago(monto);
         planRepository.guardar(plan);
 
+        // 6b. Cargar solicitud (usada por el hook contable y, si aplica, por el cierre)
+        SolicitudCredito solicitud = solicitudRepository.buscarPorId(plan.getSolicitudId())
+            .orElseThrow(() -> new CreditoNoEncontradoException(plan.getSolicitudId().toString()));
+
         // 7. Verificar si es última cuota para liberar colateral
         if (plan.estaCompletamentePagado()) {
             plan.marcarFinalizado();
             planRepository.guardar(plan);
-            
-            // Liberar colateral si existe
-            SolicitudCredito solicitud = solicitudRepository.buscarPorId(plan.getSolicitudId())
-                .orElseThrow(() -> new CreditoNoEncontradoException(plan.getSolicitudId().toString()));
-            
+
             if (solicitud.tieneColateral() && solicitud.getColateralCuentaId() != null) {
                 // Liberar el saldo retenido del colateral
                 cuentaGarantiaRepository.liberarSaldo(
-                    solicitud.getColateralCuentaId(), 
+                    solicitud.getColateralCuentaId(),
                     solicitud.getColateralMontoRetenido()
                 );
-                log.info("Colateral liberado: {} para solicitud {}", 
+                log.info("Colateral liberado: {} para solicitud {}",
                     solicitud.getColateralMontoRetenido(), solicitud.getNumeroSolicitud());
             }
-            
+
             // Transicionar solicitud a DESEMBOLSADO (crédito completado)
             solicitud.transicionarA(EstadoSolicitud.DESEMBOLSADO);
             solicitud.setUpdatedAt(LocalDateTime.now());
             solicitudRepository.guardar(solicitud);
         }
 
-        log.info("Pago registrado: cuota {} por monto {} - Ref: {} - Canal: {}", 
+        // 8. Hook contable (#268): asiento de partida doble del cobro.
+        // Mismo @Transactional → si falla, rollback completo del pago (amortización
+        // + plan + solicitud + asiento parcial). La contabilidad debe estar
+        // sincronizada con la cartera por exigencia SUDECA.
+        contabilidadPort.registrarPagoCuota(solicitud, amortizacion, monto, referenciaPago);
+
+        log.info("Pago registrado: cuota {} por monto {} - Ref: {} - Canal: {}",
             amortizacion.getNumeroCuota(), monto, referenciaPago, canalOrigen);
 
         return PagoCuotaResponse.builder()

--- a/backend/src/main/java/com/tufondo/creditos/infrastructure/contabilidad/CreditosContabilidadAdapter.java
+++ b/backend/src/main/java/com/tufondo/creditos/infrastructure/contabilidad/CreditosContabilidadAdapter.java
@@ -1,0 +1,218 @@
+package com.tufondo.creditos.infrastructure.contabilidad;
+
+import com.tufondo.contabilidad.application.dto.RegistrarAsientoCommand;
+import com.tufondo.contabilidad.application.usecase.AsientoContableService;
+import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
+import com.tufondo.creditos.application.port.output.CreditosContabilidadPort;
+import com.tufondo.creditos.domain.model.Amortizacion;
+import com.tufondo.creditos.domain.model.SolicitudCredito;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adapter que materializa cada operación de Créditos como un asiento contable
+ * de partida doble. Implementación de {@link CreditosContabilidadPort}.
+ *
+ * <p>Vive en {@code infrastructure/contabilidad} porque conoce los códigos
+ * VEN-NIF concretos del plan de cuentas — esa configuración no debe
+ * contaminar el dominio de Créditos.</p>
+ *
+ * <h2>Códigos VEN-NIF usados (V21)</h2>
+ *
+ * <table>
+ *   <tr><th>Cuenta</th><th>Naturaleza</th><th>Uso</th></tr>
+ *   <tr><td>1.3.01 Créditos Personales por Cobrar</td><td>ACTIVO (deudora)</td><td>Cartera vigente</td></tr>
+ *   <tr><td>1.1.03 Bancos Cta Corriente Bs</td><td>ACTIVO (deudora)</td><td>Plata real del fondo</td></tr>
+ *   <tr><td>4.1.01 Intereses sobre Créditos</td><td>INGRESO (acreedora)</td><td>Ingreso normal de la cartera</td></tr>
+ *   <tr><td>4.1.02 Comisiones por Otorgamiento</td><td>INGRESO (acreedora)</td><td>Comisión apertura crédito</td></tr>
+ *   <tr><td>4.1.03 Intereses Moratorios</td><td>INGRESO (acreedora)</td><td>Mora cobrada (diferenciada)</td></tr>
+ * </table>
+ *
+ * <h2>Asientos generados</h2>
+ *
+ * <h3>Desembolso</h3>
+ * <pre>
+ * DEBE  1.3.01  [monto bruto = monto solicitado]
+ * HABER 1.1.03  [monto neto = bruto - comisión]
+ * HABER 4.1.02  [comisión apertura, omitido si 0]
+ * </pre>
+ *
+ * <h3>Pago de cuota</h3>
+ * <pre>
+ * DEBE  1.1.03  [monto total cobrado]
+ * HABER 1.3.01  [capital]
+ * HABER 4.1.01  [intereses normales]
+ * HABER 4.1.03  [intereses moratorios, omitido si 0]
+ * </pre>
+ *
+ * <p>Razón regulatoria de los mappings: ver
+ * {@code docs/modulos/contabilidad/_decisiones-contables.md} D-003 y D-004.</p>
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class CreditosContabilidadAdapter implements CreditosContabilidadPort {
+
+    // ─── Códigos del plan de cuentas (V21) ─────────────────────────────────
+    static final String CUENTA_CARTERA          = "1.3.01";
+    static final String CUENTA_BANCO_BS         = "1.1.03";
+    static final String CUENTA_INTERESES        = "4.1.01";
+    static final String CUENTA_COMISION_APERTURA = "4.1.02";
+    static final String CUENTA_INTERESES_MORA   = "4.1.03";
+
+    private final AsientoContableService asientoContableService;
+
+    @Override
+    public void registrarDesembolso(SolicitudCredito solicitud,
+                                     BigDecimal montoNeto,
+                                     BigDecimal comisionApertura) {
+        BigDecimal montoBruto = solicitud.getMontoSolicitado();
+        BigDecimal comision   = comisionApertura == null ? BigDecimal.ZERO : comisionApertura;
+
+        // Validación temprana: el bruto debe = neto + comisión, sino el asiento
+        // no cuadra y AsientoContableService lo rechazará después con un mensaje
+        // genérico. Detectamos acá para mensaje claro de qué está mal en Créditos.
+        BigDecimal recomposicion = montoNeto.add(comision);
+        if (montoBruto.compareTo(recomposicion) != 0) {
+            throw new IllegalArgumentException(String.format(
+                    "Asiento desbalanceado en desembolso %s: bruto=%s ≠ neto(%s)+comisión(%s)",
+                    solicitud.getNumeroSolicitud(), montoBruto, montoNeto, comision));
+        }
+
+        List<RegistrarAsientoCommand.Partida> partidas = new ArrayList<>();
+        // DEBE: sube la cartera por el monto bruto (lo que el socio debe al fondo)
+        partidas.add(RegistrarAsientoCommand.Partida.builder()
+                .codigoCuenta(CUENTA_CARTERA)
+                .debe(montoBruto)
+                .haber(null)
+                .glosa("Cartera por cobrar — desembolso " + solicitud.getNumeroSolicitud())
+                .build());
+        // HABER: sale plata del banco del fondo al banco externo del socio
+        partidas.add(RegistrarAsientoCommand.Partida.builder()
+                .codigoCuenta(CUENTA_BANCO_BS)
+                .debe(null)
+                .haber(montoNeto)
+                .glosa("Transferencia al socio — " + nullableTrim(solicitud.getCuentaDestino(), 60))
+                .build());
+        // HABER (solo si hay comisión): ingreso por comisión apertura
+        if (comision.signum() > 0) {
+            partidas.add(RegistrarAsientoCommand.Partida.builder()
+                    .codigoCuenta(CUENTA_COMISION_APERTURA)
+                    .debe(null)
+                    .haber(comision)
+                    .glosa("Comisión por otorgamiento de crédito")
+                    .build());
+        }
+
+        RegistrarAsientoCommand cmd = RegistrarAsientoCommand.builder()
+                .fechaContable(LocalDate.now())
+                .glosa(String.format("Desembolso crédito %s — bruto %s",
+                        solicitud.getNumeroSolicitud(), montoBruto.toPlainString()))
+                .origen(OrigenAsiento.CREDITO_DESEMBOLSO)
+                .referenciaExterna(solicitud.getNumeroSolicitud())
+                .creadoPorUsuarioId(null)
+                .asientoReversaId(null)
+                .partidas(partidas)
+                .build();
+
+        asientoContableService.registrar(cmd);
+        log.debug("Asiento de desembolso generado: solicitud={} bruto={} neto={} comisión={}",
+                solicitud.getNumeroSolicitud(), montoBruto, montoNeto, comision);
+    }
+
+    @Override
+    public void registrarPagoCuota(SolicitudCredito solicitud,
+                                    Amortizacion cuota,
+                                    BigDecimal montoCobrado,
+                                    String referenciaPago) {
+        BigDecimal capital   = cuota.getCapital() == null ? BigDecimal.ZERO : cuota.getCapital();
+        BigDecimal interes   = cuota.getInteres() == null ? BigDecimal.ZERO : cuota.getInteres();
+        BigDecimal mora      = cuota.getInteresMora() == null ? BigDecimal.ZERO : cuota.getInteresMora();
+
+        // Validación: capital + interés + mora debe = montoCobrado.
+        // Si difiere, indica que la cuota tiene seguros o comisiones intra-cuota
+        // no contemplados todavía (campos existen en Amortizacion pero estamos
+        // ignorándolos por D-004 — están en 0 en flujos actuales).
+        BigDecimal sumaConocida = capital.add(interes).add(mora);
+        if (sumaConocida.compareTo(montoCobrado) != 0) {
+            throw new IllegalArgumentException(String.format(
+                    "Asiento desbalanceado en pago cuota %s (crédito %s): cobrado=%s ≠ capital(%s)+interés(%s)+mora(%s). " +
+                            "Si la cuota incluye seguros/comisiones intra-cuota, hay que extender el adapter " +
+                            "(ver _pendientes-criticos.md sección 'Desglose completo').",
+                    cuota.getNumeroCuota(), solicitud.getNumeroSolicitud(),
+                    montoCobrado, capital, interes, mora));
+        }
+
+        List<RegistrarAsientoCommand.Partida> partidas = new ArrayList<>();
+        // DEBE: entra plata al banco del fondo
+        partidas.add(RegistrarAsientoCommand.Partida.builder()
+                .codigoCuenta(CUENTA_BANCO_BS)
+                .debe(montoCobrado)
+                .haber(null)
+                .glosa("Cobro cuota " + cuota.getNumeroCuota() + " — ref " + safeRef(referenciaPago))
+                .build());
+        // HABER: baja la cartera por el capital amortizado
+        if (capital.signum() > 0) {
+            partidas.add(RegistrarAsientoCommand.Partida.builder()
+                    .codigoCuenta(CUENTA_CARTERA)
+                    .debe(null)
+                    .haber(capital)
+                    .glosa("Amortización capital cuota " + cuota.getNumeroCuota())
+                    .build());
+        }
+        // HABER: ingreso por intereses normales
+        if (interes.signum() > 0) {
+            partidas.add(RegistrarAsientoCommand.Partida.builder()
+                    .codigoCuenta(CUENTA_INTERESES)
+                    .debe(null)
+                    .haber(interes)
+                    .glosa("Intereses cuota " + cuota.getNumeroCuota())
+                    .build());
+        }
+        // HABER: ingreso por mora (SOLO si hay)
+        if (mora.signum() > 0) {
+            partidas.add(RegistrarAsientoCommand.Partida.builder()
+                    .codigoCuenta(CUENTA_INTERESES_MORA)
+                    .debe(null)
+                    .haber(mora)
+                    .glosa("Intereses moratorios cuota " + cuota.getNumeroCuota())
+                    .build());
+        }
+
+        RegistrarAsientoCommand cmd = RegistrarAsientoCommand.builder()
+                .fechaContable(LocalDate.now())
+                .glosa(String.format("Pago cuota %d crédito %s — %s",
+                        cuota.getNumeroCuota(), solicitud.getNumeroSolicitud(),
+                        montoCobrado.toPlainString()))
+                .origen(OrigenAsiento.CREDITO_COBRO)
+                .referenciaExterna(referenciaPago != null && !referenciaPago.isBlank()
+                        ? referenciaPago
+                        : "CUOTA-" + cuota.getId())
+                .creadoPorUsuarioId(null)
+                .asientoReversaId(null)
+                .partidas(partidas)
+                .build();
+
+        asientoContableService.registrar(cmd);
+        log.debug("Asiento de pago cuota generado: cuota={} crédito={} capital={} interés={} mora={}",
+                cuota.getNumeroCuota(), solicitud.getNumeroSolicitud(), capital, interes, mora);
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────
+
+    /** Trunca strings para no exceder el límite de glosa de la BD. */
+    private static String nullableTrim(String s, int max) {
+        if (s == null) return "(sin cuenta destino)";
+        return s.length() <= max ? s : s.substring(0, max) + "…";
+    }
+
+    private static String safeRef(String r) {
+        return r == null || r.isBlank() ? "(sin referencia)" : r;
+    }
+}

--- a/backend/src/test/java/com/tufondo/creditos/application/usecase/DesembolsaCreditoUseCaseHookTest.java
+++ b/backend/src/test/java/com/tufondo/creditos/application/usecase/DesembolsaCreditoUseCaseHookTest.java
@@ -1,0 +1,191 @@
+package com.tufondo.creditos.application.usecase;
+
+import com.tufondo.contabilidad.application.exception.AsientoContableException;
+import com.tufondo.creditos.application.dto.DesembolsaRequest;
+import com.tufondo.creditos.application.mapper.CreditosDTOMapper;
+import com.tufondo.creditos.application.port.output.CreditosContabilidadPort;
+import com.tufondo.creditos.domain.exception.CreditoNoEncontradoException;
+import com.tufondo.creditos.domain.exception.EstadoCreditoInvalidoException;
+import com.tufondo.creditos.domain.model.SolicitudCredito;
+import com.tufondo.creditos.domain.model.TipoCredito;
+import com.tufondo.creditos.domain.model.enums.EstadoSolicitud;
+import com.tufondo.creditos.domain.repository.PlanAmortizacionRepository;
+import com.tufondo.creditos.domain.repository.SolicitudCreditoRepository;
+import com.tufondo.creditos.domain.repository.TipoCreditoRepository;
+import com.tufondo.notificaciones.application.service.NotificacionPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests del hook contable inyectado en {@link DesembolsaCreditoUseCase}
+ * (sub-issue #268).
+ *
+ * <p>Foco: validar que el hook reciba montoNeto y comisionApertura calculados
+ * correctamente según el TipoCredito, y que NO se invoque si una validación
+ * previa falla (solicitud no aprobada, inexistente).</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class DesembolsaCreditoUseCaseHookTest {
+
+    @Mock private SolicitudCreditoRepository solicitudRepository;
+    @Mock private TipoCreditoRepository tipoCreditoRepository;
+    @Mock private PlanAmortizacionRepository planRepository;
+    @Mock private CreditosDTOMapper mapper;
+    @Mock private NotificacionPublisher notificacionPublisher;
+    @Mock private CreditosContabilidadPort contabilidadPort;
+
+    @InjectMocks private DesembolsaCreditoUseCase useCase;
+
+    private SolicitudCredito solicitud;
+    private TipoCredito tipoCredito;
+    private DesembolsaRequest request;
+    private static final String NUMERO = "SOL-CRED-2026-DESEMB-001";
+
+    @BeforeEach
+    void setUp() {
+        Long tipoId = 1L;
+        solicitud = SolicitudCredito.builder()
+                .id(UUID.randomUUID())
+                .numeroSolicitud(NUMERO)
+                .socioId(UUID.randomUUID())
+                .tipoCreditoId(tipoId)
+                .montoSolicitado(new BigDecimal("10000.00"))
+                .plazoMeses(12)
+                .tasaInteresAplicada(new BigDecimal("0.0250"))  // 2.5% mensual
+                .estado(EstadoSolicitud.APROBADA)
+                .build();
+
+        tipoCredito = TipoCredito.builder()
+                .id(tipoId)
+                .comisionApertura(new BigDecimal("0.05"))  // 5% del monto solicitado = 500
+                .build();
+
+        request = new DesembolsaRequest();
+        request.setReferenciaDesembolso("TRANSF-BANCESCO-001");
+
+        // Mocks por defecto — happy path
+        lenient().when(solicitudRepository.buscarPorNumeroSolicitud(NUMERO))
+                .thenReturn(Optional.of(solicitud));
+        lenient().when(tipoCreditoRepository.buscarPorId(tipoId))
+                .thenReturn(Optional.of(tipoCredito));
+    }
+
+    // ─── Happy path ────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("desembolso válido invoca al hook con montoNeto y comisión calculados")
+    void desembolso_invoca_hook_contable_con_calculo_correcto() {
+        useCase.ejecutar(NUMERO, request, "1.1.1.1");
+
+        // monto bruto 10000, comisión 5% = 500, neto = 9500
+        ArgumentCaptor<BigDecimal> netoCap = ArgumentCaptor.forClass(BigDecimal.class);
+        ArgumentCaptor<BigDecimal> comisionCap = ArgumentCaptor.forClass(BigDecimal.class);
+        verify(contabilidadPort).registrarDesembolso(
+                eq(solicitud), netoCap.capture(), comisionCap.capture());
+
+        assertThat(netoCap.getValue()).isEqualByComparingTo("9500.00");
+        assertThat(comisionCap.getValue()).isEqualByComparingTo("500.00");
+    }
+
+    @Test
+    @DisplayName("comisión apertura cero (TipoCredito sin comisión) → neto = bruto")
+    void desembolso_sin_comision() {
+        tipoCredito.setComisionApertura(BigDecimal.ZERO);
+
+        useCase.ejecutar(NUMERO, request, "1.1.1.1");
+
+        ArgumentCaptor<BigDecimal> netoCap = ArgumentCaptor.forClass(BigDecimal.class);
+        ArgumentCaptor<BigDecimal> comisionCap = ArgumentCaptor.forClass(BigDecimal.class);
+        verify(contabilidadPort).registrarDesembolso(
+                eq(solicitud), netoCap.capture(), comisionCap.capture());
+
+        assertThat(netoCap.getValue()).isEqualByComparingTo("10000.00");
+        assertThat(comisionCap.getValue()).isEqualByComparingTo("0.00");
+    }
+
+    @Test
+    @DisplayName("comisión override en request tiene precedencia sobre TipoCredito")
+    void desembolso_con_comision_override() {
+        request.setComisionAperturaAplicada(new BigDecimal("200.00"));
+
+        useCase.ejecutar(NUMERO, request, "1.1.1.1");
+
+        ArgumentCaptor<BigDecimal> comisionCap = ArgumentCaptor.forClass(BigDecimal.class);
+        verify(contabilidadPort).registrarDesembolso(
+                eq(solicitud), any(), comisionCap.capture());
+
+        assertThat(comisionCap.getValue()).isEqualByComparingTo("200.00");
+    }
+
+    @Test
+    @DisplayName("se notifica al socio TRAS el hook contable (no antes)")
+    void notificacion_va_despues_del_hook() {
+        useCase.ejecutar(NUMERO, request, "1.1.1.1");
+
+        // Verificación de orden: el hook DEBE ejecutarse antes que la notificación
+        // para que un rollback de contabilidad evite mensaje al socio que no corresponde.
+        var inOrder = inOrder(contabilidadPort, notificacionPublisher);
+        inOrder.verify(contabilidadPort).registrarDesembolso(any(), any(), any());
+        inOrder.verify(notificacionPublisher)
+                .notificarSocioCreditoDesembolsado(any(), any(), any(), any());
+    }
+
+    // ─── Validaciones que cortan ANTES del hook ────────────────────────────
+
+    @Test
+    @DisplayName("solicitud inexistente → NO se llama al hook")
+    void solicitud_inexistente_no_llama_hook() {
+        when(solicitudRepository.buscarPorNumeroSolicitud("SOL-INVALID"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.ejecutar("SOL-INVALID", request, "1.1.1.1"))
+                .isInstanceOf(CreditoNoEncontradoException.class);
+
+        verifyNoInteractions(contabilidadPort);
+        verifyNoInteractions(notificacionPublisher);
+    }
+
+    @Test
+    @DisplayName("solicitud en estado no APROBADA → NO se llama al hook")
+    void solicitud_no_aprobada_no_llama_hook() {
+        solicitud.setEstado(EstadoSolicitud.PENDIENTE);
+
+        assertThatThrownBy(() -> useCase.ejecutar(NUMERO, request, "1.1.1.1"))
+                .isInstanceOf(EstadoCreditoInvalidoException.class);
+
+        verifyNoInteractions(contabilidadPort);
+    }
+
+    // ─── Propagación de errores del hook ───────────────────────────────────
+
+    @Test
+    @DisplayName("error contable propaga (rollback) y NO se envía notificación")
+    void error_contable_propaga_sin_notificar() {
+        doThrow(new AsientoContableException("cuenta 1.3.01 no encontrada"))
+                .when(contabilidadPort).registrarDesembolso(any(), any(), any());
+
+        assertThatThrownBy(() -> useCase.ejecutar(NUMERO, request, "1.1.1.1"))
+                .isInstanceOf(AsientoContableException.class)
+                .hasMessageContaining("1.3.01");
+
+        // Si la contabilidad falla, NO debe enviar notificación al socio
+        // (el desembolso lógicamente no ocurrió).
+        verifyNoInteractions(notificacionPublisher);
+    }
+}

--- a/backend/src/test/java/com/tufondo/creditos/application/usecase/RegistrarPagoCuotaUseCaseHookTest.java
+++ b/backend/src/test/java/com/tufondo/creditos/application/usecase/RegistrarPagoCuotaUseCaseHookTest.java
@@ -1,0 +1,175 @@
+package com.tufondo.creditos.application.usecase;
+
+import com.tufondo.contabilidad.application.exception.AsientoContableException;
+import com.tufondo.creditos.application.mapper.CreditosDTOMapper;
+import com.tufondo.creditos.application.port.output.CreditosContabilidadPort;
+import com.tufondo.creditos.domain.exception.CreditoNoEncontradoException;
+import com.tufondo.creditos.domain.exception.CuotaNoEncontradaException;
+import com.tufondo.creditos.domain.exception.CuotaYaPagadaException;
+import com.tufondo.creditos.domain.exception.MontoInsuficienteException;
+import com.tufondo.creditos.domain.exception.PagoDuplicadoException;
+import com.tufondo.creditos.domain.model.Amortizacion;
+import com.tufondo.creditos.domain.model.PlanAmortizacion;
+import com.tufondo.creditos.domain.model.SolicitudCredito;
+import com.tufondo.creditos.domain.model.enums.EstadoAmortizacion;
+import com.tufondo.creditos.domain.repository.AmortizacionRepository;
+import com.tufondo.creditos.domain.repository.CuentaGarantiaRepository;
+import com.tufondo.creditos.domain.repository.PlanAmortizacionRepository;
+import com.tufondo.creditos.domain.repository.SolicitudCreditoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests del hook contable inyectado en {@link RegistrarPagoCuotaUseCase}
+ * (sub-issue #268).
+ *
+ * <p>Foco: validar que cada pago confirmado invoque al hook con los datos
+ * correctos, y que si una validación previa rechaza el pago, el hook NO se
+ * llame. También verifica propagación de errores contables.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class RegistrarPagoCuotaUseCaseHookTest {
+
+    @Mock private AmortizacionRepository amortizacionRepository;
+    @Mock private PlanAmortizacionRepository planRepository;
+    @Mock private SolicitudCreditoRepository solicitudRepository;
+    @Mock private CuentaGarantiaRepository cuentaGarantiaRepository;
+    @Mock private CreditosDTOMapper mapper;
+    @Mock private CreditosContabilidadPort contabilidadPort;
+
+    @InjectMocks private RegistrarPagoCuotaUseCase useCase;
+
+    private UUID cuotaId;
+    private Amortizacion cuota;
+    private PlanAmortizacion plan;
+    private SolicitudCredito solicitud;
+
+    @BeforeEach
+    void setUp() {
+        cuotaId = UUID.randomUUID();
+        UUID planId = UUID.randomUUID();
+        UUID solicitudId = UUID.randomUUID();
+
+        plan = PlanAmortizacion.builder()
+                .id(planId)
+                .solicitudId(solicitudId)
+                .saldoPendiente(new BigDecimal("9500.00"))
+                .totalPagado(BigDecimal.ZERO)  // requerido por registrarPago(monto)
+                .build();
+
+        cuota = Amortizacion.builder()
+                .id(cuotaId)
+                .planId(planId)
+                .plan(plan)
+                .numeroCuota(3)
+                .capital(new BigDecimal("400.00"))
+                .interes(new BigDecimal("100.00"))
+                .interesMora(BigDecimal.ZERO)
+                .montoCuota(new BigDecimal("500.00"))
+                .estado(EstadoAmortizacion.PENDIENTE)
+                .build();
+
+        solicitud = SolicitudCredito.builder()
+                .id(solicitudId)
+                .numeroSolicitud("SOL-CRED-2026-TEST")
+                .socioId(UUID.randomUUID())
+                .montoSolicitado(new BigDecimal("10000.00"))
+                .build();
+
+        // Mocks por defecto — happy path. Lenient: validaciones tempranas en
+        // algunos tests cortan antes y no consumen estos stubs.
+        lenient().when(amortizacionRepository.existePorReferenciaPago(any())).thenReturn(false);
+        lenient().when(amortizacionRepository.buscarPorIdWithLock(cuotaId)).thenReturn(Optional.of(cuota));
+        lenient().when(planRepository.buscarPorId(plan.getId())).thenReturn(Optional.of(plan));
+        lenient().when(solicitudRepository.buscarPorId(plan.getSolicitudId()))
+                .thenReturn(Optional.of(solicitud));
+    }
+
+    // ─── Happy path ────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("pago válido invoca al hook contable con solicitud, cuota y monto")
+    void pago_invoca_hook_contable() {
+        useCase.ejecutar(cuotaId, new BigDecimal("500.00"), "REF-001", "WEB");
+
+        verify(contabilidadPort).registrarPagoCuota(
+                eq(solicitud), eq(cuota), eq(new BigDecimal("500.00")), eq("REF-001"));
+    }
+
+    // ─── Validaciones que cortan ANTES del hook ────────────────────────────
+
+    @Test
+    @DisplayName("referencia duplicada → NO se llama al hook")
+    void referencia_duplicada_no_llama_hook() {
+        when(amortizacionRepository.existePorReferenciaPago("REF-DUP")).thenReturn(true);
+
+        assertThatThrownBy(() -> useCase.ejecutar(
+                cuotaId, new BigDecimal("500.00"), "REF-DUP", "WEB"))
+                .isInstanceOf(PagoDuplicadoException.class);
+
+        verifyNoInteractions(contabilidadPort);
+    }
+
+    @Test
+    @DisplayName("cuota inexistente → NO se llama al hook")
+    void cuota_inexistente_no_llama_hook() {
+        UUID otraCuota = UUID.randomUUID();
+        when(amortizacionRepository.buscarPorIdWithLock(otraCuota)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.ejecutar(
+                otraCuota, new BigDecimal("500.00"), "REF-X", "WEB"))
+                .isInstanceOf(CuotaNoEncontradaException.class);
+
+        verifyNoInteractions(contabilidadPort);
+    }
+
+    @Test
+    @DisplayName("cuota ya PAGADA → NO se llama al hook")
+    void cuota_ya_pagada_no_llama_hook() {
+        cuota.setEstado(EstadoAmortizacion.PAGADA);
+
+        assertThatThrownBy(() -> useCase.ejecutar(
+                cuotaId, new BigDecimal("500.00"), "REF-X", "WEB"))
+                .isInstanceOf(CuotaYaPagadaException.class);
+
+        verifyNoInteractions(contabilidadPort);
+    }
+
+    @Test
+    @DisplayName("monto insuficiente → NO se llama al hook")
+    void monto_insuficiente_no_llama_hook() {
+        assertThatThrownBy(() -> useCase.ejecutar(
+                cuotaId, new BigDecimal("100.00"), "REF-X", "WEB"))
+                .isInstanceOf(MontoInsuficienteException.class);
+
+        verifyNoInteractions(contabilidadPort);
+    }
+
+    // ─── Propagación de errores del hook ───────────────────────────────────
+
+    @Test
+    @DisplayName("si el hook contable falla, propaga y hace rollback")
+    void error_contable_propaga() {
+        doThrow(new AsientoContableException("cuenta 1.1.03 no encontrada"))
+                .when(contabilidadPort).registrarPagoCuota(any(), any(), any(), any());
+
+        assertThatThrownBy(() -> useCase.ejecutar(
+                cuotaId, new BigDecimal("500.00"), "REF-OK", "WEB"))
+                .isInstanceOf(AsientoContableException.class)
+                .hasMessageContaining("1.1.03");
+    }
+}

--- a/backend/src/test/java/com/tufondo/creditos/infrastructure/contabilidad/CreditosContabilidadAdapterIntegrationTest.java
+++ b/backend/src/test/java/com/tufondo/creditos/infrastructure/contabilidad/CreditosContabilidadAdapterIntegrationTest.java
@@ -1,0 +1,260 @@
+package com.tufondo.creditos.infrastructure.contabilidad;
+
+import com.tufondo.contabilidad.application.exception.AsientoContableException;
+import com.tufondo.contabilidad.application.usecase.AsientoContableService;
+import com.tufondo.contabilidad.domain.model.AsientoContable;
+import com.tufondo.contabilidad.domain.model.CuentaContable;
+import com.tufondo.contabilidad.domain.model.PartidaAsiento;
+import com.tufondo.contabilidad.domain.model.enums.EstadoAsiento;
+import com.tufondo.contabilidad.domain.model.enums.NaturalezaSaldo;
+import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
+import com.tufondo.contabilidad.domain.model.enums.TipoCuentaContable;
+import com.tufondo.contabilidad.domain.repository.AsientoContableRepository;
+import com.tufondo.contabilidad.infrastructure.persistence.adapter.AsientoContableRepositoryImpl;
+import com.tufondo.contabilidad.infrastructure.persistence.adapter.CuentaContableRepositoryImpl;
+import com.tufondo.contabilidad.infrastructure.persistence.jpa.AsientoContableJpaRepository;
+import com.tufondo.contabilidad.infrastructure.persistence.jpa.CuentaContableJpaRepository;
+import com.tufondo.contabilidad.infrastructure.persistence.jpa.PartidaAsientoJpaRepository;
+import com.tufondo.creditos.domain.model.Amortizacion;
+import com.tufondo.creditos.domain.model.SolicitudCredito;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Test de integración E2E del hook contable de Créditos (sub-issue #268).
+ *
+ * <p>Arranca el contexto JPA mínimo: el adapter real
+ * {@link CreditosContabilidadAdapter} delega al {@link AsientoContableService}
+ * real, que persiste vía {@link AsientoContableRepositoryImpl} contra H2.</p>
+ *
+ * <p>El seed V21 NO corre porque tests tienen {@code flyway.enabled=false}.
+ * Se pre-pueblan manualmente las cuentas mínimas que el adapter referencia.</p>
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase
+@ActiveProfiles("test")
+@Import({
+        CreditosContabilidadAdapter.class,
+        AsientoContableService.class,
+        AsientoContableRepositoryImpl.class,
+        CuentaContableRepositoryImpl.class
+})
+@DisplayName("CreditosContabilidadAdapter — integración con H2 (BD real)")
+class CreditosContabilidadAdapterIntegrationTest {
+
+    @Autowired private CreditosContabilidadAdapter adapter;
+    @Autowired private AsientoContableRepository asientoRepo;
+    @Autowired private AsientoContableJpaRepository asientoJpa;
+    @Autowired private PartidaAsientoJpaRepository partidaJpa;
+    @Autowired private CuentaContableJpaRepository cuentaJpa;
+    @Autowired private CuentaContableRepositoryImpl cuentaRepoAdapter;
+    @Autowired private EntityManager em;
+
+    private UUID carteraId, bancoBsId, ingresoInteresesId, ingresoComisionId, ingresoMoraId;
+
+    @BeforeEach
+    void setUp() {
+        partidaJpa.deleteAll();
+        asientoJpa.deleteAll();
+        cuentaJpa.deleteAll();
+
+        em.createNativeQuery("CREATE SEQUENCE IF NOT EXISTS seq_asiento_numero START WITH 1 INCREMENT BY 1")
+                .executeUpdate();
+
+        // Activo
+        UUID rubroAct = persistirCuenta("1", "ACTIVO",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, null, false);
+        UUID grupoDisp = persistirCuenta("1.1", "DISPONIBLE",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, rubroAct, false);
+        bancoBsId = persistirCuenta("1.1.03", "Bancos Cta Corriente Bs",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, grupoDisp, true);
+        UUID grupoCart = persistirCuenta("1.3", "CARTERA DE CRÉDITOS",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, rubroAct, false);
+        carteraId = persistirCuenta("1.3.01", "Créditos Personales por Cobrar",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, grupoCart, true);
+
+        // Ingresos
+        UUID rubroIng = persistirCuenta("4", "INGRESOS",
+                TipoCuentaContable.INGRESO, NaturalezaSaldo.ACREEDORA, null, false);
+        UUID grupoIngCart = persistirCuenta("4.1", "INGRESOS POR CARTERA",
+                TipoCuentaContable.INGRESO, NaturalezaSaldo.ACREEDORA, rubroIng, false);
+        ingresoInteresesId = persistirCuenta("4.1.01", "Intereses sobre Créditos",
+                TipoCuentaContable.INGRESO, NaturalezaSaldo.ACREEDORA, grupoIngCart, true);
+        ingresoComisionId = persistirCuenta("4.1.02", "Comisiones por Otorgamiento",
+                TipoCuentaContable.INGRESO, NaturalezaSaldo.ACREEDORA, grupoIngCart, true);
+        ingresoMoraId = persistirCuenta("4.1.03", "Intereses Moratorios",
+                TipoCuentaContable.INGRESO, NaturalezaSaldo.ACREEDORA, grupoIngCart, true);
+    }
+
+    // ─── Desembolso ────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("E2E desembolso SIN comisión: asiento DEBE 1.3.01 / HABER 1.1.03")
+    void e2e_desembolso_sin_comision() {
+        SolicitudCredito sol = solicitudConMonto("SOL-CRED-2026-001", "10000.00");
+
+        adapter.registrarDesembolso(sol, new BigDecimal("10000.00"), BigDecimal.ZERO);
+
+        AsientoContable asiento = asientoUnico("SOL-CRED-2026-001");
+        assertThat(asiento.getOrigen()).isEqualTo(OrigenAsiento.CREDITO_DESEMBOLSO);
+        assertThat(asiento.getEstado()).isEqualTo(EstadoAsiento.REGISTRADO);
+        assertThat(asiento.estaBalanceado()).isTrue();
+        assertThat(asiento.totalDebe()).isEqualByComparingTo("10000.00");
+        assertThat(asiento.getPartidas()).hasSize(2);
+
+        PartidaAsiento debe = partidaDebe(asiento, carteraId);
+        PartidaAsiento haber = partidaHaber(asiento, bancoBsId);
+        assertThat(debe.getDebe()).isEqualByComparingTo("10000.00");
+        assertThat(haber.getHaber()).isEqualByComparingTo("10000.00");
+    }
+
+    @Test
+    @DisplayName("E2E desembolso CON comisión: 3 partidas, suma cuadra")
+    void e2e_desembolso_con_comision() {
+        SolicitudCredito sol = solicitudConMonto("SOL-CRED-2026-002", "10000.00");
+
+        adapter.registrarDesembolso(sol, new BigDecimal("9500.00"), new BigDecimal("500.00"));
+
+        AsientoContable asiento = asientoUnico("SOL-CRED-2026-002");
+        assertThat(asiento.getPartidas()).hasSize(3);
+        assertThat(asiento.estaBalanceado()).isTrue();
+
+        assertThat(partidaDebe(asiento, carteraId).getDebe()).isEqualByComparingTo("10000.00");
+        assertThat(partidaHaber(asiento, bancoBsId).getHaber()).isEqualByComparingTo("9500.00");
+        assertThat(partidaHaber(asiento, ingresoComisionId).getHaber()).isEqualByComparingTo("500.00");
+    }
+
+    // ─── Pago de cuota ─────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("E2E pago cuota SIN mora: 3 partidas — DEBE 1.1.03 / HABER 1.3.01 + 4.1.01")
+    void e2e_pago_cuota_sin_mora() {
+        SolicitudCredito sol = solicitudConMonto("SOL-CRED-2026-010", "10000.00");
+        Amortizacion cuota = cuotaConDesglose(5, "400.00", "100.00", "0.00", "500.00");
+
+        adapter.registrarPagoCuota(sol, cuota, new BigDecimal("500.00"), "REF-PAGO-A1");
+
+        AsientoContable asiento = asientoUnico("REF-PAGO-A1");
+        assertThat(asiento.getOrigen()).isEqualTo(OrigenAsiento.CREDITO_COBRO);
+        assertThat(asiento.estaBalanceado()).isTrue();
+        assertThat(asiento.getPartidas()).hasSize(3);
+
+        assertThat(partidaDebe(asiento, bancoBsId).getDebe()).isEqualByComparingTo("500.00");
+        assertThat(partidaHaber(asiento, carteraId).getHaber()).isEqualByComparingTo("400.00");
+        assertThat(partidaHaber(asiento, ingresoInteresesId).getHaber()).isEqualByComparingTo("100.00");
+
+        // NO debe haber partida de mora
+        assertThat(asiento.getPartidas())
+                .extracting(PartidaAsiento::getCuentaId)
+                .doesNotContain(ingresoMoraId);
+    }
+
+    @Test
+    @DisplayName("E2E pago cuota CON mora: 4 partidas (la 4ta = 4.1.03 mora)")
+    void e2e_pago_cuota_con_mora() {
+        SolicitudCredito sol = solicitudConMonto("SOL-CRED-2026-011", "10000.00");
+        Amortizacion cuota = cuotaConDesglose(8, "400.00", "100.00", "30.00", "500.00");
+
+        adapter.registrarPagoCuota(sol, cuota, new BigDecimal("530.00"), "REF-PAGO-MORA1");
+
+        AsientoContable asiento = asientoUnico("REF-PAGO-MORA1");
+        assertThat(asiento.getPartidas()).hasSize(4);
+        assertThat(asiento.estaBalanceado()).isTrue();
+
+        assertThat(partidaDebe(asiento, bancoBsId).getDebe()).isEqualByComparingTo("530.00");
+        assertThat(partidaHaber(asiento, ingresoMoraId).getHaber()).isEqualByComparingTo("30.00");
+    }
+
+    // ─── Casos negativos ────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("E2E: cuenta 1.3.01 inexistente en plan → AsientoContableException")
+    void e2e_error_cuenta_cartera_inexistente() {
+        // Borrar 1.3.01 del plan para simular plan mal configurado
+        cuentaJpa.deleteById(carteraId);
+        em.flush();
+
+        SolicitudCredito sol = solicitudConMonto("SOL-FAIL", "100.00");
+
+        assertThatThrownBy(() -> adapter.registrarDesembolso(
+                sol, new BigDecimal("100.00"), BigDecimal.ZERO))
+                .isInstanceOf(AsientoContableException.class)
+                .hasMessageContaining("1.3.01");
+    }
+
+    @Test
+    @DisplayName("E2E: decimales NUMERIC(18,4) se preservan sin truncado")
+    void e2e_decimales_preservados() {
+        SolicitudCredito sol = solicitudConMonto("SOL-DEC", "999.9999");
+
+        adapter.registrarDesembolso(sol, new BigDecimal("999.9999"), BigDecimal.ZERO);
+
+        AsientoContable a = asientoUnico("SOL-DEC");
+        assertThat(a.totalDebe()).isEqualByComparingTo("999.9999");
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────
+
+    private UUID persistirCuenta(String codigo, String nombre, TipoCuentaContable tipo,
+                                  NaturalezaSaldo naturaleza, UUID padre, boolean aceptaMov) {
+        CuentaContable c = CuentaContable.crear(codigo, nombre, tipo, naturaleza, padre, aceptaMov, null);
+        cuentaRepoAdapter.guardar(c);
+        return c.getId();
+    }
+
+    private SolicitudCredito solicitudConMonto(String numero, String monto) {
+        return SolicitudCredito.builder()
+                .id(UUID.randomUUID())
+                .numeroSolicitud(numero)
+                .socioId(UUID.randomUUID())
+                .montoSolicitado(new BigDecimal(monto))
+                .cuentaDestino("0134-XXXX")
+                .build();
+    }
+
+    private Amortizacion cuotaConDesglose(int nro, String capital, String interes,
+                                           String mora, String montoCuota) {
+        return Amortizacion.builder()
+                .id(UUID.randomUUID())
+                .numeroCuota(nro)
+                .capital(new BigDecimal(capital))
+                .interes(new BigDecimal(interes))
+                .interesMora(new BigDecimal(mora))
+                .montoCuota(new BigDecimal(montoCuota))
+                .build();
+    }
+
+    private AsientoContable asientoUnico(String referencia) {
+        List<AsientoContable> hits = asientoRepo.buscarPorReferenciaExterna(referencia);
+        assertThat(hits).as("Asiento ref=%s debe existir y ser único", referencia).hasSize(1);
+        return hits.get(0);
+    }
+
+    private PartidaAsiento partidaDebe(AsientoContable a, UUID cuentaId) {
+        return a.getPartidas().stream()
+                .filter(p -> p.esDeDebe() && p.getCuentaId().equals(cuentaId))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No hay partida DEBE para cuenta " + cuentaId));
+    }
+
+    private PartidaAsiento partidaHaber(AsientoContable a, UUID cuentaId) {
+        return a.getPartidas().stream()
+                .filter(p -> p.esDeHaber() && p.getCuentaId().equals(cuentaId))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No hay partida HABER para cuenta " + cuentaId));
+    }
+}

--- a/backend/src/test/java/com/tufondo/creditos/infrastructure/contabilidad/CreditosContabilidadAdapterTest.java
+++ b/backend/src/test/java/com/tufondo/creditos/infrastructure/contabilidad/CreditosContabilidadAdapterTest.java
@@ -1,0 +1,291 @@
+package com.tufondo.creditos.infrastructure.contabilidad;
+
+import com.tufondo.contabilidad.application.dto.RegistrarAsientoCommand;
+import com.tufondo.contabilidad.application.exception.AsientoContableException;
+import com.tufondo.contabilidad.application.usecase.AsientoContableService;
+import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
+import com.tufondo.creditos.domain.model.Amortizacion;
+import com.tufondo.creditos.domain.model.SolicitudCredito;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+/**
+ * Tests unitarios del adapter que materializa operaciones de Créditos como
+ * asientos contables de partida doble (sub-issue #268).
+ *
+ * <p>Cubre las variantes:</p>
+ * <ul>
+ *   <li>Desembolso con/sin comisión apertura</li>
+ *   <li>Pago de cuota con/sin mora</li>
+ *   <li>Validación de cuadre (bruto = neto + comisión)</li>
+ *   <li>Validación de cuadre (cobrado = capital + interés + mora)</li>
+ *   <li>Propagación de excepciones</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+class CreditosContabilidadAdapterTest {
+
+    @Mock private AsientoContableService asientoContableService;
+    @InjectMocks private CreditosContabilidadAdapter adapter;
+
+    private SolicitudCredito solicitud;
+    private Amortizacion cuotaNormal;
+    private Amortizacion cuotaConMora;
+
+    @BeforeEach
+    void setUp() {
+        solicitud = SolicitudCredito.builder()
+                .id(UUID.randomUUID())
+                .numeroSolicitud("SOL-CRED-2026-000123")
+                .socioId(UUID.randomUUID())
+                .montoSolicitado(new BigDecimal("10000.00"))
+                .cuentaDestino("0134-0001-23-0000001234")
+                .build();
+
+        // Cuota sin mora — total 500: 400 capital + 100 interés
+        cuotaNormal = Amortizacion.builder()
+                .id(UUID.randomUUID())
+                .numeroCuota(3)
+                .capital(new BigDecimal("400.00"))
+                .interes(new BigDecimal("100.00"))
+                .interesMora(BigDecimal.ZERO)
+                .montoCuota(new BigDecimal("500.00"))
+                .build();
+
+        // Cuota con mora — total 530: 400 capital + 100 interés + 30 mora
+        cuotaConMora = Amortizacion.builder()
+                .id(UUID.randomUUID())
+                .numeroCuota(7)
+                .capital(new BigDecimal("400.00"))
+                .interes(new BigDecimal("100.00"))
+                .interesMora(new BigDecimal("30.00"))
+                .montoCuota(new BigDecimal("500.00"))
+                .build();
+    }
+
+    // ═══ Desembolso ═══════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Desembolso — DEBE cartera / HABER bancos + comisión opcional")
+    class Desembolso {
+
+        @Test
+        @DisplayName("Sin comisión: 2 partidas (DEBE 1.3.01 / HABER 1.1.03)")
+        void desembolso_sin_comision() {
+            adapter.registrarDesembolso(solicitud, new BigDecimal("10000.00"), BigDecimal.ZERO);
+
+            RegistrarAsientoCommand cmd = capturarComando();
+            assertThat(cmd.origen()).isEqualTo(OrigenAsiento.CREDITO_DESEMBOLSO);
+            assertThat(cmd.referenciaExterna()).isEqualTo("SOL-CRED-2026-000123");
+            assertThat(cmd.partidas()).hasSize(2);
+
+            // DEBE Cartera
+            var debe = cmd.partidas().get(0);
+            assertThat(debe.codigoCuenta()).isEqualTo("1.3.01");
+            assertThat(debe.debe()).isEqualByComparingTo("10000.00");
+            assertThat(debe.haber()).isNull();
+
+            // HABER Bancos Bs
+            var haber = cmd.partidas().get(1);
+            assertThat(haber.codigoCuenta()).isEqualTo("1.1.03");
+            assertThat(haber.haber()).isEqualByComparingTo("10000.00");
+        }
+
+        @Test
+        @DisplayName("Con comisión: 3 partidas (DEBE 1.3.01 bruto / HABER 1.1.03 neto / HABER 4.1.02 comisión)")
+        void desembolso_con_comision() {
+            // bruto 10000 = neto 9500 + comisión 500
+            adapter.registrarDesembolso(solicitud, new BigDecimal("9500.00"), new BigDecimal("500.00"));
+
+            RegistrarAsientoCommand cmd = capturarComando();
+            assertThat(cmd.partidas()).hasSize(3);
+
+            assertThat(cmd.partidas().get(0).codigoCuenta()).isEqualTo("1.3.01");
+            assertThat(cmd.partidas().get(0).debe()).isEqualByComparingTo("10000.00");
+
+            assertThat(cmd.partidas().get(1).codigoCuenta()).isEqualTo("1.1.03");
+            assertThat(cmd.partidas().get(1).haber()).isEqualByComparingTo("9500.00");
+
+            assertThat(cmd.partidas().get(2).codigoCuenta()).isEqualTo("4.1.02");
+            assertThat(cmd.partidas().get(2).haber()).isEqualByComparingTo("500.00");
+        }
+
+        @Test
+        @DisplayName("Comisión null tratada como cero (sin partida 4.1.02)")
+        void comision_null_no_genera_partida() {
+            adapter.registrarDesembolso(solicitud, new BigDecimal("10000.00"), null);
+
+            RegistrarAsientoCommand cmd = capturarComando();
+            assertThat(cmd.partidas()).hasSize(2);
+            assertThat(cmd.partidas()).extracting("codigoCuenta")
+                    .doesNotContain("4.1.02");
+        }
+
+        @Test
+        @DisplayName("Bruto ≠ neto + comisión → rechazo CON mensaje claro antes de llamar a contabilidad")
+        void desembolso_desbalanceado_se_rechaza_localmente() {
+            // bruto 10000, pero neto 9000 + comisión 500 = 9500 (faltan 500)
+            assertThatThrownBy(() -> adapter.registrarDesembolso(
+                    solicitud, new BigDecimal("9000.00"), new BigDecimal("500.00")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("desbalanceado")
+                    .hasMessageContaining("SOL-CRED-2026-000123");
+
+            // Y NO se llamó a AsientoContableService — el error fue local
+            verifyNoInteractions(asientoContableService);
+        }
+
+        @Test
+        @DisplayName("Glosa incluye número de solicitud y monto bruto")
+        void glosa_incluye_metadata() {
+            adapter.registrarDesembolso(solicitud, new BigDecimal("10000.00"), BigDecimal.ZERO);
+
+            RegistrarAsientoCommand cmd = capturarComando();
+            assertThat(cmd.glosa())
+                    .contains("SOL-CRED-2026-000123")
+                    .contains("10000");
+        }
+
+        @Test
+        @DisplayName("Glosa del HABER 1.1.03 incluye cuenta destino truncada si es larga")
+        void glosa_haber_incluye_cuenta_destino() {
+            adapter.registrarDesembolso(solicitud, new BigDecimal("10000.00"), BigDecimal.ZERO);
+
+            RegistrarAsientoCommand cmd = capturarComando();
+            var haber = cmd.partidas().get(1);
+            assertThat(haber.glosa()).contains("0134-0001-23-0000001234");
+        }
+    }
+
+    // ═══ Pago de cuota ════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Pago cuota — DEBE bancos / HABER cartera+intereses(+mora)")
+    class PagoCuota {
+
+        @Test
+        @DisplayName("Sin mora: 3 partidas (DEBE 1.1.03 / HABER 1.3.01 capital / HABER 4.1.01 interés)")
+        void pago_sin_mora_3_partidas() {
+            adapter.registrarPagoCuota(solicitud, cuotaNormal,
+                    new BigDecimal("500.00"), "REF-PAGO-001");
+
+            RegistrarAsientoCommand cmd = capturarComando();
+            assertThat(cmd.origen()).isEqualTo(OrigenAsiento.CREDITO_COBRO);
+            assertThat(cmd.referenciaExterna()).isEqualTo("REF-PAGO-001");
+            assertThat(cmd.partidas()).hasSize(3);
+
+            // DEBE Bancos
+            assertThat(cmd.partidas().get(0).codigoCuenta()).isEqualTo("1.1.03");
+            assertThat(cmd.partidas().get(0).debe()).isEqualByComparingTo("500.00");
+
+            // HABER Cartera (capital)
+            assertThat(cmd.partidas().get(1).codigoCuenta()).isEqualTo("1.3.01");
+            assertThat(cmd.partidas().get(1).haber()).isEqualByComparingTo("400.00");
+
+            // HABER Intereses
+            assertThat(cmd.partidas().get(2).codigoCuenta()).isEqualTo("4.1.01");
+            assertThat(cmd.partidas().get(2).haber()).isEqualByComparingTo("100.00");
+
+            // NO debe haber partida de mora
+            assertThat(cmd.partidas()).extracting("codigoCuenta")
+                    .doesNotContain("4.1.03");
+        }
+
+        @Test
+        @DisplayName("Con mora > 0: 4 partidas (la 4ta HABER 4.1.03 mora)")
+        void pago_con_mora_4_partidas() {
+            adapter.registrarPagoCuota(solicitud, cuotaConMora,
+                    new BigDecimal("530.00"), "REF-PAGO-MORA");
+
+            RegistrarAsientoCommand cmd = capturarComando();
+            assertThat(cmd.partidas()).hasSize(4);
+
+            assertThat(cmd.partidas().get(3).codigoCuenta()).isEqualTo("4.1.03");
+            assertThat(cmd.partidas().get(3).haber()).isEqualByComparingTo("30.00");
+        }
+
+        @Test
+        @DisplayName("Mora exactamente 0 NO genera partida 4.1.03")
+        void mora_cero_no_genera_partida() {
+            adapter.registrarPagoCuota(solicitud, cuotaNormal,
+                    new BigDecimal("500.00"), "REF-001");
+
+            RegistrarAsientoCommand cmd = capturarComando();
+            assertThat(cmd.partidas()).extracting("codigoCuenta")
+                    .doesNotContain("4.1.03");
+        }
+
+        @Test
+        @DisplayName("Cobrado ≠ capital + interés + mora → rechazo (probable seguros/comisiones intra-cuota)")
+        void pago_desbalanceado_se_rechaza() {
+            // cuotaNormal espera total 500, pero se "cobró" 600 → 100 sin clasificar
+            assertThatThrownBy(() -> adapter.registrarPagoCuota(
+                    solicitud, cuotaNormal, new BigDecimal("600.00"), "REF-X"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("desbalanceado")
+                    .hasMessageContaining("seguros/comisiones");
+
+            verifyNoInteractions(asientoContableService);
+        }
+
+        @Test
+        @DisplayName("Referencia null/vacía → genera referencia fallback 'CUOTA-{id}'")
+        void referencia_null_usa_fallback() {
+            adapter.registrarPagoCuota(solicitud, cuotaNormal, new BigDecimal("500.00"), null);
+
+            RegistrarAsientoCommand cmd = capturarComando();
+            assertThat(cmd.referenciaExterna()).startsWith("CUOTA-");
+        }
+    }
+
+    // ═══ Propagación de errores ═══════════════════════════════════════════
+
+    @Test
+    @DisplayName("excepción de AsientoContableService se propaga (no se traga)")
+    void error_contable_se_propaga_en_desembolso() {
+        doThrow(new AsientoContableException("plan de cuentas no inicializado"))
+                .when(asientoContableService).registrar(org.mockito.ArgumentMatchers.any());
+
+        assertThatThrownBy(() -> adapter.registrarDesembolso(
+                solicitud, new BigDecimal("10000.00"), BigDecimal.ZERO))
+                .isInstanceOf(AsientoContableException.class)
+                .hasMessageContaining("plan de cuentas");
+    }
+
+    @Test
+    @DisplayName("excepción de AsientoContableService se propaga en pago cuota también")
+    void error_contable_se_propaga_en_pago_cuota() {
+        doThrow(new AsientoContableException("cuenta 4.1.01 no encontrada"))
+                .when(asientoContableService).registrar(org.mockito.ArgumentMatchers.any());
+
+        assertThatThrownBy(() -> adapter.registrarPagoCuota(
+                solicitud, cuotaNormal, new BigDecimal("500.00"), "REF"))
+                .isInstanceOf(AsientoContableException.class)
+                .hasMessageContaining("4.1.01");
+    }
+
+    // ─── Helper ────────────────────────────────────────────────────────────
+
+    private RegistrarAsientoCommand capturarComando() {
+        ArgumentCaptor<RegistrarAsientoCommand> captor =
+                ArgumentCaptor.forClass(RegistrarAsientoCommand.class);
+        verify(asientoContableService).registrar(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/docs/modulos/contabilidad/00-overview.md
+++ b/docs/modulos/contabilidad/00-overview.md
@@ -28,11 +28,11 @@ contable de partida doble. Eso significa:
 El EPIC #263 cierra esa brecha desde la base (plan de cuentas) hasta los
 reportes finales.
 
-## Estado actual (2026-05-20)
+## Estado actual (2026-05-20, post #268)
 
 ```
 Plan de cuentas (#264) ──► Asientos (#265+#266) ──► Hooks Ahorros (#267) ──► Hooks Créditos (#268) ──► Reportes (#269-#271) ──► Cierre (#272+#273)
-       ✅                       ✅                        🚧 (PR #315)              ⏳                       ⏳                        ⏳
+       ✅                       ✅                        ✅                        🚧 (PR)                  ⏳                        ⏳
 ```
 
 ## Timeline cronológico de decisiones y entregas
@@ -107,16 +107,27 @@ Este hallazgo desencadenó:
 3. La identificación de varios pendientes regulatorios que documenté en
    [[_pendientes-criticos]].
 
-### 2026-05-20 — Próximo: #268 Hooks de Créditos
+### 2026-05-20 — #268 Hooks de Créditos (IMPLEMENTADO)
 
-**[[04-hooks-creditos|#268 — Hooks Créditos]]** (en diseño)
+**[[04-hooks-creditos|#268 — Hooks Créditos]]** (PR en revisión)
 
-Mismo patrón que #267 pero con operaciones del módulo Créditos:
-- **Desembolso**: DEBE `1.3.01` Cartera / HABER `1.1.03` Bancos / HABER `4.1.02` Comisión
-- **Pago cuota**: DEBE `1.1.03` Bancos / HABER `1.3.01` (capital) / HABER `4.1.01` (intereses) / HABER `4.1.03` (mora si aplica)
+Mismo patrón que #267 aplicado al módulo Créditos, con mapping previamente
+aprobado por [[_contador-fatrans]] ([[_decisiones-contables#D-003|D-003]] y
+[[_decisiones-contables#D-004|D-004]]):
+- **Desembolso**: DEBE `1.3.01` Cartera / HABER `1.1.03` Bancos / HABER `4.1.02` Comisión (si > 0)
+- **Pago cuota**: DEBE `1.1.03` Bancos / HABER `1.3.01` capital / HABER `4.1.01` intereses / HABER `4.1.03` mora (si > 0)
 
-Mapping **aprobado** por contador-fatrans con observaciones documentadas en
-[[_decisiones-contables#D-003|D-003]] y [[_decisiones-contables#D-004|D-004]].
+**Decisiones de implementación adicionales**:
+- Adapter valida localmente el cuadre antes de invocar contabilidad → mensajes de error claros indicando si es problema de cálculo del use case vs. plan de cuentas.
+- En `RegistrarPagoCuotaUseCase`: refactor mínimo para cargar `SolicitudCredito` siempre (antes solo se cargaba si era el último pago).
+- Hook contable se invoca **antes** de la notificación al socio (verificado con `InOrder`), para que un rollback contable evite notificar un desembolso que no ocurrió.
+
+**Tests**: 32 nuevos, todos verde.
+
+**Pendientes deliberadamente fuera de scope** (documentados en `04-hooks-creditos.md`):
+- Crédito en USD (modelo no tiene campo `moneda`)
+- Ejecución de colateral (use case existe pero sin hook)
+- Pago parcial (flujo actual exige completo)
 
 ## Lo que viene después de #268
 

--- a/docs/modulos/contabilidad/04-hooks-creditos.md
+++ b/docs/modulos/contabilidad/04-hooks-creditos.md
@@ -1,21 +1,22 @@
 ---
-tags: [contabilidad, creditos, hooks, integracion, planificacion]
+tags: [contabilidad, creditos, hooks, integracion]
 sub-issue: "#268"
-pr: pending
-estado: en-diseño
+pr: en-curso
+estado: implementado
 created: 2026-05-20
+actualizado: 2026-05-20 (implementación completa, 32 tests verdes)
 ---
 
-# 🔌 Hooks contables — módulo Créditos (PLAN, no implementado todavía)
+# 🔌 Hooks contables — módulo Créditos
 
-> [!summary] Sub-issue [[Home|#268]] (en diseño)
-> Cada desembolso de crédito y cada pago de cuota debe generar
-> automáticamente su [[02-asientos-contables|asiento contable]] de partida
-> doble, en la misma transacción que mueve los datos operativos.
+> [!summary] Sub-issue [[Home|#268]] — IMPLEMENTADO
+> Cada desembolso de crédito y cada pago de cuota genera **automáticamente**
+> su [[02-asientos-contables|asiento contable]] de partida doble, en la misma
+> transacción que mueve los datos operativos.
 >
-> Mapping **aprobado** por [[_contador-fatrans|contador-fatrans]] con
-> observaciones documentadas en [[_decisiones-contables#D-003|D-003]] y
-> [[_decisiones-contables#D-004|D-004]].
+> Mapping aprobado por [[_contador-fatrans|contador-fatrans]] —
+> [[_decisiones-contables#D-003|D-003]] (desembolso) y
+> [[_decisiones-contables#D-004|D-004]] (pago cuota).
 
 ## Mapping operación → asiento
 
@@ -115,7 +116,7 @@ public interface CreditosContabilidadPort {
 }
 ```
 
-## Cambios al codebase planificados
+## Cambios al codebase (implementado)
 
 ```
 backend/src/main/java/com/tufondo/creditos/
@@ -123,40 +124,51 @@ backend/src/main/java/com/tufondo/creditos/
 │   ├── port/output/
 │   │   └── CreditosContabilidadPort.java            [NUEVO]
 │   └── usecase/
-│       ├── DesembolsaCreditoUseCase.java             [+inject port +call hook]
-│       └── RegistrarPagoCuotaUseCase.java            [+inject port +call hook]
+│       ├── DesembolsaCreditoUseCase.java             [+inject port, +llamada al hook]
+│       └── RegistrarPagoCuotaUseCase.java            [+inject port, +cargar solicitud, +llamada al hook]
 └── infrastructure/contabilidad/
     └── CreditosContabilidadAdapter.java              [NUEVO — mapea códigos]
 
 backend/src/test/java/com/tufondo/creditos/
 ├── application/usecase/
-│   ├── DesembolsaCreditoUseCaseTest.java             [NUEVO]
-│   └── RegistrarPagoCuotaUseCaseTest.java            [NUEVO]
+│   ├── DesembolsaCreditoUseCaseHookTest.java         [NUEVO — 7 tests]
+│   └── RegistrarPagoCuotaUseCaseHookTest.java        [NUEVO — 6 tests]
 └── infrastructure/contabilidad/
-    ├── CreditosContabilidadAdapterTest.java          [NUEVO — Mockito unit]
-    └── CreditosContabilidadAdapterIntegrationTest    [NUEVO — H2 E2E]
+    ├── CreditosContabilidadAdapterTest.java          [NUEVO — 13 Mockito unit]
+    └── CreditosContabilidadAdapterIntegrationTest    [NUEVO — 6 H2 E2E]
 ```
 
-## Tests planificados
+## Tests implementados (32 tests verdes)
 
-| Test class | Casos esperados | Estrategia |
+| Test class | Casos | Estrategia |
 |---|---|---|
-| `CreditosContabilidadAdapterTest` | ~12 unit | Mockito — verifica `RegistrarAsientoCommand` para desembolso con/sin comisión, pago con/sin mora |
-| `CreditosContabilidadAdapterIntegrationTest` | ~6 E2E | `@DataJpaTest` con H2 — asiento real persistido con partidas correctas |
-| `DesembolsaCreditoUseCaseTest` | ~6 unit | Mockito — verifica que el hook se invoque tras estado DESEMBOLSADO, propagación de errores |
-| `RegistrarPagoCuotaUseCaseTest` | ~7 unit | Mockito — verifica hook tras estado PAGADA, idempotencia por `referenciaPago` |
+| `CreditosContabilidadAdapterTest` | **13** (Mockito) | Unit — verifica `RegistrarAsientoCommand` para desembolso con/sin comisión, pago con/sin mora, validaciones locales de cuadre |
+| `CreditosContabilidadAdapterIntegrationTest` | **6** (H2 E2E) | `@DataJpaTest` — asiento real persistido con partidas correctas, decimales NUMERIC(18,4) preservados |
+| `DesembolsaCreditoUseCaseHookTest` | **7** (Mockito) | Hook se invoca con monto neto + comisión correctos, IDOR/estado cortan antes, error contable propaga sin notificar |
+| `RegistrarPagoCuotaUseCaseHookTest` | **6** (Mockito) | Hook recibe (solicitud, cuota, monto, referencia), validaciones tempranas cortan antes, error propaga |
 
-### Casos específicos a cubrir
+### Casos cubiertos
 
-- ✅ Desembolso sin comisión → 2 partidas (DEBE 1.3.01, HABER 1.1.03).
-- ✅ Desembolso con comisión > 0 → 3 partidas (la 3ra HABER 4.1.02).
-- ✅ Pago cuota sin mora → 3 partidas (DEBE 1.1.03, HABER 1.3.01, HABER 4.1.01).
-- ✅ Pago cuota con mora > 0 → 4 partidas (la 4ta HABER 4.1.03).
-- ✅ Cuadre exacto: `Σdebe == Σhaber` con decimales (forzar cuotas decimales raras).
-- ✅ Si AsientoContableService lanza, el use case propaga y hace rollback.
-- ✅ Si el plan de cuentas no tiene `1.3.01` o `1.1.03` → falla clara.
-- ✅ Doble pago de la misma `referenciaPago` se rechaza (idempotencia).
-- ✅ Crédito con moneda USD → excepción clara (no implementado, evitar bug silencioso).
+> [!check] Garantías de los tests
+> - ✅ Desembolso sin comisión → 2 partidas (DEBE 1.3.01, HABER 1.1.03)
+> - ✅ Desembolso con comisión > 0 → 3 partidas (la 3ra HABER 4.1.02)
+> - ✅ Pago cuota sin mora → 3 partidas (DEBE 1.1.03, HABER 1.3.01, HABER 4.1.01)
+> - ✅ Pago cuota con mora > 0 → 4 partidas (la 4ta HABER 4.1.03)
+> - ✅ Cuadre exacto: `Σdebe == Σhaber` (validado por dominio + verificación local del adapter)
+> - ✅ Si `AsientoContableService` lanza, el use case propaga y hace rollback
+> - ✅ Si el plan de cuentas no tiene `1.3.01` o `1.1.03` → `AsientoContableException` clara
+> - ✅ Doble pago de la misma `referenciaPago` se rechaza con `PagoDuplicadoException` antes del hook
+> - ✅ Cuota con seguros/comisiones intra-cuota (campos no usados hoy) → rechazo local con mensaje explicativo
+> - ✅ Decimales NUMERIC(18,4) preservados sin truncado
+> - ✅ Orden: hook contable ANTES de notificación al socio (rollback evita notificar)
+> - ✅ Referencia null/vacía → fallback `CUOTA-{id}` para auditoría
+> - ✅ Comisión apertura override en request tiene precedencia sobre TipoCredito.comisionApertura
+
+### Pendiente (no incluido en #268)
+
+- ⏳ **Crédito con moneda USD**: la validación de moneda no existe en el modelo `SolicitudCredito` actualmente (no hay campo `moneda`). Cuando se agregue, hay que decidir si crear `1.3.04` Créditos USD separados o convertir a Bs. Ver [[_pendientes-criticos#Cartera-y-operaciones-USD-separadas|P2]].
+- ⏳ **Ejecución de colateral**: cuando una cuota se ejecuta sobre garantía, el asiento es distinto (no es cobro normal). El use case `EjecutarColateralUseCase` existe pero NO tiene hook todavía. Sub-issue dedicado futuro.
+- ⏳ **Pago parcial**: el flujo actual exige `monto >= montoRequerido`. Si se permite parcial en el futuro, el asiento de capital + interés debe prorratearse — sub-issue.
 
 ## Dependencias
 

--- a/docs/modulos/contabilidad/Home.md
+++ b/docs/modulos/contabilidad/Home.md
@@ -66,8 +66,8 @@ backend/src/main/java/com/tufondo/ahorros/
 |---|---|---|---|
 | [[01-plan-cuentas\|#264]] | ✅ Merged (PR #313) | Plan de cuentas VEN-NIF (V21) — ~55 cuentas seed | [[_decisiones-contables#D-001\|D-001]] V21 congelado |
 | [[02-asientos-contables\|#265 + #266]] | ✅ Merged (PR #314) | Tablas + dominio + service + 50+ tests | Asientos inmutables, ON DELETE RESTRICT |
-| [[03-hooks-ahorros\|#267]] | 🚧 PR #315 abierto | Hooks de Ahorros: depósito/retiro → asiento auto | [[_decisiones-contables#D-002\|D-002]] usar `1.1.03` no `1.1.01` |
-| [[04-hooks-creditos\|#268]] | 🚧 En diseño | Hooks de Créditos | [[_decisiones-contables#D-003\|D-003]] [[_decisiones-contables#D-004\|D-004]] |
+| [[03-hooks-ahorros\|#267]] | ✅ Merged (PR #315) | Hooks de Ahorros: depósito/retiro → asiento auto | [[_decisiones-contables#D-002\|D-002]] usar `1.1.03` no `1.1.01` |
+| [[04-hooks-creditos\|#268]] | 🚧 En PR | Hooks de Créditos: desembolso + pago cuota → asiento auto | [[_decisiones-contables#D-003\|D-003]] [[_decisiones-contables#D-004\|D-004]] |
 | #269 | ⏳ Pending | Libro Diario + export PDF SUDECA | |
 | #270 | ⏳ Pending | Libro Mayor (saldos por cuenta) | |
 | #271 | ⏳ Pending | Balance General + Estado de Resultados | |
@@ -122,7 +122,9 @@ docker run --rm `
 
 Última corrida verde:
 - **Módulo contabilidad solo**: 120 tests, 0 failures (2026-05-20)
-- **Suite completa backend**: 555 tests, 0 failures (2026-05-20, post #267)
+- **#267 (Ahorros)**: 28 tests nuevos, todos verde
+- **#268 (Créditos)**: 32 tests nuevos, todos verde — 13 adapter unit + 6 E2E + 7 desembolso hook + 6 pago hook
+- **Suite completa backend**: 555+ tests, 0 failures (2026-05-20)
 
 ## Cómo trabajar el módulo
 


### PR DESCRIPTION
## Resumen

Sub-issue **#268** del EPIC Contabilidad **#263**. Cada desembolso de crédito y cada pago de cuota ahora genera **automáticamente** su asiento contable de partida doble dentro de la misma `@Transactional`, manteniendo sincronizada la cartera con el libro mayor por exigencia regulatoria SUDECA.

Mapping aprobado por el sub-agente especializado [`contador-fatrans`](https://github.com/gamijoam/fatrans/blob/feat/contab-hooks-creditos-268-v2/.claude/agents/contador-fatrans.md) — decisiones [D-003](https://github.com/gamijoam/fatrans/blob/feat/contab-hooks-creditos-268-v2/docs/modulos/contabilidad/_decisiones-contables.md#d-003) (desembolso) y [D-004](https://github.com/gamijoam/fatrans/blob/feat/contab-hooks-creditos-268-v2/docs/modulos/contabilidad/_decisiones-contables.md#d-004) (pago cuota).

## Mapping operación → asiento

### Desembolso (`CREDITO_DESEMBOLSO`)

| | DEBE | HABER |
|---|---|---|
| Cartera (sube por bruto) | `1.3.01` Créditos por Cobrar | |
| Bancos (sale neto al socio) | | `1.1.03` Bancos Cta Corriente Bs |
| Comisión apertura (si > 0) | | `4.1.02` Comisiones por Otorgamiento |

### Pago de cuota (`CREDITO_COBRO`)

| | DEBE | HABER |
|---|---|---|
| Bancos (entra total cobrado) | `1.1.03` Bancos Cta Corriente Bs | |
| Cartera (baja capital amortizado) | | `1.3.01` Créditos por Cobrar |
| Intereses normales | | `4.1.01` Intereses sobre Créditos |
| Mora (solo si > 0) | | `4.1.03` Intereses Moratorios |

## Arquitectura (mismo patrón que #267)

```
DesembolsaCreditoUseCase ─┬─► CreditosContabilidadPort (interfaz)
RegistrarPagoCuotaUseCase ┘            ↓
                          CreditosContabilidadAdapter (impl)
                                       ↓
                          AsientoContableService.registrar()
```

Cero cambios en `com.tufondo.contabilidad.*` — solo agregamos un consumidor.

## Decisiones de implementación destacadas

1. **Validación local del cuadre** en el adapter ANTES de llamar a contabilidad. Si `bruto ≠ neto + comisión` o `cobrado ≠ capital + interés + mora`, lanza con mensaje claro indicando si es problema del use case o de seguros/comisiones intra-cuota no soportados.

2. **Orden del hook respecto a notificación**: en `DesembolsaCreditoUseCase` el hook contable se invoca ANTES de la notificación al socio. Validado con `InOrder` en test — si la contabilidad hace rollback, no se notifica un desembolso que en realidad no ocurrió.

3. **Refactor mínimo en `RegistrarPagoCuotaUseCase`**: ahora carga `SolicitudCredito` siempre (antes solo dentro del bloque "última cuota"). El hook necesita la solicitud para el `referenciaExterna` y para la moneda futura.

4. **Referencia externa del asiento**: desembolso usa `numeroSolicitud`, pago usa `referenciaPago` o fallback `CUOTA-{id}`. Permite trazabilidad bidireccional en auditoría.

## Tests reales — 32 nuevos, todos verde

Corridos en Docker (`maven:3.9-eclipse-temurin-21`) con BD H2 modo Postgres:

| Test class | Casos | Tipo |
|---|---|---|
| `CreditosContabilidadAdapterTest` | 13 (Mockito + nested) | Unit — verifica `RegistrarAsientoCommand` para cada combinación (con/sin comisión, con/sin mora) |
| `CreditosContabilidadAdapterIntegrationTest` | 6 | **E2E con BD real (H2)** — el asiento queda persistido con partidas correctas, decimales NUMERIC(18,4) preservados |
| `DesembolsaCreditoUseCaseHookTest` | 7 | Unit — hook invocado con cálculos correctos, IDOR/estado cortan antes, error contable propaga sin notificar |
| `RegistrarPagoCuotaUseCaseHookTest` | 6 | Unit — validaciones previas cortan antes, hook recibe argumentos correctos, error propaga |

**Suite completa backend: 587 tests / 0 failures / 0 errors** ✅

## Documentación actualizada

- [`04-hooks-creditos.md`](https://github.com/gamijoam/fatrans/blob/feat/contab-hooks-creditos-268-v2/docs/modulos/contabilidad/04-hooks-creditos.md) — pasa de "en diseño" a "implementado"
- [`Home.md`](https://github.com/gamijoam/fatrans/blob/feat/contab-hooks-creditos-268-v2/docs/modulos/contabilidad/Home.md) — actualiza estado #268 + métricas tests
- [`00-overview.md`](https://github.com/gamijoam/fatrans/blob/feat/contab-hooks-creditos-268-v2/docs/modulos/contabilidad/00-overview.md) — entrada nueva en timeline

## Pendientes fuera de scope (documentados)

- **Crédito en USD**: `SolicitudCredito` no tiene campo `moneda`. Cuando se agregue, decidir si crear `1.3.04` Créditos USD o convertir a Bs. Ver `_pendientes-criticos.md` P2.
- **`EjecutarColateralUseCase`**: existe pero sin hook — asiento distinto al cobro normal. Sub-issue dedicado.
- **Pago parcial**: flujo actual exige pago completo. Si se permite parcial, hay que prorratear capital/interés.
- **Devengo mensual de intereses** (VEN-NIF NIC-1): actualmente criterio de caja modificado. Bloqueante antes del primer cierre fiscal serio. Ver `_pendientes-criticos.md` P1.

## Test plan (post-merge en QA)

- [ ] Desembolsar un crédito sin comisión vía `POST /api/v1/creditos/{numero}/desembolsar` → verificar asiento `CREDITO_DESEMBOLSO` con 2 partidas (DEBE `1.3.01`, HABER `1.1.03`).
- [ ] Desembolsar uno con comisión → verificar 3 partidas (la 3ra HABER `4.1.02`).
- [ ] Registrar pago de cuota sin mora → verificar asiento `CREDITO_COBRO` con 3 partidas.
- [ ] Pagar cuota vencida con mora → verificar 4 partidas (la 4ta HABER `4.1.03`).
- [ ] Provocar error contable (borrar `1.3.01` del plan) → desembolso debe fallar 422 y NO modificar `SolicitudCredito` ni `PlanAmortizacion`.