### PR TITLE
feat(contab #269): Libro Diario JSON + PDF — primer reporte SUDECA

### DIFF
--- a/backend/src/main/java/com/tufondo/FondoApplication.java
+++ b/backend/src/main/java/com/tufondo/FondoApplication.java
@@ -1,13 +1,14 @@
 package com.tufondo;
 
 import com.tufondo.auth.infrastructure.configuration.JwtProperties;
+import com.tufondo.contabilidad.application.config.EntidadProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({JwtProperties.class, EntidadProperties.class})
 @EnableScheduling  // Issue #231: necesario para BcvScraperJob
 public class FondoApplication {
 

--- a/backend/src/main/java/com/tufondo/contabilidad/api/controller/LibroDiarioController.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/api/controller/LibroDiarioController.java
@@ -1,0 +1,116 @@
+package com.tufondo.contabilidad.api.controller;
+
+import com.tufondo.contabilidad.application.dto.LibroDiarioFilter;
+import com.tufondo.contabilidad.application.dto.LibroDiarioResponse;
+import com.tufondo.contabilidad.application.port.output.ContabilidadPdfPort;
+import com.tufondo.contabilidad.application.usecase.GenerarLibroDiarioUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+/**
+ * Controller del Libro Diario (sub-issue #269).
+ *
+ * <p>Expone GET con dos formatos:</p>
+ * <ul>
+ *   <li>{@code .../libro-diario} — JSON estructurado (default)</li>
+ *   <li>{@code .../libro-diario/pdf} — PDF descargable</li>
+ * </ul>
+ *
+ * <p>Solo accesible para roles ADMIN / SUPER_ADMIN / SISTEMA. Ideal sería
+ * un rol CONTADOR dedicado — ver pendiente "Crear rol CONTADOR" en
+ * {@code docs/modulos/contabilidad/_pendientes-criticos.md}.</p>
+ */
+@RestController
+@RequestMapping("/api/v1/contabilidad/libro-diario")
+@RequiredArgsConstructor
+@Tag(name = "Contabilidad - Libro Diario",
+        description = "Reporte SUDECA con todos los asientos del período")
+public class LibroDiarioController {
+
+    private final GenerarLibroDiarioUseCase useCase;
+    private final ContabilidadPdfPort pdfPort;
+
+    /**
+     * Libro Diario en JSON.
+     *
+     * <p>Devuelve la estructura completa con encabezado, asientos y totales.
+     * El frontend admin puede mostrar la tabla o re-descargar como PDF.</p>
+     */
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN','SUPER_ADMIN','SISTEMA')")
+    @Operation(summary = "Genera el Libro Diario en JSON",
+            description = "Solo ADMIN/SUPER_ADMIN/SISTEMA. Rango ≤ 1 año fiscal.")
+    public ResponseEntity<LibroDiarioResponse> generar(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate desde,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hasta,
+            @RequestParam(defaultValue = "true") boolean incluirAnulados,
+            Authentication authentication) {
+
+        UUID solicitanteId = extraerUsuarioId(authentication);
+        LibroDiarioFilter filter = new LibroDiarioFilter(desde, hasta, incluirAnulados);
+        LibroDiarioResponse response = useCase.ejecutar(filter, solicitanteId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Libro Diario en PDF. Mismo contenido que el endpoint JSON pero renderizado
+     * para impresión / archivo.
+     */
+    @GetMapping("/pdf")
+    @PreAuthorize("hasAnyRole('ADMIN','SUPER_ADMIN','SISTEMA')")
+    @Operation(summary = "Genera el Libro Diario en PDF para descarga",
+            description = "Mismo dataset que JSON, formateado tabular SUDECA.")
+    public ResponseEntity<byte[]> generarPdf(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate desde,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hasta,
+            @RequestParam(defaultValue = "true") boolean incluirAnulados,
+            Authentication authentication) {
+
+        UUID solicitanteId = extraerUsuarioId(authentication);
+        LibroDiarioFilter filter = new LibroDiarioFilter(desde, hasta, incluirAnulados);
+        LibroDiarioResponse data = useCase.ejecutar(filter, solicitanteId);
+        byte[] pdf = pdfPort.generarLibroDiarioPdf(data);
+
+        String filename = String.format("LibroDiario_%s_a_%s.pdf",
+                desde.format(DateTimeFormatter.BASIC_ISO_DATE),
+                hasta.format(DateTimeFormatter.BASIC_ISO_DATE));
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_PDF_VALUE)
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"" + filename + "\"")
+                .header(HttpHeaders.CACHE_CONTROL,
+                        "no-store, no-cache, must-revalidate, private")
+                .body(pdf);
+    }
+
+    /** Helper: extrae socioId o usuarioId del token JWT. */
+    private UUID extraerUsuarioId(Authentication authentication) {
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof com.tufondo.auth.infrastructure.security.AuthenticatedUser authUser) {
+            UUID socioId = authUser.getSocioId();
+            if (socioId != null) return socioId;
+        }
+        try {
+            return UUID.fromString(authentication.getName());
+        } catch (IllegalArgumentException e) {
+            return null; // usuarios admin sin UUID en name — auditoría queda con null
+        }
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/config/EntidadProperties.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/config/EntidadProperties.java
@@ -1,0 +1,42 @@
+package com.tufondo.contabilidad.application.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Properties identificatorias de la entidad (sub-issue #269).
+ *
+ * <p>Razón social, RIF, dirección — datos que aparecen en cabecera de los
+ * reportes contables formales (Libro Diario, Libro Mayor, Balance General).
+ * Se configuran vía {@code application.yml}:</p>
+ *
+ * <pre>
+ * entidad:
+ *   razonSocial: "Asociación Fatrans de Ahorro y Crédito"
+ *   rif: "J-XXXXXXX-X"
+ *   direccion: "..."
+ * </pre>
+ *
+ * <p><strong>Por qué properties y no parámetros en BD</strong>: los reportes
+ * SUDECA exigen cabeceras de identificación fiscal que cambian rara vez
+ * (cuando cambia el RIF o la razón social, lo cual implica trámites legales).
+ * Properties son configurables sin migration y suficiente para arrancar.
+ * Si en el futuro se necesita una UI de admin para editarlos, sub-issue
+ * dedicado migra a {@code parametros_sistema}.</p>
+ */
+@Data
+@ConfigurationProperties(prefix = "entidad")
+public class EntidadProperties {
+
+    /** Razón social completa que aparece en cabeceras de reportes. */
+    private String razonSocial = "Asociación Fatrans de Ahorro y Crédito (configurar)";
+
+    /** RIF venezolano formato J-XXXXXXX-X. */
+    private String rif = "J-XXXXXXXX-X (configurar)";
+
+    /** Dirección física, opcional. */
+    private String direccion = "";
+
+    /** Sigla corta, opcional. */
+    private String sigla = "FATRANS";
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/dto/LibroDiarioFilter.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/dto/LibroDiarioFilter.java
@@ -1,0 +1,48 @@
+package com.tufondo.contabilidad.application.dto;
+
+import java.time.LocalDate;
+
+/**
+ * Filtros para la generación del Libro Diario (sub-issue #269).
+ *
+ * <p>El rango {@code desde-hasta} es obligatorio y debe ser ≤ 1 año fiscal
+ * para evitar reportes gigantes que comprometan memoria/timeout. SUDECA
+ * típicamente exige el Libro Diario mensual o anual — pedirlo por décadas
+ * no tiene sentido operativo.</p>
+ *
+ * @param desde            inicio del período (inclusive)
+ * @param hasta            fin del período (inclusive)
+ * @param incluirAnulados  si {@code true} (default), incluye asientos
+ *                         ANULADOS marcados visualmente. Si {@code false},
+ *                         solo REGISTRADOS. SUDECA exige normalmente el
+ *                         "todo" con la marca, no la exclusión.
+ */
+public record LibroDiarioFilter(
+        LocalDate desde,
+        LocalDate hasta,
+        boolean incluirAnulados
+) {
+    public static final int RANGO_MAX_DIAS = 366; // 1 año bisiesto
+
+    /** Constructor con defaults. */
+    public LibroDiarioFilter {
+        if (desde == null || hasta == null) {
+            throw new IllegalArgumentException("desde y hasta son obligatorios");
+        }
+        if (hasta.isBefore(desde)) {
+            throw new IllegalArgumentException("hasta no puede ser anterior a desde");
+        }
+        long dias = java.time.temporal.ChronoUnit.DAYS.between(desde, hasta);
+        if (dias > RANGO_MAX_DIAS) {
+            throw new IllegalArgumentException(String.format(
+                    "rango de %d días excede el máximo de %d (1 año fiscal). " +
+                            "Divida la consulta en períodos menores.",
+                    dias, RANGO_MAX_DIAS));
+        }
+    }
+
+    /** Constructor por defecto con incluirAnulados=true. */
+    public static LibroDiarioFilter de(LocalDate desde, LocalDate hasta) {
+        return new LibroDiarioFilter(desde, hasta, true);
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/dto/LibroDiarioResponse.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/dto/LibroDiarioResponse.java
@@ -1,0 +1,89 @@
+package com.tufondo.contabilidad.application.dto;
+
+import com.tufondo.contabilidad.domain.model.enums.EstadoAsiento;
+import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Response del Libro Diario (sub-issue #269).
+ *
+ * <p>Estructura tradicional contable: encabezado con datos de la entidad y
+ * período, lista de asientos con sus partidas, y totales del período. El
+ * frontend o el adapter PDF consumen este mismo DTO.</p>
+ */
+@Builder
+public record LibroDiarioResponse(
+        Encabezado encabezado,
+        List<AsientoDiario> asientos,
+        Totales totales
+) {
+
+    /**
+     * Datos identificatorios y de auditoría que cabecean el reporte.
+     * Razón social y RIF vienen de properties — ver {@code EntidadProperties}.
+     */
+    @Builder
+    public record Encabezado(
+            String razonSocial,
+            String rif,
+            LocalDate desde,
+            LocalDate hasta,
+            Instant generadoEn,
+            UUID generadoPorUsuarioId,
+            boolean incluyeAnulados
+    ) {}
+
+    /**
+     * Un asiento del libro, con su número formateado para presentación
+     * ({@code AÑO-NNNNNN}, ej. "2026-000001") y sus partidas en orden.
+     */
+    @Builder
+    public record AsientoDiario(
+            long numero,
+            String numeroFormateado,       // "2026-000123" (año + correlativo)
+            LocalDate fechaContable,
+            OrigenAsiento origen,
+            EstadoAsiento estado,
+            String glosa,
+            String referenciaExterna,
+            String motivoAnulacion,         // null si REGISTRADO
+            List<PartidaDiario> partidas,
+            BigDecimal totalDebe,
+            BigDecimal totalHaber
+    ) {}
+
+    /**
+     * Una partida (renglón) del asiento. Incluye nombre de cuenta (resuelto
+     * por el use case via lookup en el plan) para que el reporte sea
+     * autocontenido y no requiera otras llamadas.
+     */
+    @Builder
+    public record PartidaDiario(
+            String codigoCuenta,
+            String nombreCuenta,
+            BigDecimal debe,
+            BigDecimal haber,
+            String glosa,
+            int orden
+    ) {}
+
+    /**
+     * Totales agregados del período. Si {@code balanceado=false} hay un
+     * problema serio — sería bug del sistema porque cada asiento individual
+     * está balanceado por invariante de dominio.
+     */
+    @Builder
+    public record Totales(
+            int cantidadAsientos,
+            int cantidadAnulados,
+            BigDecimal totalDebe,
+            BigDecimal totalHaber,
+            boolean balanceado
+    ) {}
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/port/output/ContabilidadPdfPort.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/port/output/ContabilidadPdfPort.java
@@ -1,0 +1,29 @@
+package com.tufondo.contabilidad.application.port.output;
+
+import com.tufondo.contabilidad.application.dto.LibroDiarioResponse;
+
+/**
+ * Puerto de salida para generación de reportes contables en PDF.
+ *
+ * <p>Sub-issue #269. Se crea propio del módulo contabilidad en lugar de
+ * reutilizar el {@code PdfGeneratorPort} de {@code documentospdf} porque:</p>
+ * <ul>
+ *   <li>Aquel está acoplado a {@code TipoDocumento} enum del otro módulo.</li>
+ *   <li>Los reportes contables tienen contrato distinto (DTO tipado vs Map).</li>
+ *   <li>Mantiene separación de responsabilidades entre módulos.</li>
+ * </ul>
+ *
+ * <p>La implementación PUEDE compartir librería (OpenPDF) — solo el contrato
+ * es separado.</p>
+ */
+public interface ContabilidadPdfPort {
+
+    /**
+     * Genera el PDF del Libro Diario a partir del response ya armado por
+     * el use case (con encabezado, asientos y totales).
+     *
+     * @param libroDiario datos completos del reporte
+     * @return bytes del PDF listo para descarga
+     */
+    byte[] generarLibroDiarioPdf(LibroDiarioResponse libroDiario);
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/usecase/GenerarLibroDiarioUseCase.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/usecase/GenerarLibroDiarioUseCase.java
@@ -1,0 +1,171 @@
+package com.tufondo.contabilidad.application.usecase;
+
+import com.tufondo.contabilidad.application.config.EntidadProperties;
+import com.tufondo.contabilidad.application.dto.LibroDiarioFilter;
+import com.tufondo.contabilidad.application.dto.LibroDiarioResponse;
+import com.tufondo.contabilidad.domain.model.AsientoContable;
+import com.tufondo.contabilidad.domain.model.CuentaContable;
+import com.tufondo.contabilidad.domain.model.PartidaAsiento;
+import com.tufondo.contabilidad.domain.model.enums.EstadoAsiento;
+import com.tufondo.contabilidad.domain.repository.AsientoContableRepository;
+import com.tufondo.contabilidad.domain.repository.CuentaContableRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Genera el Libro Diario (sub-issue #269) — reporte secuencial de todos los
+ * asientos contables del período, ordenados por número correlativo.
+ *
+ * <p>Es el primer reporte exigido por SUDECA para auditoría. Incluye todos
+ * los asientos REGISTRADOS y opcionalmente los ANULADOS (con marca visual),
+ * para que la auditoría externa pueda ver el flujo completo del período sin
+ * censura.</p>
+ *
+ * <h2>Performance</h2>
+ * <ul>
+ *   <li>Lectura: 1 query a {@code listarPorRangoFecha} (ya batch-loaded las partidas).</li>
+ *   <li>Lookup de nombres: 1 query a {@code listarTodas()} del plan + index en memoria.
+ *       Costo O(n) ~ decenas-cientos de cuentas, despreciable.</li>
+ *   <li>No paginar — el Libro Diario es por naturaleza secuencial y completo.
+ *       La validación del rango (≤ 1 año) en {@link LibroDiarioFilter} acota el tamaño.</li>
+ * </ul>
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GenerarLibroDiarioUseCase {
+
+    private final AsientoContableRepository asientoRepository;
+    private final CuentaContableRepository cuentaRepository;
+    private final EntidadProperties entidadProperties;
+
+    @Transactional(readOnly = true)
+    public LibroDiarioResponse ejecutar(LibroDiarioFilter filter, UUID solicitanteId) {
+        log.info("Generando Libro Diario: desde={} hasta={} incluyeAnulados={} solicitante={}",
+                filter.desde(), filter.hasta(), filter.incluirAnulados(), solicitanteId);
+
+        // 1. Cargar todos los asientos del período (orden por número correlativo)
+        List<AsientoContable> asientosRaw = asientoRepository
+                .listarPorRangoFecha(filter.desde(), filter.hasta());
+
+        // 2. Filtrar por anulados si el filtro lo pide
+        List<AsientoContable> asientos = filter.incluirAnulados()
+                ? asientosRaw
+                : asientosRaw.stream()
+                    .filter(a -> a.getEstado() != EstadoAsiento.ANULADO)
+                    .toList();
+
+        // 3. Cargar plan de cuentas e indexar por UUID para lookup de nombres
+        Map<UUID, CuentaContable> indexPorId = cuentaRepository.listarTodas().stream()
+                .collect(Collectors.toMap(CuentaContable::getId, Function.identity()));
+
+        // 4. Mapear cada asiento al DTO con sus partidas resueltas
+        List<LibroDiarioResponse.AsientoDiario> dtoAsientos = asientos.stream()
+                .map(a -> mapearAsiento(a, indexPorId))
+                .toList();
+
+        // 5. Calcular totales del período
+        int cantidadAnulados = (int) asientos.stream()
+                .filter(a -> a.getEstado() == EstadoAsiento.ANULADO).count();
+        BigDecimal totalDebe = asientos.stream()
+                .map(AsientoContable::totalDebe)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal totalHaber = asientos.stream()
+                .map(AsientoContable::totalHaber)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        LibroDiarioResponse.Totales totales = LibroDiarioResponse.Totales.builder()
+                .cantidadAsientos(asientos.size())
+                .cantidadAnulados(cantidadAnulados)
+                .totalDebe(totalDebe)
+                .totalHaber(totalHaber)
+                .balanceado(totalDebe.compareTo(totalHaber) == 0)
+                .build();
+
+        // 6. Armar encabezado con properties + auditoría
+        LibroDiarioResponse.Encabezado encabezado = LibroDiarioResponse.Encabezado.builder()
+                .razonSocial(entidadProperties.getRazonSocial())
+                .rif(entidadProperties.getRif())
+                .desde(filter.desde())
+                .hasta(filter.hasta())
+                .generadoEn(Instant.now())
+                .generadoPorUsuarioId(solicitanteId)
+                .incluyeAnulados(filter.incluirAnulados())
+                .build();
+
+        return LibroDiarioResponse.builder()
+                .encabezado(encabezado)
+                .asientos(dtoAsientos)
+                .totales(totales)
+                .build();
+    }
+
+    private LibroDiarioResponse.AsientoDiario mapearAsiento(
+            AsientoContable a, Map<UUID, CuentaContable> indexCuentas) {
+
+        // Partidas ordenadas por su campo `orden`
+        List<LibroDiarioResponse.PartidaDiario> partidasDto = a.getPartidas().stream()
+                .sorted(Comparator.comparingInt(PartidaAsiento::getOrden))
+                .map(p -> mapearPartida(p, indexCuentas))
+                .toList();
+
+        return LibroDiarioResponse.AsientoDiario.builder()
+                .numero(a.getNumero())
+                .numeroFormateado(formatearNumero(a))
+                .fechaContable(a.getFechaContable())
+                .origen(a.getOrigen())
+                .estado(a.getEstado())
+                .glosa(a.getGlosa())
+                .referenciaExterna(a.getReferenciaExterna())
+                .motivoAnulacion(a.getMotivoAnulacion())
+                .partidas(partidasDto)
+                .totalDebe(a.totalDebe())
+                .totalHaber(a.totalHaber())
+                .build();
+    }
+
+    private LibroDiarioResponse.PartidaDiario mapearPartida(
+            PartidaAsiento p, Map<UUID, CuentaContable> indexCuentas) {
+        CuentaContable cuenta = indexCuentas.get(p.getCuentaId());
+        // Defensa: si por alguna razón la cuenta no está en el index (ej. fue
+        // borrada — aunque las FK ON DELETE RESTRICT lo impiden), mostramos
+        // el UUID como nombre para que el reporte no rompa.
+        String nombre = cuenta != null ? cuenta.getNombre() : "[CUENTA DESCONOCIDA " + p.getCuentaId() + "]";
+        String codigo = cuenta != null ? cuenta.getCodigo() : "???";
+
+        return LibroDiarioResponse.PartidaDiario.builder()
+                .codigoCuenta(codigo)
+                .nombreCuenta(nombre)
+                .debe(p.getDebe())
+                .haber(p.getHaber())
+                .glosa(p.getGlosa())
+                .orden(p.getOrden())
+                .build();
+    }
+
+    /**
+     * Formatea el número del asiento como {@code AÑO-NNNNNN} (ej. "2026-000123").
+     * El año se toma de la fecha contable, no del momento de inserción.
+     *
+     * <p>NOTA: actualmente la SEQUENCE BD es continua y nunca se resetea.
+     * Este formato presenta el número de forma "anual" sin requerir cambio
+     * de modelo. SUDECA exige reset anual real — ver pendiente
+     * P1 "Reset anual del correlativo" en {@code _pendientes-criticos.md}.
+     * Sub-issue dedicado antes del primer cierre fiscal.</p>
+     */
+    static String formatearNumero(AsientoContable a) {
+        int anio = a.getFechaContable().getYear();
+        return String.format("%d-%06d", anio, a.getNumero());
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/infrastructure/pdf/LibroDiarioPdfAdapter.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/infrastructure/pdf/LibroDiarioPdfAdapter.java
@@ -1,0 +1,231 @@
+package com.tufondo.contabilidad.infrastructure.pdf;
+
+import com.lowagie.text.*;
+import com.lowagie.text.pdf.*;
+import com.tufondo.contabilidad.application.dto.LibroDiarioResponse;
+import com.tufondo.contabilidad.application.port.output.ContabilidadPdfPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.awt.Color;
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Adapter de generación PDF del Libro Diario (sub-issue #269).
+ *
+ * <p>Implementa {@link ContabilidadPdfPort} usando la librería OpenPDF, la
+ * misma que el módulo {@code documentospdf} (ya está en {@code pom.xml}).</p>
+ *
+ * <h2>Formato</h2>
+ * <ul>
+ *   <li>A4 horizontal — para acomodar 7 columnas legibles.</li>
+ *   <li>Cabecera con razón social, RIF, período, fecha de generación.</li>
+ *   <li>Tabla con columnas: Fecha | Nº Asiento | Origen | Cuenta | Glosa | Debe | Haber.</li>
+ *   <li>Cada asiento se renderiza como una fila "agrupadora" (sin DEBE/HABER)
+ *       seguida de N filas con las partidas (una por renglón).</li>
+ *   <li>Asientos ANULADOS se marcan con fondo rojo claro y la palabra
+ *       "ANULADO" en la columna estado.</li>
+ *   <li>Totales al pie + folio "Página X de Y" en cada página.</li>
+ * </ul>
+ */
+@Component
+@Slf4j
+public class LibroDiarioPdfAdapter implements ContabilidadPdfPort {
+
+    private static final Font TITLE_FONT      = new Font(Font.HELVETICA, 14, Font.BOLD, Color.BLACK);
+    private static final Font SUBTITLE_FONT   = new Font(Font.HELVETICA, 10, Font.NORMAL, Color.DARK_GRAY);
+    private static final Font TABLE_HEADER    = new Font(Font.HELVETICA, 9, Font.BOLD, Color.WHITE);
+    private static final Font ROW_FONT        = new Font(Font.HELVETICA, 8, Font.NORMAL, Color.BLACK);
+    private static final Font ROW_FONT_BOLD   = new Font(Font.HELVETICA, 8, Font.BOLD, Color.BLACK);
+    private static final Font ROW_FONT_ANUL   = new Font(Font.HELVETICA, 8, Font.NORMAL, Color.RED);
+    private static final Font FOOTER_FONT     = new Font(Font.HELVETICA, 7, Font.NORMAL, Color.GRAY);
+
+    private static final Color HEADER_BG          = new Color(70, 70, 70);
+    private static final Color ANULADO_BG         = new Color(255, 230, 230);
+    private static final Color ASIENTO_HEADER_BG  = new Color(230, 240, 255);
+
+    private static final DateTimeFormatter FECHA_FMT = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+    private static final DateTimeFormatter TS_FMT    = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+
+    @Override
+    public byte[] generarLibroDiarioPdf(LibroDiarioResponse libro) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            Document doc = new Document(PageSize.A4.rotate(), 30, 30, 40, 40);
+            PdfWriter writer = PdfWriter.getInstance(doc, baos);
+            writer.setPageEvent(new FolioFooter()); // "Página X de Y" en cada página
+            doc.open();
+
+            // ─── Encabezado ────────────────────────────────────────────────
+            agregarEncabezado(doc, libro.encabezado());
+
+            // ─── Tabla de asientos ─────────────────────────────────────────
+            PdfPTable tabla = construirTabla(libro);
+            doc.add(tabla);
+
+            // ─── Totales ───────────────────────────────────────────────────
+            agregarTotales(doc, libro.totales());
+
+            doc.close();
+            return baos.toByteArray();
+        } catch (Exception e) {
+            log.error("Error generando PDF Libro Diario", e);
+            throw new RuntimeException("No se pudo generar el Libro Diario: " + e.getMessage(), e);
+        }
+    }
+
+    // ─── Construcción de secciones ─────────────────────────────────────────
+
+    private void agregarEncabezado(Document doc, LibroDiarioResponse.Encabezado enc) throws DocumentException {
+        Paragraph razon = new Paragraph(enc.razonSocial(), TITLE_FONT);
+        razon.setAlignment(Element.ALIGN_CENTER);
+        doc.add(razon);
+
+        Paragraph rif = new Paragraph("RIF: " + enc.rif(), SUBTITLE_FONT);
+        rif.setAlignment(Element.ALIGN_CENTER);
+        doc.add(rif);
+
+        Paragraph titulo = new Paragraph("LIBRO DIARIO", TITLE_FONT);
+        titulo.setAlignment(Element.ALIGN_CENTER);
+        titulo.setSpacingBefore(8);
+        doc.add(titulo);
+
+        String periodo = String.format("Período: %s al %s",
+                enc.desde().format(FECHA_FMT), enc.hasta().format(FECHA_FMT));
+        Paragraph per = new Paragraph(periodo, SUBTITLE_FONT);
+        per.setAlignment(Element.ALIGN_CENTER);
+        doc.add(per);
+
+        String gen = String.format("Generado: %s%s",
+                enc.generadoEn().atZone(ZoneId.of("America/Caracas")).format(TS_FMT),
+                enc.incluyeAnulados() ? " — Incluye asientos anulados" : " — Solo registrados");
+        Paragraph genP = new Paragraph(gen, FOOTER_FONT);
+        genP.setAlignment(Element.ALIGN_CENTER);
+        genP.setSpacingAfter(10);
+        doc.add(genP);
+    }
+
+    private PdfPTable construirTabla(LibroDiarioResponse libro) throws DocumentException {
+        // Ancho relativo de columnas: Fecha | Nº | Origen | Código | Cuenta | Glosa | Debe | Haber
+        float[] anchos = {2.2f, 2.2f, 2.2f, 1.5f, 3.5f, 4.5f, 2.0f, 2.0f};
+        PdfPTable tabla = new PdfPTable(anchos);
+        tabla.setWidthPercentage(100);
+        tabla.setHeaderRows(1);
+
+        // Header
+        agregarHeaderTabla(tabla,
+                "Fecha", "Nº Asiento", "Origen", "Código", "Cuenta", "Glosa", "Debe", "Haber");
+
+        // Filas por asiento
+        for (LibroDiarioResponse.AsientoDiario a : libro.asientos()) {
+            boolean anulado = a.estado().name().equals("ANULADO");
+            Color rowBg = anulado ? ANULADO_BG : Color.WHITE;
+            Font rowFont = anulado ? ROW_FONT_ANUL : ROW_FONT;
+
+            // Fila "agrupadora" del asiento (con glosa general y datos de cabecera)
+            String tagAnul = anulado ? " [ANULADO]" : "";
+            String glosaAgr = (a.glosa() == null ? "" : a.glosa())
+                    + (anulado && a.motivoAnulacion() != null
+                        ? " — Motivo: " + a.motivoAnulacion() : "");
+
+            agregarCelda(tabla, a.fechaContable().format(FECHA_FMT), rowFont, ASIENTO_HEADER_BG, Element.ALIGN_LEFT);
+            agregarCelda(tabla, a.numeroFormateado() + tagAnul, ROW_FONT_BOLD, ASIENTO_HEADER_BG, Element.ALIGN_LEFT);
+            agregarCelda(tabla, a.origen().name(), rowFont, ASIENTO_HEADER_BG, Element.ALIGN_LEFT);
+            agregarCelda(tabla, "", rowFont, ASIENTO_HEADER_BG, Element.ALIGN_LEFT);
+            agregarCelda(tabla, a.referenciaExterna() == null ? "" : a.referenciaExterna(),
+                    rowFont, ASIENTO_HEADER_BG, Element.ALIGN_LEFT);
+            agregarCelda(tabla, glosaAgr, rowFont, ASIENTO_HEADER_BG, Element.ALIGN_LEFT);
+            agregarCelda(tabla, "", rowFont, ASIENTO_HEADER_BG, Element.ALIGN_RIGHT);
+            agregarCelda(tabla, "", rowFont, ASIENTO_HEADER_BG, Element.ALIGN_RIGHT);
+
+            // Filas por partida
+            for (LibroDiarioResponse.PartidaDiario p : a.partidas()) {
+                agregarCelda(tabla, "", rowFont, rowBg, Element.ALIGN_LEFT);
+                agregarCelda(tabla, "", rowFont, rowBg, Element.ALIGN_LEFT);
+                agregarCelda(tabla, "", rowFont, rowBg, Element.ALIGN_LEFT);
+                agregarCelda(tabla, p.codigoCuenta(), rowFont, rowBg, Element.ALIGN_LEFT);
+                agregarCelda(tabla, p.nombreCuenta(), rowFont, rowBg, Element.ALIGN_LEFT);
+                agregarCelda(tabla, p.glosa() == null ? "" : p.glosa(), rowFont, rowBg, Element.ALIGN_LEFT);
+                agregarCelda(tabla, formatoMonto(p.debe()), rowFont, rowBg, Element.ALIGN_RIGHT);
+                agregarCelda(tabla, formatoMonto(p.haber()), rowFont, rowBg, Element.ALIGN_RIGHT);
+            }
+        }
+
+        return tabla;
+    }
+
+    private void agregarTotales(Document doc, LibroDiarioResponse.Totales t) throws DocumentException {
+        Paragraph espacio = new Paragraph(" ");
+        espacio.setSpacingBefore(12);
+        doc.add(espacio);
+
+        PdfPTable totales = new PdfPTable(new float[]{14f, 2.0f, 2.0f});
+        totales.setWidthPercentage(100);
+
+        String resumen = String.format(
+                "TOTALES DEL PERÍODO  —  %d asientos%s  —  %s",
+                t.cantidadAsientos(),
+                t.cantidadAnulados() > 0 ? " (" + t.cantidadAnulados() + " anulados)" : "",
+                t.balanceado() ? "BALANCEADO ✓" : "⚠ DESBALANCEADO");
+        Font totalFont = t.balanceado() ? ROW_FONT_BOLD
+                : new Font(Font.HELVETICA, 10, Font.BOLD, Color.RED);
+        agregarCelda(totales, resumen, totalFont, Color.WHITE, Element.ALIGN_LEFT);
+        agregarCelda(totales, formatoMonto(t.totalDebe()), ROW_FONT_BOLD, Color.WHITE, Element.ALIGN_RIGHT);
+        agregarCelda(totales, formatoMonto(t.totalHaber()), ROW_FONT_BOLD, Color.WHITE, Element.ALIGN_RIGHT);
+
+        doc.add(totales);
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────
+
+    private void agregarHeaderTabla(PdfPTable tabla, String... headers) {
+        for (String h : headers) {
+            PdfPCell cell = new PdfPCell(new Phrase(h, TABLE_HEADER));
+            cell.setBackgroundColor(HEADER_BG);
+            cell.setPadding(4);
+            cell.setHorizontalAlignment(Element.ALIGN_CENTER);
+            tabla.addCell(cell);
+        }
+    }
+
+    private void agregarCelda(PdfPTable tabla, String texto, Font font, Color bg, int align) {
+        PdfPCell cell = new PdfPCell(new Phrase(texto == null ? "" : texto, font));
+        cell.setBackgroundColor(bg);
+        cell.setPadding(3);
+        cell.setHorizontalAlignment(align);
+        tabla.addCell(cell);
+    }
+
+    private String formatoMonto(BigDecimal v) {
+        if (v == null || v.signum() == 0) return "";
+        return v.toPlainString();
+    }
+
+    // ─── Folio "Página X de Y" ─────────────────────────────────────────────
+
+    /**
+     * Event handler de OpenPDF que pinta el footer con folio "Página X de Y"
+     * al pie de cada página. SUDECA exige numeración de páginas continua.
+     */
+    private static class FolioFooter extends PdfPageEventHelper {
+        @Override
+        public void onEndPage(PdfWriter writer, Document doc) {
+            try {
+                PdfContentByte cb = writer.getDirectContent();
+                Phrase pieIzq = new Phrase("Libro Diario — Fatrans", FOOTER_FONT);
+                ColumnText.showTextAligned(cb, Element.ALIGN_LEFT, pieIzq,
+                        doc.left(), doc.bottom() - 15, 0);
+
+                Phrase pieDer = new Phrase(String.format("Página %d", writer.getPageNumber()), FOOTER_FONT);
+                ColumnText.showTextAligned(cb, Element.ALIGN_RIGHT, pieDer,
+                        doc.right(), doc.bottom() - 15, 0);
+            } catch (Exception e) {
+                // Defensive: el footer es cosmético — no romper la generación si falla.
+                log.warn("Error escribiendo footer del Libro Diario", e);
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/tufondo/contabilidad/application/dto/LibroDiarioFilterTest.java
+++ b/backend/src/test/java/com/tufondo/contabilidad/application/dto/LibroDiarioFilterTest.java
@@ -1,0 +1,85 @@
+package com.tufondo.contabilidad.application.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests del DTO {@link LibroDiarioFilter} — validaciones de rango.
+ */
+class LibroDiarioFilterTest {
+
+    @Test
+    @DisplayName("filtro válido (1 mes) → OK")
+    void filtro_un_mes_valido() {
+        var f = new LibroDiarioFilter(
+                LocalDate.of(2026, 5, 1),
+                LocalDate.of(2026, 5, 31),
+                true);
+        assertThat(f.desde()).isEqualTo(LocalDate.of(2026, 5, 1));
+        assertThat(f.hasta()).isEqualTo(LocalDate.of(2026, 5, 31));
+        assertThat(f.incluirAnulados()).isTrue();
+    }
+
+    @Test
+    @DisplayName("filtro 366 días (año bisiesto) → OK (límite máximo)")
+    void rango_366_dias_es_aceptado() {
+        // 2024 fue bisiesto: 366 días entre 2024-01-01 y 2024-12-31 = 365 días.
+        // Verifico el máximo absoluto del constructor (366).
+        var f = new LibroDiarioFilter(
+                LocalDate.of(2026, 1, 1),
+                LocalDate.of(2027, 1, 2),  // exactamente 366 días después
+                true);
+        assertThat(f).isNotNull();
+    }
+
+    @Test
+    @DisplayName("rango > 366 días → rechazado")
+    void rango_excesivo_rechazado() {
+        assertThatThrownBy(() -> new LibroDiarioFilter(
+                LocalDate.of(2026, 1, 1),
+                LocalDate.of(2028, 1, 1),  // 2 años
+                true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("excede el máximo");
+    }
+
+    @Test
+    @DisplayName("hasta < desde → rechazado")
+    void rango_invertido_rechazado() {
+        assertThatThrownBy(() -> new LibroDiarioFilter(
+                LocalDate.of(2026, 5, 31),
+                LocalDate.of(2026, 5, 1),
+                true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("anterior");
+    }
+
+    @Test
+    @DisplayName("desde o hasta null → rechazado")
+    void fechas_null_rechazado() {
+        assertThatThrownBy(() -> new LibroDiarioFilter(null, LocalDate.now(), true))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new LibroDiarioFilter(LocalDate.now(), null, true))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("factory de() crea filtro con incluirAnulados=true")
+    void factory_de_default() {
+        var f = LibroDiarioFilter.de(LocalDate.now().minusDays(7), LocalDate.now());
+        assertThat(f.incluirAnulados()).isTrue();
+    }
+
+    @Test
+    @DisplayName("desde = hasta (mismo día) → OK (período de 1 día)")
+    void rango_un_dia_valido() {
+        var d = LocalDate.of(2026, 5, 20);
+        var f = new LibroDiarioFilter(d, d, false);
+        assertThat(f.desde()).isEqualTo(f.hasta());
+    }
+}

--- a/backend/src/test/java/com/tufondo/contabilidad/application/usecase/GenerarLibroDiarioUseCaseTest.java
+++ b/backend/src/test/java/com/tufondo/contabilidad/application/usecase/GenerarLibroDiarioUseCaseTest.java
@@ -1,0 +1,249 @@
+package com.tufondo.contabilidad.application.usecase;
+
+import com.tufondo.contabilidad.application.config.EntidadProperties;
+import com.tufondo.contabilidad.application.dto.LibroDiarioFilter;
+import com.tufondo.contabilidad.application.dto.LibroDiarioResponse;
+import com.tufondo.contabilidad.domain.model.AsientoContable;
+import com.tufondo.contabilidad.domain.model.CuentaContable;
+import com.tufondo.contabilidad.domain.model.PartidaAsiento;
+import com.tufondo.contabilidad.domain.model.enums.EstadoAsiento;
+import com.tufondo.contabilidad.domain.model.enums.NaturalezaSaldo;
+import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
+import com.tufondo.contabilidad.domain.model.enums.TipoCuentaContable;
+import com.tufondo.contabilidad.domain.repository.AsientoContableRepository;
+import com.tufondo.contabilidad.domain.repository.CuentaContableRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests del {@link GenerarLibroDiarioUseCase} (sub-issue #269).
+ *
+ * <p>Foco: filtros funcionan, totales correctos, asientos anulados se manejan
+ * según parámetro, plan de cuentas se resuelve para mostrar nombres, formato
+ * de número correcto.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class GenerarLibroDiarioUseCaseTest {
+
+    @Mock private AsientoContableRepository asientoRepo;
+    @Mock private CuentaContableRepository cuentaRepo;
+
+    @InjectMocks private GenerarLibroDiarioUseCase useCase;
+
+    private CuentaContable caja;
+    private CuentaContable depositos;
+    private AsientoContable asientoRegistrado;
+    private AsientoContable asientoAnulado;
+    private LocalDate desde = LocalDate.of(2026, 5, 1);
+    private LocalDate hasta = LocalDate.of(2026, 5, 31);
+
+    @BeforeEach
+    void setUp() {
+        // Inyecto EntidadProperties manualmente porque @InjectMocks no lo crea
+        // (no es mock, es un POJO de propiedades). Reemplazo el constructor.
+        EntidadProperties props = new EntidadProperties();
+        props.setRazonSocial("Fatrans Test");
+        props.setRif("J-TEST-0");
+        useCase = new GenerarLibroDiarioUseCase(asientoRepo, cuentaRepo, props);
+
+        caja = CuentaContable.crear(
+                "1.1.03", "Bancos Cta Corriente Bs",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA,
+                UUID.randomUUID(), true, null);
+        depositos = CuentaContable.crear(
+                "2.1.01", "Cuentas de Ahorro Bs",
+                TipoCuentaContable.PASIVO, NaturalezaSaldo.ACREEDORA,
+                UUID.randomUUID(), true, null);
+
+        // Asiento REGISTRADO con número 1 → "2026-000001"
+        asientoRegistrado = AsientoContable.reconstruir(
+                UUID.randomUUID(), 1L,
+                LocalDate.of(2026, 5, 10), "Depósito test",
+                OrigenAsiento.AHORRO_DEPOSITO, "MOV-001",
+                EstadoAsiento.REGISTRADO, null, null, null,
+                List.of(
+                        PartidaAsiento.alDebe(caja.getId(), new BigDecimal("100.00"), 1, "DEBE"),
+                        PartidaAsiento.alHaber(depositos.getId(), new BigDecimal("100.00"), 2, "HABER")
+                ),
+                null, null, 0L);
+
+        // Asiento ANULADO con número 2 → "2026-000002"
+        asientoAnulado = AsientoContable.reconstruir(
+                UUID.randomUUID(), 2L,
+                LocalDate.of(2026, 5, 15), "Depósito que se anuló",
+                OrigenAsiento.AHORRO_DEPOSITO, "MOV-002",
+                EstadoAsiento.ANULADO, null, "Error en monto", null,
+                List.of(
+                        PartidaAsiento.alDebe(caja.getId(), new BigDecimal("200.00"), 1, null),
+                        PartidaAsiento.alHaber(depositos.getId(), new BigDecimal("200.00"), 2, null)
+                ),
+                null, null, 0L);
+
+        when(cuentaRepo.listarTodas()).thenReturn(List.of(caja, depositos));
+    }
+
+    // ─── Happy path ────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("período con 1 asiento → totales y partidas correctos")
+    void happy_path_un_asiento() {
+        when(asientoRepo.listarPorRangoFecha(desde, hasta))
+                .thenReturn(List.of(asientoRegistrado));
+
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, true), UUID.randomUUID());
+
+        assertThat(resp.asientos()).hasSize(1);
+        assertThat(resp.totales().cantidadAsientos()).isEqualTo(1);
+        assertThat(resp.totales().cantidadAnulados()).isZero();
+        assertThat(resp.totales().totalDebe()).isEqualByComparingTo("100.00");
+        assertThat(resp.totales().totalHaber()).isEqualByComparingTo("100.00");
+        assertThat(resp.totales().balanceado()).isTrue();
+    }
+
+    @Test
+    @DisplayName("encabezado incluye razón social, RIF y rango")
+    void encabezado_completo() {
+        when(asientoRepo.listarPorRangoFecha(desde, hasta)).thenReturn(List.of());
+
+        UUID solicitante = UUID.randomUUID();
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, true), solicitante);
+
+        assertThat(resp.encabezado().razonSocial()).isEqualTo("Fatrans Test");
+        assertThat(resp.encabezado().rif()).isEqualTo("J-TEST-0");
+        assertThat(resp.encabezado().desde()).isEqualTo(desde);
+        assertThat(resp.encabezado().hasta()).isEqualTo(hasta);
+        assertThat(resp.encabezado().generadoPorUsuarioId()).isEqualTo(solicitante);
+        assertThat(resp.encabezado().incluyeAnulados()).isTrue();
+        assertThat(resp.encabezado().generadoEn()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("partidas se renderizan con código + nombre de cuenta resuelto")
+    void partidas_resuelven_nombre_cuenta() {
+        when(asientoRepo.listarPorRangoFecha(desde, hasta))
+                .thenReturn(List.of(asientoRegistrado));
+
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, true), UUID.randomUUID());
+
+        LibroDiarioResponse.AsientoDiario a = resp.asientos().get(0);
+        assertThat(a.partidas()).hasSize(2);
+        // DEBE
+        assertThat(a.partidas().get(0).codigoCuenta()).isEqualTo("1.1.03");
+        assertThat(a.partidas().get(0).nombreCuenta()).isEqualTo("Bancos Cta Corriente Bs");
+        assertThat(a.partidas().get(0).debe()).isEqualByComparingTo("100.00");
+        // HABER
+        assertThat(a.partidas().get(1).codigoCuenta()).isEqualTo("2.1.01");
+        assertThat(a.partidas().get(1).nombreCuenta()).isEqualTo("Cuentas de Ahorro Bs");
+        assertThat(a.partidas().get(1).haber()).isEqualByComparingTo("100.00");
+    }
+
+    // ─── Anulados ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("incluirAnulados=true → incluye ambos asientos y cuenta los anulados")
+    void incluye_anulados_true() {
+        when(asientoRepo.listarPorRangoFecha(desde, hasta))
+                .thenReturn(List.of(asientoRegistrado, asientoAnulado));
+
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, true), UUID.randomUUID());
+
+        assertThat(resp.asientos()).hasSize(2);
+        assertThat(resp.totales().cantidadAsientos()).isEqualTo(2);
+        assertThat(resp.totales().cantidadAnulados()).isEqualTo(1);
+        assertThat(resp.totales().totalDebe()).isEqualByComparingTo("300.00");
+        assertThat(resp.totales().totalHaber()).isEqualByComparingTo("300.00");
+    }
+
+    @Test
+    @DisplayName("incluirAnulados=false → filtra los ANULADOS")
+    void incluye_anulados_false() {
+        when(asientoRepo.listarPorRangoFecha(desde, hasta))
+                .thenReturn(List.of(asientoRegistrado, asientoAnulado));
+
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, false), UUID.randomUUID());
+
+        assertThat(resp.asientos()).hasSize(1);
+        assertThat(resp.totales().cantidadAnulados()).isZero();
+        assertThat(resp.totales().totalDebe()).isEqualByComparingTo("100.00");
+    }
+
+    @Test
+    @DisplayName("asiento anulado mantiene motivoAnulacion visible")
+    void asiento_anulado_expone_motivo() {
+        when(asientoRepo.listarPorRangoFecha(desde, hasta))
+                .thenReturn(List.of(asientoAnulado));
+
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, true), UUID.randomUUID());
+
+        LibroDiarioResponse.AsientoDiario a = resp.asientos().get(0);
+        assertThat(a.estado()).isEqualTo(EstadoAsiento.ANULADO);
+        assertThat(a.motivoAnulacion()).isEqualTo("Error en monto");
+    }
+
+    // ─── Formato del número correlativo ────────────────────────────────────
+
+    @Test
+    @DisplayName("numeroFormateado usa formato AÑO-NNNNNN")
+    void numero_formateado_anio_y_seis_digitos() {
+        when(asientoRepo.listarPorRangoFecha(desde, hasta))
+                .thenReturn(List.of(asientoRegistrado));
+
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, true), UUID.randomUUID());
+
+        assertThat(resp.asientos().get(0).numeroFormateado()).isEqualTo("2026-000001");
+    }
+
+    // ─── Casos borde ───────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("período sin asientos → response vacío balanceado en cero")
+    void periodo_vacio() {
+        when(asientoRepo.listarPorRangoFecha(desde, hasta)).thenReturn(List.of());
+
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, true), UUID.randomUUID());
+
+        assertThat(resp.asientos()).isEmpty();
+        assertThat(resp.totales().cantidadAsientos()).isZero();
+        assertThat(resp.totales().totalDebe()).isEqualByComparingTo("0");
+        assertThat(resp.totales().totalHaber()).isEqualByComparingTo("0");
+        assertThat(resp.totales().balanceado()).isTrue();  // 0 = 0
+    }
+
+    @Test
+    @DisplayName("cuenta no encontrada en plan → fallback al UUID (no crashea)")
+    void cuenta_faltante_no_rompe() {
+        // Devolver plan vacío para forzar el fallback
+        when(cuentaRepo.listarTodas()).thenReturn(List.of());
+        when(asientoRepo.listarPorRangoFecha(desde, hasta))
+                .thenReturn(List.of(asientoRegistrado));
+
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, true), UUID.randomUUID());
+
+        // El reporte se genera, pero las partidas tienen el nombre fallback
+        LibroDiarioResponse.PartidaDiario p = resp.asientos().get(0).partidas().get(0);
+        assertThat(p.nombreCuenta()).contains("CUENTA DESCONOCIDA");
+        assertThat(p.codigoCuenta()).isEqualTo("???");
+    }
+}

--- a/backend/src/test/java/com/tufondo/contabilidad/infrastructure/pdf/LibroDiarioPdfAdapterTest.java
+++ b/backend/src/test/java/com/tufondo/contabilidad/infrastructure/pdf/LibroDiarioPdfAdapterTest.java
@@ -1,0 +1,218 @@
+package com.tufondo.contabilidad.infrastructure.pdf;
+
+import com.tufondo.contabilidad.application.dto.LibroDiarioResponse;
+import com.tufondo.contabilidad.domain.model.enums.EstadoAsiento;
+import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests del {@link LibroDiarioPdfAdapter}.
+ *
+ * <p>Verifica que el PDF se genera (bytes válidos) sin crashear ante
+ * variaciones: período vacío, asientos anulados, muchas filas, decimales,
+ * desbalance (caso defensivo).</p>
+ */
+class LibroDiarioPdfAdapterTest {
+
+    private final LibroDiarioPdfAdapter adapter = new LibroDiarioPdfAdapter();
+
+    @Test
+    @DisplayName("período vacío genera PDF con cabecera y totales en cero")
+    void pdf_periodo_vacio() {
+        byte[] pdf = adapter.generarLibroDiarioPdf(libroVacio());
+
+        assertThat(pdf).isNotEmpty();
+        assertThat(esPdfValido(pdf)).isTrue();
+        assertThat(pdf.length).isGreaterThan(500); // al menos cabecera + estructura mínima
+    }
+
+    @Test
+    @DisplayName("PDF con 1 asiento normal — bytes válidos y mayor que el vacío")
+    void pdf_un_asiento() {
+        var libro = libroConAsientos(List.of(asientoNormal(1, "2026-000001")));
+        byte[] pdf = adapter.generarLibroDiarioPdf(libro);
+
+        assertThat(esPdfValido(pdf)).isTrue();
+        assertThat(pdf.length).isGreaterThan(1000);
+    }
+
+    @Test
+    @DisplayName("PDF con asiento ANULADO se genera (marca visual no rompe)")
+    void pdf_con_anulado() {
+        var libro = libroConAsientos(List.of(
+                asientoNormal(1, "2026-000001"),
+                asientoAnulado(2, "2026-000002")));
+        byte[] pdf = adapter.generarLibroDiarioPdf(libro);
+
+        assertThat(esPdfValido(pdf)).isTrue();
+    }
+
+    @Test
+    @DisplayName("PDF con muchos asientos (paginación) genera sin OOM")
+    void pdf_muchos_asientos_pagina() {
+        // 50 asientos cada uno con 2 partidas → ~100 filas; debe paginar
+        var asientos = java.util.stream.IntStream.rangeClosed(1, 50)
+                .mapToObj(i -> asientoNormal((long) i, String.format("2026-%06d", i)))
+                .toList();
+        var libro = libroConAsientos(asientos);
+
+        byte[] pdf = adapter.generarLibroDiarioPdf(libro);
+
+        assertThat(esPdfValido(pdf)).isTrue();
+        // PDF con 50 asientos debe ser visiblemente más grande
+        assertThat(pdf.length).isGreaterThan(5000);
+    }
+
+    @Test
+    @DisplayName("PDF con desbalance (caso defensivo) marca visualmente sin crashear")
+    void pdf_desbalance_se_renderiza() {
+        // Simular un desbalance manual en los totales para asegurar que el adapter
+        // no asume balance; solo lo marca visualmente.
+        var enc = encabezado();
+        var asiento = asientoNormal(1, "2026-000001");
+        var totalesDesbalanceados = LibroDiarioResponse.Totales.builder()
+                .cantidadAsientos(1)
+                .cantidadAnulados(0)
+                .totalDebe(new BigDecimal("100.00"))
+                .totalHaber(new BigDecimal("90.00"))  // diferencia
+                .balanceado(false)
+                .build();
+        var libro = LibroDiarioResponse.builder()
+                .encabezado(enc)
+                .asientos(List.of(asiento))
+                .totales(totalesDesbalanceados)
+                .build();
+
+        byte[] pdf = adapter.generarLibroDiarioPdf(libro);
+        assertThat(esPdfValido(pdf)).isTrue();
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────
+
+    /** Verifica que el byte array empiece con "%PDF" — header de PDF. */
+    private boolean esPdfValido(byte[] pdf) {
+        if (pdf == null || pdf.length < 4) return false;
+        return pdf[0] == '%' && pdf[1] == 'P' && pdf[2] == 'D' && pdf[3] == 'F';
+    }
+
+    private LibroDiarioResponse libroVacio() {
+        return LibroDiarioResponse.builder()
+                .encabezado(encabezado())
+                .asientos(List.of())
+                .totales(LibroDiarioResponse.Totales.builder()
+                        .cantidadAsientos(0)
+                        .cantidadAnulados(0)
+                        .totalDebe(BigDecimal.ZERO)
+                        .totalHaber(BigDecimal.ZERO)
+                        .balanceado(true)
+                        .build())
+                .build();
+    }
+
+    private LibroDiarioResponse libroConAsientos(List<LibroDiarioResponse.AsientoDiario> asientos) {
+        BigDecimal totalDebe = asientos.stream()
+                .map(LibroDiarioResponse.AsientoDiario::totalDebe)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal totalHaber = asientos.stream()
+                .map(LibroDiarioResponse.AsientoDiario::totalHaber)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        int anulados = (int) asientos.stream()
+                .filter(a -> a.estado() == EstadoAsiento.ANULADO).count();
+        return LibroDiarioResponse.builder()
+                .encabezado(encabezado())
+                .asientos(asientos)
+                .totales(LibroDiarioResponse.Totales.builder()
+                        .cantidadAsientos(asientos.size())
+                        .cantidadAnulados(anulados)
+                        .totalDebe(totalDebe)
+                        .totalHaber(totalHaber)
+                        .balanceado(totalDebe.compareTo(totalHaber) == 0)
+                        .build())
+                .build();
+    }
+
+    private LibroDiarioResponse.Encabezado encabezado() {
+        return LibroDiarioResponse.Encabezado.builder()
+                .razonSocial("Fatrans Test")
+                .rif("J-12345678-9")
+                .desde(LocalDate.of(2026, 5, 1))
+                .hasta(LocalDate.of(2026, 5, 31))
+                .generadoEn(Instant.now())
+                .generadoPorUsuarioId(UUID.randomUUID())
+                .incluyeAnulados(true)
+                .build();
+    }
+
+    private LibroDiarioResponse.AsientoDiario asientoNormal(long numero, String formateado) {
+        return LibroDiarioResponse.AsientoDiario.builder()
+                .numero(numero)
+                .numeroFormateado(formateado)
+                .fechaContable(LocalDate.of(2026, 5, 10))
+                .origen(OrigenAsiento.AHORRO_DEPOSITO)
+                .estado(EstadoAsiento.REGISTRADO)
+                .glosa("Depósito de prueba " + numero)
+                .referenciaExterna("MOV-" + numero)
+                .motivoAnulacion(null)
+                .totalDebe(new BigDecimal("100.00"))
+                .totalHaber(new BigDecimal("100.00"))
+                .partidas(List.of(
+                        LibroDiarioResponse.PartidaDiario.builder()
+                                .codigoCuenta("1.1.03")
+                                .nombreCuenta("Bancos Cta Corriente Bs")
+                                .debe(new BigDecimal("100.00"))
+                                .haber(BigDecimal.ZERO)
+                                .glosa("Ingreso")
+                                .orden(1)
+                                .build(),
+                        LibroDiarioResponse.PartidaDiario.builder()
+                                .codigoCuenta("2.1.01")
+                                .nombreCuenta("Cuentas de Ahorro Bs")
+                                .debe(BigDecimal.ZERO)
+                                .haber(new BigDecimal("100.00"))
+                                .glosa("Crédito ahorro")
+                                .orden(2)
+                                .build()))
+                .build();
+    }
+
+    private LibroDiarioResponse.AsientoDiario asientoAnulado(long numero, String formateado) {
+        return LibroDiarioResponse.AsientoDiario.builder()
+                .numero(numero)
+                .numeroFormateado(formateado)
+                .fechaContable(LocalDate.of(2026, 5, 12))
+                .origen(OrigenAsiento.AHORRO_RETIRO)
+                .estado(EstadoAsiento.ANULADO)
+                .glosa("Retiro que se anuló")
+                .referenciaExterna("MOV-" + numero)
+                .motivoAnulacion("Error en el monto registrado")
+                .totalDebe(new BigDecimal("250.00"))
+                .totalHaber(new BigDecimal("250.00"))
+                .partidas(List.of(
+                        LibroDiarioResponse.PartidaDiario.builder()
+                                .codigoCuenta("2.1.01")
+                                .nombreCuenta("Cuentas de Ahorro Bs")
+                                .debe(new BigDecimal("250.00"))
+                                .haber(BigDecimal.ZERO)
+                                .glosa("")
+                                .orden(1)
+                                .build(),
+                        LibroDiarioResponse.PartidaDiario.builder()
+                                .codigoCuenta("1.1.03")
+                                .nombreCuenta("Bancos Cta Corriente Bs")
+                                .debe(BigDecimal.ZERO)
+                                .haber(new BigDecimal("250.00"))
+                                .glosa("")
+                                .orden(2)
+                                .build()))
+                .build();
+    }
+}

--- a/docs/modulos/contabilidad/00-overview.md
+++ b/docs/modulos/contabilidad/00-overview.md
@@ -28,11 +28,11 @@ contable de partida doble. Eso significa:
 El EPIC #263 cierra esa brecha desde la base (plan de cuentas) hasta los
 reportes finales.
 
-## Estado actual (2026-05-20, post #268)
+## Estado actual (2026-05-20, post #269)
 
 ```
-Plan de cuentas (#264) ──► Asientos (#265+#266) ──► Hooks Ahorros (#267) ──► Hooks Créditos (#268) ──► Reportes (#269-#271) ──► Cierre (#272+#273)
-       ✅                       ✅                        ✅                        🚧 (PR)                  ⏳                        ⏳
+Plan de cuentas (#264) ──► Asientos (#265+#266) ──► Hooks Ahorros (#267) ──► Hooks Créditos (#268) ──► Libro Diario (#269) ──► Resto reportes (#270-#271) ──► Cierre (#272+#273)
+       ✅                       ✅                        ✅                        ✅                     🚧 PR #317              ⏳                           ⏳
 ```
 
 ## Timeline cronológico de decisiones y entregas
@@ -107,9 +107,9 @@ Este hallazgo desencadenó:
 3. La identificación de varios pendientes regulatorios que documenté en
    [[_pendientes-criticos]].
 
-### 2026-05-20 — #268 Hooks de Créditos (IMPLEMENTADO)
+### 2026-05-20 — #268 Hooks de Créditos (PR #316, MERGED)
 
-**[[04-hooks-creditos|#268 — Hooks Créditos]]** (PR en revisión)
+**[[04-hooks-creditos|#268 — Hooks Créditos]]** (merged)
 
 Mismo patrón que #267 aplicado al módulo Créditos, con mapping previamente
 aprobado por [[_contador-fatrans]] ([[_decisiones-contables#D-003|D-003]] y
@@ -129,11 +129,35 @@ aprobado por [[_contador-fatrans]] ([[_decisiones-contables#D-003|D-003]] y
 - Ejecución de colateral (use case existe pero sin hook)
 - Pago parcial (flujo actual exige completo)
 
-## Lo que viene después de #268
+### 2026-05-20 — #269 Libro Diario (PR #317 — primer reporte SUDECA)
+
+**[[05-libro-diario|#269 — Libro Diario]]** (PR en revisión)
+
+Primer reporte contable exigido por SUDECA: listado secuencial de todos los
+asientos del período. Endpoint `GET /api/v1/contabilidad/libro-diario` (JSON)
+y `/pdf` (descarga). Solo ADMIN/SUPER_ADMIN/SISTEMA por ahora.
+
+**Decisiones tomadas** ([[_decisiones-contables#D-006|D-006]]):
+- Incluir asientos ANULADOS por defecto con marca visual (SUDECA exige auditoría completa, no censura).
+- Correlativo formateado como `AÑO-NNNNNN` visualmente. Reset anual real
+  queda como pendiente P1 antes del primer cierre fiscal.
+- Puerto PDF dedicado al módulo contabilidad (no reutilizar `documentospdf`).
+- Razón social y RIF vía properties configurables en `application.yml`.
+
+**21 tests nuevos, todos verde**:
+- `LibroDiarioFilterTest` (7) — validaciones de rango
+- `GenerarLibroDiarioUseCaseTest` (9) — Mockito
+- `LibroDiarioPdfAdapterTest` (5) — verificación de bytes PDF
+
+**Pendientes abiertos**:
+- Reset anual real del correlativo (P1, antes de cierre fiscal)
+- Crear rol `CONTADOR` dedicado (P2)
+- Firma digital del PDF (sub-issue futuro)
+
+## Lo que viene después de #269
 
 | # | Tema | Comentario |
 |---|---|---|
-| #269 | Libro Diario + PDF SUDECA | Reporte por rango de fechas con totales del período |
 | #270 | Libro Mayor | Saldos acumulados por cuenta a una fecha de corte |
 | #271 | Balance General + Estado de Resultados | Reportes finales VEN-NIF |
 | #272 | Cierre mensual/anual | Bloqueo de período + asientos de cierre |

--- a/docs/modulos/contabilidad/05-libro-diario.md
+++ b/docs/modulos/contabilidad/05-libro-diario.md
@@ -1,0 +1,230 @@
+---
+tags: [contabilidad, reporte, libro-diario, sudeca, ven-nif]
+sub-issue: "#269"
+pr: en-curso
+estado: implementado
+created: 2026-05-20
+---
+
+# 📖 Libro Diario — primer reporte SUDECA
+
+> [!summary] Sub-issue [[Home|#269]] — IMPLEMENTADO
+> Genera el Libro Diario contable: listado secuencial completo de todos los
+> asientos del período por orden de número correlativo. **Primer reporte
+> exigido por SUDECA** para auditoría regulatoria.
+
+## Endpoint
+
+```http
+GET /api/v1/contabilidad/libro-diario
+GET /api/v1/contabilidad/libro-diario/pdf
+```
+
+**Permisos**: solo `ROLE_ADMIN`, `ROLE_SUPER_ADMIN`, `ROLE_SISTEMA`.
+
+> [!note] ROL_CONTADOR pendiente
+> Idealmente este endpoint debería ser accesible también a un `ROLE_CONTADOR`
+> dedicado. El enum `Rol` actual no lo contempla. Ver pendiente "Crear rol
+> CONTADOR" en [[_pendientes-criticos]].
+
+### Query parameters
+
+| Parámetro | Tipo | Default | Descripción |
+|---|---|---|---|
+| `desde` | `LocalDate` (`YYYY-MM-DD`) | **obligatorio** | Inicio del período (inclusive) |
+| `hasta` | `LocalDate` (`YYYY-MM-DD`) | **obligatorio** | Fin del período (inclusive) |
+| `incluirAnulados` | `boolean` | `true` | Si incluir asientos anulados con marca visual ([[_decisiones-contables#D-006\|D-006]]) |
+
+### Validaciones de rango
+
+- `hasta >= desde` — sino `400 Bad Request`
+- `(hasta - desde) ≤ 366 días` — sino `400 Bad Request`. Para reportes más largos, dividir consulta.
+
+## Estructura del response JSON
+
+```json
+{
+  "encabezado": {
+    "razonSocial": "Asociación Fatrans de Ahorro y Crédito",
+    "rif": "J-XXXXXXXX-X",
+    "desde": "2026-05-01",
+    "hasta": "2026-05-31",
+    "generadoEn": "2026-05-20T14:30:00Z",
+    "generadoPorUsuarioId": "...",
+    "incluyeAnulados": true
+  },
+  "asientos": [
+    {
+      "numero": 1,
+      "numeroFormateado": "2026-000001",
+      "fechaContable": "2026-05-01",
+      "origen": "AHORRO_DEPOSITO",
+      "estado": "REGISTRADO",
+      "glosa": "Depósito MOV-... en cuenta AHO-...",
+      "referenciaExterna": "MOV-2026-000001",
+      "motivoAnulacion": null,
+      "totalDebe": "1500.00",
+      "totalHaber": "1500.00",
+      "partidas": [
+        {
+          "codigoCuenta": "1.1.03",
+          "nombreCuenta": "Bancos Cta Corriente Bs",
+          "debe": "1500.00",
+          "haber": "0.00",
+          "glosa": "Ingreso por transferencia del socio",
+          "orden": 1
+        },
+        {
+          "codigoCuenta": "2.1.01",
+          "nombreCuenta": "Cuentas de Ahorro Bs",
+          "debe": "0.00",
+          "haber": "1500.00",
+          "glosa": "Crédito en cuenta de ahorro",
+          "orden": 2
+        }
+      ]
+    }
+  ],
+  "totales": {
+    "cantidadAsientos": 1,
+    "cantidadAnulados": 0,
+    "totalDebe": "1500.00",
+    "totalHaber": "1500.00",
+    "balanceado": true
+  }
+}
+```
+
+## Formato del PDF
+
+- **Tamaño**: A4 horizontal (paisaje) — para acomodar 7 columnas legibles.
+- **Cabecera**: razón social + RIF + título "LIBRO DIARIO" + período + fecha generación.
+- **Tabla**: columnas `Fecha | Nº Asiento | Origen | Código | Cuenta | Glosa | Debe | Haber`.
+- **Asientos**: fila "agrupadora" con datos de cabecera (fecha, número, origen, glosa) en gris claro, seguida de N filas con cada partida.
+- **Asientos ANULADOS**: fondo rojo claro + texto rojo + tag `[ANULADO]` + motivo.
+- **Totales**: al pie del documento — cantidad, total DEBE, total HABER, indicador BALANCEADO ✓ / ⚠ DESBALANCEADO.
+- **Folio**: `Página N` al pie de cada página (event handler PdfWriter).
+
+## Decisiones de diseño tomadas
+
+### Asientos anulados se incluyen por defecto ([[_decisiones-contables#D-006|D-006]])
+
+SUDECA exige el libro **completo** — la inmutabilidad legal aplica a TODO lo
+registrado, no solo a lo activo. Los anulados se muestran con marca visual
+(fondo rojo, tag `[ANULADO]`, motivo). El parámetro `incluirAnulados=false`
+permite ocultarlos solo si se necesita una vista limpia para fines internos.
+
+### Formato del número correlativo: `AÑO-NNNNNN`
+
+El `numeroFormateado` se construye como `{año de fechaContable}-{numero a 6 dígitos}` (ej. `"2026-000001"`). Esto presenta el número de forma "anual" sin
+requerir cambio del modelo de BD.
+
+> [!warning] Pendiente regulatorio
+> La SEQUENCE BD (`seq_asiento_numero`) actualmente NO se resetea por año
+> fiscal. SUDECA exige reset anual real. Para esta iteración solo formateamos
+> visualmente. **Antes del primer cierre fiscal serio** hay que implementar
+> el reset real — ver [[_pendientes-criticos#Reset-anual-del-correlativo-de-asientos|P1]].
+
+### Properties configurables para identidad de la entidad
+
+Razón social y RIF se configuran vía `application.yml`:
+
+```yaml
+entidad:
+  razonSocial: "Asociación Fatrans de Ahorro y Crédito"
+  rif: "J-XXXXXXXX-X"
+  direccion: "..."
+  sigla: "FATRANS"
+```
+
+Defaults documentan que es necesario configurar (`"(configurar)"`). Si en el
+futuro se necesita UI de admin para editarlos, sub-issue dedicado migra a
+`parametros_sistema` en BD.
+
+### Puerto PDF dedicado al módulo contabilidad
+
+Se creó `ContabilidadPdfPort` propio del módulo en lugar de reutilizar el
+`PdfGeneratorPort` de `documentospdf`. Razón:
+
+- `PdfGeneratorPort` está acoplado a `TipoDocumento` enum del otro módulo (acoplaría módulos).
+- Los reportes contables tienen contrato distinto (DTO tipado vs `Map<String, Object>`).
+- Misma librería (OpenPDF) puede compartirse — solo el contrato es separado.
+
+## Arquitectura (3 capas)
+
+```
+LibroDiarioController (api/controller)
+        │
+        │ GET /api/v1/contabilidad/libro-diario[?...formato=PDF]
+        ▼
+GenerarLibroDiarioUseCase (application/usecase)
+        │   - valida filtro vía LibroDiarioFilter
+        │   - lookup asientos vía AsientoContableRepository.listarPorRangoFecha
+        │   - lookup nombres de cuenta vía CuentaContableRepository.listarTodas
+        │   - construye LibroDiarioResponse con totales
+        ▼ (si pidieron PDF)
+ContabilidadPdfPort (application/port/output)
+        │
+        ▼
+LibroDiarioPdfAdapter (infrastructure/pdf — OpenPDF)
+```
+
+## Tests (21 nuevos, todos verde)
+
+| Test class | Casos | Estrategia |
+|---|---|---|
+| `LibroDiarioFilterTest` | 7 | Validaciones de rango (≤ 1 año, hasta ≥ desde, null check) |
+| `GenerarLibroDiarioUseCaseTest` | 9 | Mockito — happy path, encabezado, partidas resueltas, anulados con/sin, período vacío, cuenta faltante (fallback), formato del número |
+| `LibroDiarioPdfAdapterTest` | 5 | Verificación de bytes PDF (header `%PDF`), períodos vacíos / con asientos / con anulados / con muchas filas (paginación) / desbalance defensivo |
+
+### Casos cubiertos
+
+> [!check] Garantías
+> - ✅ Rango ≤ 1 año fiscal (366 días). Rangos mayores rechazados.
+> - ✅ `hasta < desde` rechazado.
+> - ✅ Encabezado completo (razón social, RIF, período, auditoría).
+> - ✅ Partidas resuelven nombre de cuenta vía lookup (1 query, indexado en memoria).
+> - ✅ Asientos anulados con marca visual + motivo de anulación visible.
+> - ✅ `incluirAnulados=false` filtra los ANULADOS.
+> - ✅ Período sin asientos: response vacío balanceado en cero (no rompe).
+> - ✅ Cuenta no encontrada en plan: fallback a UUID + nombre genérico (no rompe).
+> - ✅ Totales del período son la suma exacta de cada asiento.
+> - ✅ PDF se genera con bytes válidos `%PDF`, escala a 50+ asientos sin OOM.
+> - ✅ PDF marca visualmente desbalances (caso defensivo, no debería ocurrir).
+
+## Pendientes intencionalmente fuera de scope
+
+- ⏳ **Reset anual real del correlativo** ([[_pendientes-criticos#Reset-anual-del-correlativo-de-asientos|P1]]) — actualmente solo formateamos visualmente, BD usa SEQUENCE continua.
+- ⏳ **Firma digital del PDF** — SUDECA exige firma del contador y representante legal en formato impreso. Versión digital con FEA queda como sub-issue dedicado.
+- ⏳ **Rol `CONTADOR` dedicado** — actualmente solo admins acceden. Sub-issue para agregar al enum `Rol`.
+- ⏳ **Razón social en BD** — actualmente properties. Si se necesita UI de admin, migrar a `parametros_sistema`.
+
+## Cómo usar
+
+### Desde un cliente HTTP (admin autenticado)
+
+```bash
+# JSON
+curl -X GET \
+  -H "Authorization: Bearer $JWT" \
+  "https://qa-api.fatrans.com.ve/api/v1/contabilidad/libro-diario?desde=2026-05-01&hasta=2026-05-31"
+
+# PDF
+curl -X GET \
+  -H "Authorization: Bearer $JWT" \
+  -o LibroDiario_Mayo2026.pdf \
+  "https://qa-api.fatrans.com.ve/api/v1/contabilidad/libro-diario/pdf?desde=2026-05-01&hasta=2026-05-31"
+```
+
+### Desde el frontend admin (cuando se construya)
+
+El frontend de admin puede:
+1. Mostrar tabla con los asientos del JSON, paginada client-side.
+2. Botón "Descargar PDF" que invoca el endpoint `/pdf` con los mismos filtros.
+
+## Referencias
+
+- Issue: [[Home|#269]]
+- Decisión: [[_decisiones-contables#D-006|D-006 — incluir anulados, formato anual del correlativo]]
+- Dependencias: [[01-plan-cuentas|#264]], [[02-asientos-contables|#265+#266]]
+- Próximo: [[06-libro-mayor]] (#270) — saldos acumulados por cuenta

--- a/docs/modulos/contabilidad/Home.md
+++ b/docs/modulos/contabilidad/Home.md
@@ -28,7 +28,8 @@ estado: en-construccion
 - 📋 [[01-plan-cuentas]] — #264 — Plan de cuentas VEN-NIF (V21, ~55 cuentas)
 - 🧾 [[02-asientos-contables]] — #265 + #266 — Tablas + dominio + service partida doble
 - 🔌 [[03-hooks-ahorros]] — #267 — Hooks Ahorros: depósito/retiro → asiento auto
-- 🔌 [[04-hooks-creditos]] — #268 — Hooks Créditos: desembolso/cobro → asiento auto (en diseño)
+- 🔌 [[04-hooks-creditos]] — #268 — Hooks Créditos: desembolso/cobro → asiento auto
+- 📖 [[05-libro-diario]] — #269 — Reporte Libro Diario JSON + PDF SUDECA
 
 ## Mapa del módulo (código)
 
@@ -67,8 +68,8 @@ backend/src/main/java/com/tufondo/ahorros/
 | [[01-plan-cuentas\|#264]] | ✅ Merged (PR #313) | Plan de cuentas VEN-NIF (V21) — ~55 cuentas seed | [[_decisiones-contables#D-001\|D-001]] V21 congelado |
 | [[02-asientos-contables\|#265 + #266]] | ✅ Merged (PR #314) | Tablas + dominio + service + 50+ tests | Asientos inmutables, ON DELETE RESTRICT |
 | [[03-hooks-ahorros\|#267]] | ✅ Merged (PR #315) | Hooks de Ahorros: depósito/retiro → asiento auto | [[_decisiones-contables#D-002\|D-002]] usar `1.1.03` no `1.1.01` |
-| [[04-hooks-creditos\|#268]] | 🚧 En PR | Hooks de Créditos: desembolso + pago cuota → asiento auto | [[_decisiones-contables#D-003\|D-003]] [[_decisiones-contables#D-004\|D-004]] |
-| #269 | ⏳ Pending | Libro Diario + export PDF SUDECA | |
+| [[04-hooks-creditos\|#268]] | ✅ Merged (PR #316) | Hooks de Créditos: desembolso/cobro → asiento auto | [[_decisiones-contables#D-003\|D-003]] [[_decisiones-contables#D-004\|D-004]] |
+| [[05-libro-diario\|#269]] | 🚧 PR #317 abierto | Libro Diario JSON + PDF SUDECA | [[_decisiones-contables#D-006\|D-006]] incluir anulados |
 | #270 | ⏳ Pending | Libro Mayor (saldos por cuenta) | |
 | #271 | ⏳ Pending | Balance General + Estado de Resultados | |
 | #272 | ⏳ Pending | Cierre mensual / anual con bloqueo de período | |

--- a/docs/modulos/contabilidad/_decisiones-contables.md
+++ b/docs/modulos/contabilidad/_decisiones-contables.md
@@ -237,6 +237,50 @@ HABER 4.1.05 Comisiones Otras (cuenta a crear)
 
 ---
 
+## D-006 — Libro Diario incluye anulados por defecto + formato visual anual del correlativo
+
+**Fecha:** 2026-05-20
+**Sub-issue:** [[05-libro-diario|#269]]
+**Estado:** ✅ Aprobada e implementada
+**Revisor:** [[_contador-fatrans|contador-fatrans]] (rol asumido en sesión, archivo activo)
+
+### Contexto
+Al diseñar el Libro Diario surgieron dos preguntas:
+1. ¿Incluir asientos ANULADOS o solo REGISTRADOS?
+2. ¿El correlativo debe resetearse anualmente como exige SUDECA?
+
+### Decisión
+
+**1. Incluir ANULADOS por defecto, con marca visual.**
+
+El parámetro `incluirAnulados` default es `true`. Los anulados aparecen con
+fondo rojo claro, texto rojo, tag `[ANULADO]` y motivo visible.
+
+**Razón regulatoria**: SUDECA exige auditoría completa. La inmutabilidad legal
+aplica a TODO lo registrado, no solo a lo activo. Censurar anulados del Libro
+Diario sería hallazgo de auditoría.
+
+**2. Formato anual visual del correlativo (sin cambiar BD por ahora).**
+
+El campo `numeroFormateado` muestra el número como `AÑO-NNNNNN` (ej. `2026-000001`),
+construido como `{año de fechaContable}-{numero a 6 dígitos}`. La SEQUENCE
+BD `seq_asiento_numero` sigue corriendo continua.
+
+**Razón temporal**: cambiar la SEQUENCE para reset anual requiere migration
++ posiblemente cambio del modelo `AsientoContable` (agregar campo `año_fiscal`).
+Es trabajo no trivial. Para esta iteración, formateamos visualmente como
+quick win. Bloqueante real: antes del primer cierre fiscal serio.
+
+### Consecuencias
+
+- Endpoint `GET /libro-diario?incluirAnulados=true|false` permite a admin
+  toggear si necesita vista limpia.
+- PDF marca visualmente los anulados.
+- **Pendiente P1 abierto**: "Reset anual del correlativo de asientos" en
+  [[_pendientes-criticos]]. Sub-issue dedicado antes del primer cierre.
+
+---
+
 ## D-005 — (PENDIENTE) Criterio de caja vs devengo para intereses de cartera
 
 **Fecha:** 2026-05-20

--- a/docs/modulos/contabilidad/_pendientes-criticos.md
+++ b/docs/modulos/contabilidad/_pendientes-criticos.md
@@ -98,6 +98,57 @@ HABER 2.1.01 Cuentas de Ahorro Bs (o el destino real del pago)
 - [ ] Implementar `DevengarInteresesAhorrosJob`.
 - [ ] Cuando #267 madure: hook `OrigenAsiento.AHORRO_INTERES` para el pago.
 
+### Reset anual del correlativo de asientos
+**Decisión origen:** [[_decisiones-contables#D-006|D-006]]
+**Sub-issue:** sin asignar — abrir antes del primer cierre fiscal
+**Prioridad:** P1 (bloqueante antes del primer cierre)
+
+SUDECA exige que el correlativo del Libro Diario se reinicie en 1 al inicio
+de cada año fiscal. Actualmente la SEQUENCE `seq_asiento_numero` corre
+continua desde siempre y nunca se resetea.
+
+El sub-issue **#269** parchó esto visualmente formateando el número como
+`AÑO-NNNNNN` (ej. `2026-000123` aunque internamente el número sea `47891`).
+Esto es aceptable para mostrar reportes pero NO para auditoría formal.
+
+**Implementación correcta**:
+
+**Opción A — Cambiar el modelo**: agregar campo `año_fiscal` y `numero_anual`
+a `asientos_contables`. SEQUENCE separada por año o lógica de aplicación
+para asignar el siguiente número del año en curso.
+
+**Opción B — Reset físico de SEQUENCE**: job al inicio de cada año fiscal:
+```sql
+ALTER SEQUENCE seq_asiento_numero RESTART WITH 1;
+```
+Combinado con un campo `numero_anual` que se inserta en el asiento.
+
+**Tareas**:
+- [ ] Decidir opción A vs B con contador colegiado.
+- [ ] Migration nueva (V23+) con el cambio.
+- [ ] Modificar `AsientoContableRepositoryImpl` para usar el nuevo correlativo.
+- [ ] Actualizar `GenerarLibroDiarioUseCase.formatearNumero()` para usar el
+  campo persistido en lugar del cálculo visual.
+- [ ] Job `@Scheduled` que ejecute el reset el 1 de enero a las 00:00 UTC-4.
+
+### Crear rol CONTADOR dedicado
+**Sub-issue:** sin asignar
+**Prioridad:** P2 (mejora de control de acceso)
+
+El enum `Rol` actual tiene `SOCIO, ADMIN, SUPER_ADMIN, CAJERO, ANALISTA_KYC,
+ANALISTA_CREDITO, SISTEMA`. Falta `CONTADOR` dedicado.
+
+Hoy los endpoints contables (`/libro-diario`, futuros `/libro-mayor`,
+`/balance-general`) usan `ADMIN/SUPER_ADMIN/SISTEMA`. Ideal: `CONTADOR`
+puede leer reportes pero NO ejecutar operaciones operativas como crear
+socios, modificar tasas, etc.
+
+**Tareas**:
+- [ ] Agregar `CONTADOR` al enum `Rol`.
+- [ ] Definir permisos en `SecurityConfig` (lectura contable + asientos manuales).
+- [ ] Actualizar `@PreAuthorize` de controllers contables.
+- [ ] UI admin: pantalla para asignar rol CONTADOR.
+
 ### Provisión de cartera de créditos
 **Prioridad:** P1
 


### PR DESCRIPTION
## Resumen

Sub-issue **#269** del EPIC Contabilidad **#263**. **Primer reporte contable** exigido por SUDECA: listado secuencial de todos los asientos del período por orden de número correlativo.

## Endpoints

```http
GET /api/v1/contabilidad/libro-diario          (JSON)
GET /api/v1/contabilidad/libro-diario/pdf      (descarga A4 horizontal)
```

**Query params**: `desde` (obligatorio), `hasta` (obligatorio, ≤ 1 año fiscal), `incluirAnulados` (default `true`).

**Permisos**: `ROLE_ADMIN`, `ROLE_SUPER_ADMIN`, `ROLE_SISTEMA`. Falta crear rol `CONTADOR` dedicado — pendiente P2 documentado.

## Decisiones tomadas (D-006)

| # | Decisión | Razón |
|---|---|---|
| 1 | Asientos ANULADOS se incluyen por defecto con marca visual | SUDECA exige auditoría completa, no censura. La inmutabilidad legal aplica a TODO lo registrado. |
| 2 | Correlativo formateado como `AÑO-NNNNNN` visualmente (ej. `2026-000001`) | SEQUENCE BD sigue continua. Reset anual real queda como pendiente P1 antes del primer cierre fiscal. |
| 3 | Puerto PDF dedicado `ContabilidadPdfPort` (no reutilizar `documentospdf`) | Separación de responsabilidades; los reportes contables tienen contrato distinto. Misma librería OpenPDF. |
| 4 | Razón social y RIF vía `application.yml` (no en BD) | Properties son configurables sin migration y suficiente para arrancar. Migrar a `parametros_sistema` con UI admin es sub-issue futuro. |

## Arquitectura (hexagonal)

```
LibroDiarioController (api/controller)
        │
        │ GET /libro-diario[?desde=&hasta=&incluirAnulados=]
        ▼
GenerarLibroDiarioUseCase (application/usecase)
        │   - valida filtro vía LibroDiarioFilter (rango ≤ 1 año)
        │   - listarPorRangoFecha (asientos)
        │   - listarTodas (plan de cuentas → index UUID→nombre)
        │   - calcula totales
        ▼ (si pidió PDF)
ContabilidadPdfPort (port output dedicado)
        │
        ▼
LibroDiarioPdfAdapter (OpenPDF, A4 horizontal)
```

## PDF features

- **A4 horizontal** para 7 columnas legibles.
- **Cabecera**: razón social + RIF + "LIBRO DIARIO" + período + fecha generación.
- **Tabla**: `Fecha | Nº Asiento | Origen | Código | Cuenta | Glosa | Debe | Haber`.
- **Fila agrupadora** por asiento (fondo gris claro con datos cabecera) seguida de N filas con cada partida.
- **ANULADOS** marcados visualmente: fondo rojo claro, texto rojo, tag `[ANULADO]`, motivo visible.
- **Totales** al pie con indicador `BALANCEADO ✓` / `⚠ DESBALANCEADO`.
- **Folio "Página N"** en cada página vía `PdfPageEventHelper`.

## Tests reales — 21 nuevos, todos verde

Corridos en Docker (`maven:3.9-eclipse-temurin-21`) con BD H2 modo Postgres:

| Test class | Casos | Tipo |
|---|---|---|
| `LibroDiarioFilterTest` | 7 | Unit — validaciones de rango |
| `GenerarLibroDiarioUseCaseTest` | 9 | Mockito — happy path + casos borde |
| `LibroDiarioPdfAdapterTest` | 5 | Verificación de bytes PDF (`%PDF` header), escalado, casos defensivos |

**Suite completa backend: 576 tests / 0 failures / 0 errors** ✅
(555 previos + 21 nuevos de #269 — #268 todavía no está en develop)

### Casos cubiertos

- ✅ Rango ≤ 1 año fiscal (366 días). Rangos mayores rechazados con mensaje claro.
- ✅ `hasta < desde` rechazado.
- ✅ Período vacío genera response balanceado en cero (no rompe).
- ✅ Encabezado completo con razón social, RIF, período, ID solicitante.
- ✅ Partidas resuelven nombre de cuenta vía lookup (1 query, indexado en memoria).
- ✅ Asientos ANULADOS con motivo de anulación visible.
- ✅ `incluirAnulados=false` filtra correctamente los ANULADOS.
- ✅ Formato del correlativo `AÑO-NNNNNN` (ej. `2026-000001`).
- ✅ Cuenta no encontrada en plan: fallback a UUID + nombre genérico (no crashea).
- ✅ Totales del período son la suma exacta de cada asiento.
- ✅ PDF genera bytes válidos `%PDF`.
- ✅ PDF escala a 50+ asientos sin OOM.
- ✅ PDF marca visualmente desbalances (caso defensivo, no debería ocurrir).

## Documentación (vault Obsidian)

Actualizado `docs/modulos/contabilidad/`:
- [`05-libro-diario.md`](https://github.com/gamijoam/fatrans/blob/feat/contab-libro-diario-269/docs/modulos/contabilidad/05-libro-diario.md) (nuevo) — referencia completa del reporte
- [`Home.md`](https://github.com/gamijoam/fatrans/blob/feat/contab-libro-diario-269/docs/modulos/contabilidad/Home.md) — actualiza estado #269
- [`00-overview.md`](https://github.com/gamijoam/fatrans/blob/feat/contab-libro-diario-269/docs/modulos/contabilidad/00-overview.md) — timeline + decisiones
- [`_decisiones-contables.md`](https://github.com/gamijoam/fatrans/blob/feat/contab-libro-diario-269/docs/modulos/contabilidad/_decisiones-contables.md) — D-006 nuevo
- [`_pendientes-criticos.md`](https://github.com/gamijoam/fatrans/blob/feat/contab-libro-diario-269/docs/modulos/contabilidad/_pendientes-criticos.md) — 2 pendientes nuevos

## Configuración necesaria post-merge

Agregar en `application.yml` (o variables de entorno equivalentes):

```yaml
entidad:
  razonSocial: "Asociación Fatrans de Ahorro y Crédito"
  rif: "J-XXXXXXXX-X"  # ← reemplazar por el RIF real
  direccion: "..."
  sigla: "FATRANS"
```

Si NO se configura, los reportes aparecerán con `"(configurar)"` como placeholder explícito.

## Pendientes fuera de scope (documentados)

- ⏳ **Reset anual real del correlativo** ([[_pendientes-criticos|P1]]) — actualmente solo formato visual, BD usa SEQUENCE continua. Bloqueante antes del primer cierre fiscal serio.
- ⏳ **Rol `CONTADOR` dedicado** ([[_pendientes-criticos|P2]]) — actualmente solo admins acceden a reportes contables.
- ⏳ **Firma digital del PDF** — SUDECA exige firma del contador y representante legal en formato impreso. Sub-issue dedicado.
- ⏳ **Razón social en BD** — actualmente properties. Si se necesita UI admin para editarlas, sub-issue dedicado.

## Test plan (post-merge en QA)

- [ ] Configurar `entidad.razonSocial` y `entidad.rif` en QA con valores reales.
- [ ] Generar Libro Diario JSON del mes en curso → verificar encabezado, estructura y totales.
- [ ] Descargar PDF → abrir en visor → verificar tabla legible, asientos agrupados, totales.
- [ ] Probar con período vacío → response balanceado en cero, PDF mínimo.
- [ ] Probar con rango > 1 año → debe rechazar con 400.
- [ ] Generar después de anular algún asiento → verificar marca visual `[ANULADO]` + motivo.
- [ ] Probar acceso con usuario SOCIO → debe rechazar 403.