### PR TITLE
feat(contab #270): Libro Mayor JSON + PDF — saldos y movimientos por cuenta

### DIFF
--- a/backend/src/main/java/com/tufondo/FondoApplication.java
+++ b/backend/src/main/java/com/tufondo/FondoApplication.java
@@ -1,13 +1,14 @@
 package com.tufondo;
 
 import com.tufondo.auth.infrastructure.configuration.JwtProperties;
+import com.tufondo.contabilidad.application.config.EntidadProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({JwtProperties.class, EntidadProperties.class})
 @EnableScheduling  // Issue #231: necesario para BcvScraperJob
 public class FondoApplication {
 

--- a/backend/src/main/java/com/tufondo/contabilidad/api/controller/LibroDiarioController.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/api/controller/LibroDiarioController.java
@@ -1,0 +1,116 @@
+package com.tufondo.contabilidad.api.controller;
+
+import com.tufondo.contabilidad.application.dto.LibroDiarioFilter;
+import com.tufondo.contabilidad.application.dto.LibroDiarioResponse;
+import com.tufondo.contabilidad.application.port.output.ContabilidadPdfPort;
+import com.tufondo.contabilidad.application.usecase.GenerarLibroDiarioUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+/**
+ * Controller del Libro Diario (sub-issue #269).
+ *
+ * <p>Expone GET con dos formatos:</p>
+ * <ul>
+ *   <li>{@code .../libro-diario} — JSON estructurado (default)</li>
+ *   <li>{@code .../libro-diario/pdf} — PDF descargable</li>
+ * </ul>
+ *
+ * <p>Solo accesible para roles ADMIN / SUPER_ADMIN / SISTEMA. Ideal sería
+ * un rol CONTADOR dedicado — ver pendiente "Crear rol CONTADOR" en
+ * {@code docs/modulos/contabilidad/_pendientes-criticos.md}.</p>
+ */
+@RestController
+@RequestMapping("/api/v1/contabilidad/libro-diario")
+@RequiredArgsConstructor
+@Tag(name = "Contabilidad - Libro Diario",
+        description = "Reporte SUDECA con todos los asientos del período")
+public class LibroDiarioController {
+
+    private final GenerarLibroDiarioUseCase useCase;
+    private final ContabilidadPdfPort pdfPort;
+
+    /**
+     * Libro Diario en JSON.
+     *
+     * <p>Devuelve la estructura completa con encabezado, asientos y totales.
+     * El frontend admin puede mostrar la tabla o re-descargar como PDF.</p>
+     */
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN','SUPER_ADMIN','SISTEMA')")
+    @Operation(summary = "Genera el Libro Diario en JSON",
+            description = "Solo ADMIN/SUPER_ADMIN/SISTEMA. Rango ≤ 1 año fiscal.")
+    public ResponseEntity<LibroDiarioResponse> generar(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate desde,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hasta,
+            @RequestParam(defaultValue = "true") boolean incluirAnulados,
+            Authentication authentication) {
+
+        UUID solicitanteId = extraerUsuarioId(authentication);
+        LibroDiarioFilter filter = new LibroDiarioFilter(desde, hasta, incluirAnulados);
+        LibroDiarioResponse response = useCase.ejecutar(filter, solicitanteId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Libro Diario en PDF. Mismo contenido que el endpoint JSON pero renderizado
+     * para impresión / archivo.
+     */
+    @GetMapping("/pdf")
+    @PreAuthorize("hasAnyRole('ADMIN','SUPER_ADMIN','SISTEMA')")
+    @Operation(summary = "Genera el Libro Diario en PDF para descarga",
+            description = "Mismo dataset que JSON, formateado tabular SUDECA.")
+    public ResponseEntity<byte[]> generarPdf(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate desde,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hasta,
+            @RequestParam(defaultValue = "true") boolean incluirAnulados,
+            Authentication authentication) {
+
+        UUID solicitanteId = extraerUsuarioId(authentication);
+        LibroDiarioFilter filter = new LibroDiarioFilter(desde, hasta, incluirAnulados);
+        LibroDiarioResponse data = useCase.ejecutar(filter, solicitanteId);
+        byte[] pdf = pdfPort.generarLibroDiarioPdf(data);
+
+        String filename = String.format("LibroDiario_%s_a_%s.pdf",
+                desde.format(DateTimeFormatter.BASIC_ISO_DATE),
+                hasta.format(DateTimeFormatter.BASIC_ISO_DATE));
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_PDF_VALUE)
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"" + filename + "\"")
+                .header(HttpHeaders.CACHE_CONTROL,
+                        "no-store, no-cache, must-revalidate, private")
+                .body(pdf);
+    }
+
+    /** Helper: extrae socioId o usuarioId del token JWT. */
+    private UUID extraerUsuarioId(Authentication authentication) {
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof com.tufondo.auth.infrastructure.security.AuthenticatedUser authUser) {
+            UUID socioId = authUser.getSocioId();
+            if (socioId != null) return socioId;
+        }
+        try {
+            return UUID.fromString(authentication.getName());
+        } catch (IllegalArgumentException e) {
+            return null; // usuarios admin sin UUID en name — auditoría queda con null
+        }
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/api/controller/LibroMayorController.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/api/controller/LibroMayorController.java
@@ -1,0 +1,109 @@
+package com.tufondo.contabilidad.api.controller;
+
+import com.tufondo.contabilidad.application.dto.LibroMayorFilter;
+import com.tufondo.contabilidad.application.dto.LibroMayorResponse;
+import com.tufondo.contabilidad.application.port.output.ContabilidadPdfPort;
+import com.tufondo.contabilidad.application.usecase.GenerarLibroMayorUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+/**
+ * Controller del Libro Mayor (sub-issue #270).
+ *
+ * <p>Endpoints:</p>
+ * <ul>
+ *   <li>{@code GET /api/v1/contabilidad/libro-mayor}     — JSON</li>
+ *   <li>{@code GET /api/v1/contabilidad/libro-mayor/pdf} — descarga A4 horizontal</li>
+ * </ul>
+ *
+ * <p>Solo {@code ROLE_ADMIN / SUPER_ADMIN / SISTEMA}. Falta agregar rol
+ * {@code CONTADOR} dedicado — ver {@code _pendientes-criticos.md}.</p>
+ */
+@RestController
+@RequestMapping("/api/v1/contabilidad/libro-mayor")
+@RequiredArgsConstructor
+@Tag(name = "Contabilidad - Libro Mayor",
+        description = "Reporte SUDECA con saldos y movimientos por cuenta")
+public class LibroMayorController {
+
+    private final GenerarLibroMayorUseCase useCase;
+    private final ContabilidadPdfPort pdfPort;
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN','SUPER_ADMIN','SISTEMA')")
+    @Operation(summary = "Genera el Libro Mayor en JSON",
+            description = "Rango ≤ 1 año fiscal. Filtros opcionales: cuenta específica, incluir sin movimientos, incluir totalizadoras.")
+    public ResponseEntity<LibroMayorResponse> generar(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate desde,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hasta,
+            @RequestParam(required = false) String codigoCuenta,
+            @RequestParam(defaultValue = "false") boolean incluirSinMovimientos,
+            @RequestParam(defaultValue = "false") boolean incluirTotalizadoras,
+            Authentication authentication) {
+
+        UUID solicitanteId = extraerUsuarioId(authentication);
+        LibroMayorFilter filter = new LibroMayorFilter(
+                desde, hasta, codigoCuenta, incluirSinMovimientos, incluirTotalizadoras);
+        LibroMayorResponse response = useCase.ejecutar(filter, solicitanteId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/pdf")
+    @PreAuthorize("hasAnyRole('ADMIN','SUPER_ADMIN','SISTEMA')")
+    @Operation(summary = "Genera el Libro Mayor en PDF para descarga")
+    public ResponseEntity<byte[]> generarPdf(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate desde,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hasta,
+            @RequestParam(required = false) String codigoCuenta,
+            @RequestParam(defaultValue = "false") boolean incluirSinMovimientos,
+            @RequestParam(defaultValue = "false") boolean incluirTotalizadoras,
+            Authentication authentication) {
+
+        UUID solicitanteId = extraerUsuarioId(authentication);
+        LibroMayorFilter filter = new LibroMayorFilter(
+                desde, hasta, codigoCuenta, incluirSinMovimientos, incluirTotalizadoras);
+        LibroMayorResponse data = useCase.ejecutar(filter, solicitanteId);
+        byte[] pdf = pdfPort.generarLibroMayorPdf(data);
+
+        String filename = String.format("LibroMayor_%s_a_%s%s.pdf",
+                desde.format(DateTimeFormatter.BASIC_ISO_DATE),
+                hasta.format(DateTimeFormatter.BASIC_ISO_DATE),
+                codigoCuenta != null && !codigoCuenta.isBlank() ? "_" + codigoCuenta : "");
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_PDF_VALUE)
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"" + filename + "\"")
+                .header(HttpHeaders.CACHE_CONTROL,
+                        "no-store, no-cache, must-revalidate, private")
+                .body(pdf);
+    }
+
+    private UUID extraerUsuarioId(Authentication authentication) {
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof com.tufondo.auth.infrastructure.security.AuthenticatedUser authUser) {
+            UUID socioId = authUser.getSocioId();
+            if (socioId != null) return socioId;
+        }
+        try {
+            return UUID.fromString(authentication.getName());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/config/EntidadProperties.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/config/EntidadProperties.java
@@ -1,0 +1,42 @@
+package com.tufondo.contabilidad.application.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Properties identificatorias de la entidad (sub-issue #269).
+ *
+ * <p>Razón social, RIF, dirección — datos que aparecen en cabecera de los
+ * reportes contables formales (Libro Diario, Libro Mayor, Balance General).
+ * Se configuran vía {@code application.yml}:</p>
+ *
+ * <pre>
+ * entidad:
+ *   razonSocial: "Asociación Fatrans de Ahorro y Crédito"
+ *   rif: "J-XXXXXXX-X"
+ *   direccion: "..."
+ * </pre>
+ *
+ * <p><strong>Por qué properties y no parámetros en BD</strong>: los reportes
+ * SUDECA exigen cabeceras de identificación fiscal que cambian rara vez
+ * (cuando cambia el RIF o la razón social, lo cual implica trámites legales).
+ * Properties son configurables sin migration y suficiente para arrancar.
+ * Si en el futuro se necesita una UI de admin para editarlos, sub-issue
+ * dedicado migra a {@code parametros_sistema}.</p>
+ */
+@Data
+@ConfigurationProperties(prefix = "entidad")
+public class EntidadProperties {
+
+    /** Razón social completa que aparece en cabeceras de reportes. */
+    private String razonSocial = "Asociación Fatrans de Ahorro y Crédito (configurar)";
+
+    /** RIF venezolano formato J-XXXXXXX-X. */
+    private String rif = "J-XXXXXXXX-X (configurar)";
+
+    /** Dirección física, opcional. */
+    private String direccion = "";
+
+    /** Sigla corta, opcional. */
+    private String sigla = "FATRANS";
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/dto/LibroDiarioFilter.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/dto/LibroDiarioFilter.java
@@ -1,0 +1,48 @@
+package com.tufondo.contabilidad.application.dto;
+
+import java.time.LocalDate;
+
+/**
+ * Filtros para la generación del Libro Diario (sub-issue #269).
+ *
+ * <p>El rango {@code desde-hasta} es obligatorio y debe ser ≤ 1 año fiscal
+ * para evitar reportes gigantes que comprometan memoria/timeout. SUDECA
+ * típicamente exige el Libro Diario mensual o anual — pedirlo por décadas
+ * no tiene sentido operativo.</p>
+ *
+ * @param desde            inicio del período (inclusive)
+ * @param hasta            fin del período (inclusive)
+ * @param incluirAnulados  si {@code true} (default), incluye asientos
+ *                         ANULADOS marcados visualmente. Si {@code false},
+ *                         solo REGISTRADOS. SUDECA exige normalmente el
+ *                         "todo" con la marca, no la exclusión.
+ */
+public record LibroDiarioFilter(
+        LocalDate desde,
+        LocalDate hasta,
+        boolean incluirAnulados
+) {
+    public static final int RANGO_MAX_DIAS = 366; // 1 año bisiesto
+
+    /** Constructor con defaults. */
+    public LibroDiarioFilter {
+        if (desde == null || hasta == null) {
+            throw new IllegalArgumentException("desde y hasta son obligatorios");
+        }
+        if (hasta.isBefore(desde)) {
+            throw new IllegalArgumentException("hasta no puede ser anterior a desde");
+        }
+        long dias = java.time.temporal.ChronoUnit.DAYS.between(desde, hasta);
+        if (dias > RANGO_MAX_DIAS) {
+            throw new IllegalArgumentException(String.format(
+                    "rango de %d días excede el máximo de %d (1 año fiscal). " +
+                            "Divida la consulta en períodos menores.",
+                    dias, RANGO_MAX_DIAS));
+        }
+    }
+
+    /** Constructor por defecto con incluirAnulados=true. */
+    public static LibroDiarioFilter de(LocalDate desde, LocalDate hasta) {
+        return new LibroDiarioFilter(desde, hasta, true);
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/dto/LibroDiarioResponse.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/dto/LibroDiarioResponse.java
@@ -1,0 +1,89 @@
+package com.tufondo.contabilidad.application.dto;
+
+import com.tufondo.contabilidad.domain.model.enums.EstadoAsiento;
+import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Response del Libro Diario (sub-issue #269).
+ *
+ * <p>Estructura tradicional contable: encabezado con datos de la entidad y
+ * período, lista de asientos con sus partidas, y totales del período. El
+ * frontend o el adapter PDF consumen este mismo DTO.</p>
+ */
+@Builder
+public record LibroDiarioResponse(
+        Encabezado encabezado,
+        List<AsientoDiario> asientos,
+        Totales totales
+) {
+
+    /**
+     * Datos identificatorios y de auditoría que cabecean el reporte.
+     * Razón social y RIF vienen de properties — ver {@code EntidadProperties}.
+     */
+    @Builder
+    public record Encabezado(
+            String razonSocial,
+            String rif,
+            LocalDate desde,
+            LocalDate hasta,
+            Instant generadoEn,
+            UUID generadoPorUsuarioId,
+            boolean incluyeAnulados
+    ) {}
+
+    /**
+     * Un asiento del libro, con su número formateado para presentación
+     * ({@code AÑO-NNNNNN}, ej. "2026-000001") y sus partidas en orden.
+     */
+    @Builder
+    public record AsientoDiario(
+            long numero,
+            String numeroFormateado,       // "2026-000123" (año + correlativo)
+            LocalDate fechaContable,
+            OrigenAsiento origen,
+            EstadoAsiento estado,
+            String glosa,
+            String referenciaExterna,
+            String motivoAnulacion,         // null si REGISTRADO
+            List<PartidaDiario> partidas,
+            BigDecimal totalDebe,
+            BigDecimal totalHaber
+    ) {}
+
+    /**
+     * Una partida (renglón) del asiento. Incluye nombre de cuenta (resuelto
+     * por el use case via lookup en el plan) para que el reporte sea
+     * autocontenido y no requiera otras llamadas.
+     */
+    @Builder
+    public record PartidaDiario(
+            String codigoCuenta,
+            String nombreCuenta,
+            BigDecimal debe,
+            BigDecimal haber,
+            String glosa,
+            int orden
+    ) {}
+
+    /**
+     * Totales agregados del período. Si {@code balanceado=false} hay un
+     * problema serio — sería bug del sistema porque cada asiento individual
+     * está balanceado por invariante de dominio.
+     */
+    @Builder
+    public record Totales(
+            int cantidadAsientos,
+            int cantidadAnulados,
+            BigDecimal totalDebe,
+            BigDecimal totalHaber,
+            boolean balanceado
+    ) {}
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/dto/LibroMayorFilter.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/dto/LibroMayorFilter.java
@@ -1,0 +1,60 @@
+package com.tufondo.contabilidad.application.dto;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Filtros para la generación del Libro Mayor (sub-issue #270).
+ *
+ * @param desde                 inicio del período (inclusive)
+ * @param hasta                 fin del período (inclusive)
+ * @param codigoCuenta          si presente, solo se incluye esa cuenta;
+ *                              si null/vacío, todas las cuentas hoja del plan
+ * @param incluirSinMovimientos si {@code true}, incluye cuentas que no
+ *                              tuvieron ningún movimiento en el período
+ *                              (útil para auditoría "completa")
+ * @param incluirTotalizadoras  si {@code true}, también muestra cuentas de
+ *                              nivel 1-2 (las que NO aceptan movimientos
+ *                              directos pero suman las de sus hijas)
+ */
+public record LibroMayorFilter(
+        LocalDate desde,
+        LocalDate hasta,
+        String codigoCuenta,
+        boolean incluirSinMovimientos,
+        boolean incluirTotalizadoras
+) {
+    public static final int RANGO_MAX_DIAS = 366; // 1 año bisiesto
+
+    public LibroMayorFilter {
+        if (desde == null || hasta == null) {
+            throw new IllegalArgumentException("desde y hasta son obligatorios");
+        }
+        if (hasta.isBefore(desde)) {
+            throw new IllegalArgumentException("hasta no puede ser anterior a desde");
+        }
+        long dias = ChronoUnit.DAYS.between(desde, hasta);
+        if (dias > RANGO_MAX_DIAS) {
+            throw new IllegalArgumentException(String.format(
+                    "rango de %d días excede el máximo de %d (1 año fiscal). " +
+                            "Divida la consulta en períodos menores.",
+                    dias, RANGO_MAX_DIAS));
+        }
+        // codigoCuenta puede ser null o vacío — se interpreta como "todas".
+    }
+
+    /** Factory: todas las cuentas con movimientos, sin totalizadoras. */
+    public static LibroMayorFilter completo(LocalDate desde, LocalDate hasta) {
+        return new LibroMayorFilter(desde, hasta, null, false, false);
+    }
+
+    /** Factory: solo una cuenta específica. */
+    public static LibroMayorFilter deCuenta(LocalDate desde, LocalDate hasta, String codigoCuenta) {
+        return new LibroMayorFilter(desde, hasta, codigoCuenta, true, false);
+    }
+
+    /** {@code true} si se debe filtrar a una cuenta específica. */
+    public boolean filtraPorCuenta() {
+        return codigoCuenta != null && !codigoCuenta.isBlank();
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/dto/LibroMayorResponse.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/dto/LibroMayorResponse.java
@@ -1,0 +1,93 @@
+package com.tufondo.contabilidad.application.dto;
+
+import com.tufondo.contabilidad.domain.model.enums.NaturalezaSaldo;
+import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
+import com.tufondo.contabilidad.domain.model.enums.TipoCuentaContable;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Response del Libro Mayor (sub-issue #270).
+ *
+ * <p>Estructura: encabezado con datos de la entidad, lista de cuentas (cada
+ * una con su saldo inicial, movimientos del período y saldo final), y
+ * totales generales agregados.</p>
+ */
+@Builder
+public record LibroMayorResponse(
+        Encabezado encabezado,
+        List<CuentaConMovimientos> cuentas,
+        Totales totales
+) {
+
+    @Builder
+    public record Encabezado(
+            String razonSocial,
+            String rif,
+            LocalDate desde,
+            LocalDate hasta,
+            Instant generadoEn,
+            UUID generadoPorUsuarioId,
+            String filtroCuenta,            // null si todas las cuentas
+            boolean incluyeSinMovimientos,
+            boolean incluyeTotalizadoras
+    ) {}
+
+    /**
+     * Una cuenta con su saldo inicial al comienzo del período, todos sus
+     * movimientos del rango, y su saldo final calculado.
+     */
+    @Builder
+    public record CuentaConMovimientos(
+            String codigo,
+            String nombre,
+            TipoCuentaContable tipo,
+            NaturalezaSaldo naturaleza,
+            BigDecimal saldoInicialDebe,   // antes de aplicar naturaleza
+            BigDecimal saldoInicialHaber,
+            BigDecimal saldoInicialNeto,   // ya firmado según naturaleza
+            String saldoInicialEtiqueta,   // "D" (deudor) / "A" (acreedor) / "—"
+            List<MovimientoMayor> movimientos,
+            BigDecimal totalDebePeriodo,
+            BigDecimal totalHaberPeriodo,
+            int cantidadMovimientos,
+            BigDecimal saldoFinalDebe,
+            BigDecimal saldoFinalHaber,
+            BigDecimal saldoFinalNeto,
+            String saldoFinalEtiqueta
+    ) {}
+
+    /**
+     * Un movimiento del mayor: la partida de esta cuenta + datos del asiento
+     * padre + contracuenta resuelta (la principal del lado opuesto).
+     */
+    @Builder
+    public record MovimientoMayor(
+            LocalDate fechaContable,
+            long numeroAsiento,
+            String numeroAsientoFormateado,   // "2026-000001"
+            OrigenAsiento origen,
+            String glosaAsiento,
+            String referenciaExterna,
+            String contracuentaCodigo,        // cuenta principal del lado opuesto
+            String contracuentaNombre,
+            String contracuentaResumen,       // "(múltiple)" si > 1 contracuenta
+            BigDecimal debe,                  // 0 si esta partida es HABER
+            BigDecimal haber,                 // 0 si esta partida es DEBE
+            BigDecimal saldoAcumulado         // saldo después de esta partida
+    ) {}
+
+    @Builder
+    public record Totales(
+            int cantidadCuentas,
+            int cantidadMovimientos,
+            BigDecimal totalDebe,
+            BigDecimal totalHaber,
+            boolean balanceado
+    ) {}
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/port/output/ContabilidadPdfPort.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/port/output/ContabilidadPdfPort.java
@@ -1,12 +1,14 @@
 package com.tufondo.contabilidad.application.port.output;
 
 import com.tufondo.contabilidad.application.dto.LibroDiarioResponse;
+import com.tufondo.contabilidad.application.dto.LibroMayorResponse;
 
 /**
  * Puerto de salida para generación de reportes contables en PDF.
  *
- * <p>Sub-issue #269. Se crea propio del módulo contabilidad en lugar de
- * reutilizar el {@code PdfGeneratorPort} de {@code documentospdf} porque:</p>
+ * <p>Sub-issue #269 (Libro Diario) y #270 (Libro Mayor). Se crea propio del
+ * módulo contabilidad en lugar de reutilizar el {@code PdfGeneratorPort} de
+ * {@code documentospdf} porque:</p>
  * <ul>
  *   <li>Aquel está acoplado a {@code TipoDocumento} enum del otro módulo.</li>
  *   <li>Los reportes contables tienen contrato distinto (DTO tipado vs Map).</li>
@@ -26,4 +28,14 @@ public interface ContabilidadPdfPort {
      * @return bytes del PDF listo para descarga
      */
     byte[] generarLibroDiarioPdf(LibroDiarioResponse libroDiario);
+
+    /**
+     * Genera el PDF del Libro Mayor: una sección por cuenta con saldo
+     * inicial, movimientos del período con contracuenta, saldo acumulado
+     * por línea, y saldo final. Totales generales al pie.
+     *
+     * @param libroMayor datos completos del reporte (sub-issue #270)
+     * @return bytes del PDF listo para descarga
+     */
+    byte[] generarLibroMayorPdf(LibroMayorResponse libroMayor);
 }

--- a/backend/src/main/java/com/tufondo/contabilidad/application/port/output/ContabilidadPdfPort.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/port/output/ContabilidadPdfPort.java
@@ -1,0 +1,29 @@
+package com.tufondo.contabilidad.application.port.output;
+
+import com.tufondo.contabilidad.application.dto.LibroDiarioResponse;
+
+/**
+ * Puerto de salida para generación de reportes contables en PDF.
+ *
+ * <p>Sub-issue #269. Se crea propio del módulo contabilidad en lugar de
+ * reutilizar el {@code PdfGeneratorPort} de {@code documentospdf} porque:</p>
+ * <ul>
+ *   <li>Aquel está acoplado a {@code TipoDocumento} enum del otro módulo.</li>
+ *   <li>Los reportes contables tienen contrato distinto (DTO tipado vs Map).</li>
+ *   <li>Mantiene separación de responsabilidades entre módulos.</li>
+ * </ul>
+ *
+ * <p>La implementación PUEDE compartir librería (OpenPDF) — solo el contrato
+ * es separado.</p>
+ */
+public interface ContabilidadPdfPort {
+
+    /**
+     * Genera el PDF del Libro Diario a partir del response ya armado por
+     * el use case (con encabezado, asientos y totales).
+     *
+     * @param libroDiario datos completos del reporte
+     * @return bytes del PDF listo para descarga
+     */
+    byte[] generarLibroDiarioPdf(LibroDiarioResponse libroDiario);
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/usecase/GenerarLibroDiarioUseCase.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/usecase/GenerarLibroDiarioUseCase.java
@@ -1,0 +1,171 @@
+package com.tufondo.contabilidad.application.usecase;
+
+import com.tufondo.contabilidad.application.config.EntidadProperties;
+import com.tufondo.contabilidad.application.dto.LibroDiarioFilter;
+import com.tufondo.contabilidad.application.dto.LibroDiarioResponse;
+import com.tufondo.contabilidad.domain.model.AsientoContable;
+import com.tufondo.contabilidad.domain.model.CuentaContable;
+import com.tufondo.contabilidad.domain.model.PartidaAsiento;
+import com.tufondo.contabilidad.domain.model.enums.EstadoAsiento;
+import com.tufondo.contabilidad.domain.repository.AsientoContableRepository;
+import com.tufondo.contabilidad.domain.repository.CuentaContableRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Genera el Libro Diario (sub-issue #269) — reporte secuencial de todos los
+ * asientos contables del período, ordenados por número correlativo.
+ *
+ * <p>Es el primer reporte exigido por SUDECA para auditoría. Incluye todos
+ * los asientos REGISTRADOS y opcionalmente los ANULADOS (con marca visual),
+ * para que la auditoría externa pueda ver el flujo completo del período sin
+ * censura.</p>
+ *
+ * <h2>Performance</h2>
+ * <ul>
+ *   <li>Lectura: 1 query a {@code listarPorRangoFecha} (ya batch-loaded las partidas).</li>
+ *   <li>Lookup de nombres: 1 query a {@code listarTodas()} del plan + index en memoria.
+ *       Costo O(n) ~ decenas-cientos de cuentas, despreciable.</li>
+ *   <li>No paginar — el Libro Diario es por naturaleza secuencial y completo.
+ *       La validación del rango (≤ 1 año) en {@link LibroDiarioFilter} acota el tamaño.</li>
+ * </ul>
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GenerarLibroDiarioUseCase {
+
+    private final AsientoContableRepository asientoRepository;
+    private final CuentaContableRepository cuentaRepository;
+    private final EntidadProperties entidadProperties;
+
+    @Transactional(readOnly = true)
+    public LibroDiarioResponse ejecutar(LibroDiarioFilter filter, UUID solicitanteId) {
+        log.info("Generando Libro Diario: desde={} hasta={} incluyeAnulados={} solicitante={}",
+                filter.desde(), filter.hasta(), filter.incluirAnulados(), solicitanteId);
+
+        // 1. Cargar todos los asientos del período (orden por número correlativo)
+        List<AsientoContable> asientosRaw = asientoRepository
+                .listarPorRangoFecha(filter.desde(), filter.hasta());
+
+        // 2. Filtrar por anulados si el filtro lo pide
+        List<AsientoContable> asientos = filter.incluirAnulados()
+                ? asientosRaw
+                : asientosRaw.stream()
+                    .filter(a -> a.getEstado() != EstadoAsiento.ANULADO)
+                    .toList();
+
+        // 3. Cargar plan de cuentas e indexar por UUID para lookup de nombres
+        Map<UUID, CuentaContable> indexPorId = cuentaRepository.listarTodas().stream()
+                .collect(Collectors.toMap(CuentaContable::getId, Function.identity()));
+
+        // 4. Mapear cada asiento al DTO con sus partidas resueltas
+        List<LibroDiarioResponse.AsientoDiario> dtoAsientos = asientos.stream()
+                .map(a -> mapearAsiento(a, indexPorId))
+                .toList();
+
+        // 5. Calcular totales del período
+        int cantidadAnulados = (int) asientos.stream()
+                .filter(a -> a.getEstado() == EstadoAsiento.ANULADO).count();
+        BigDecimal totalDebe = asientos.stream()
+                .map(AsientoContable::totalDebe)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal totalHaber = asientos.stream()
+                .map(AsientoContable::totalHaber)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        LibroDiarioResponse.Totales totales = LibroDiarioResponse.Totales.builder()
+                .cantidadAsientos(asientos.size())
+                .cantidadAnulados(cantidadAnulados)
+                .totalDebe(totalDebe)
+                .totalHaber(totalHaber)
+                .balanceado(totalDebe.compareTo(totalHaber) == 0)
+                .build();
+
+        // 6. Armar encabezado con properties + auditoría
+        LibroDiarioResponse.Encabezado encabezado = LibroDiarioResponse.Encabezado.builder()
+                .razonSocial(entidadProperties.getRazonSocial())
+                .rif(entidadProperties.getRif())
+                .desde(filter.desde())
+                .hasta(filter.hasta())
+                .generadoEn(Instant.now())
+                .generadoPorUsuarioId(solicitanteId)
+                .incluyeAnulados(filter.incluirAnulados())
+                .build();
+
+        return LibroDiarioResponse.builder()
+                .encabezado(encabezado)
+                .asientos(dtoAsientos)
+                .totales(totales)
+                .build();
+    }
+
+    private LibroDiarioResponse.AsientoDiario mapearAsiento(
+            AsientoContable a, Map<UUID, CuentaContable> indexCuentas) {
+
+        // Partidas ordenadas por su campo `orden`
+        List<LibroDiarioResponse.PartidaDiario> partidasDto = a.getPartidas().stream()
+                .sorted(Comparator.comparingInt(PartidaAsiento::getOrden))
+                .map(p -> mapearPartida(p, indexCuentas))
+                .toList();
+
+        return LibroDiarioResponse.AsientoDiario.builder()
+                .numero(a.getNumero())
+                .numeroFormateado(formatearNumero(a))
+                .fechaContable(a.getFechaContable())
+                .origen(a.getOrigen())
+                .estado(a.getEstado())
+                .glosa(a.getGlosa())
+                .referenciaExterna(a.getReferenciaExterna())
+                .motivoAnulacion(a.getMotivoAnulacion())
+                .partidas(partidasDto)
+                .totalDebe(a.totalDebe())
+                .totalHaber(a.totalHaber())
+                .build();
+    }
+
+    private LibroDiarioResponse.PartidaDiario mapearPartida(
+            PartidaAsiento p, Map<UUID, CuentaContable> indexCuentas) {
+        CuentaContable cuenta = indexCuentas.get(p.getCuentaId());
+        // Defensa: si por alguna razón la cuenta no está en el index (ej. fue
+        // borrada — aunque las FK ON DELETE RESTRICT lo impiden), mostramos
+        // el UUID como nombre para que el reporte no rompa.
+        String nombre = cuenta != null ? cuenta.getNombre() : "[CUENTA DESCONOCIDA " + p.getCuentaId() + "]";
+        String codigo = cuenta != null ? cuenta.getCodigo() : "???";
+
+        return LibroDiarioResponse.PartidaDiario.builder()
+                .codigoCuenta(codigo)
+                .nombreCuenta(nombre)
+                .debe(p.getDebe())
+                .haber(p.getHaber())
+                .glosa(p.getGlosa())
+                .orden(p.getOrden())
+                .build();
+    }
+
+    /**
+     * Formatea el número del asiento como {@code AÑO-NNNNNN} (ej. "2026-000123").
+     * El año se toma de la fecha contable, no del momento de inserción.
+     *
+     * <p>NOTA: actualmente la SEQUENCE BD es continua y nunca se resetea.
+     * Este formato presenta el número de forma "anual" sin requerir cambio
+     * de modelo. SUDECA exige reset anual real — ver pendiente
+     * P1 "Reset anual del correlativo" en {@code _pendientes-criticos.md}.
+     * Sub-issue dedicado antes del primer cierre fiscal.</p>
+     */
+    static String formatearNumero(AsientoContable a) {
+        int anio = a.getFechaContable().getYear();
+        return String.format("%d-%06d", anio, a.getNumero());
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/usecase/GenerarLibroMayorUseCase.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/usecase/GenerarLibroMayorUseCase.java
@@ -1,0 +1,285 @@
+package com.tufondo.contabilidad.application.usecase;
+
+import com.tufondo.contabilidad.application.config.EntidadProperties;
+import com.tufondo.contabilidad.application.dto.LibroMayorFilter;
+import com.tufondo.contabilidad.application.dto.LibroMayorResponse;
+import com.tufondo.contabilidad.application.exception.AsientoContableException;
+import com.tufondo.contabilidad.domain.model.AsientoContable;
+import com.tufondo.contabilidad.domain.model.CuentaContable;
+import com.tufondo.contabilidad.domain.model.PartidaAsiento;
+import com.tufondo.contabilidad.domain.model.SaldoCuenta;
+import com.tufondo.contabilidad.domain.model.enums.NaturalezaSaldo;
+import com.tufondo.contabilidad.domain.repository.AsientoContableRepository;
+import com.tufondo.contabilidad.domain.repository.CuentaContableRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Genera el Libro Mayor (sub-issue #270): agrupa los movimientos contables
+ * por cuenta, calcula saldo inicial al comienzo del período, lista todos
+ * los movimientos del rango con su contracuenta resuelta, y calcula saldo
+ * final.
+ *
+ * <p>Decisiones formalizadas en {@code D-007} (ver
+ * {@code docs/modulos/contabilidad/_decisiones-contables.md}):</p>
+ * <ul>
+ *   <li>Saldo inicial real (sumando todo lo previo a {@code desde-1}), no asume cero.</li>
+ *   <li>Solo cuentas hoja por default (las que aceptan movimientos).</li>
+ *   <li>Cuentas sin movimientos NO se incluyen por default.</li>
+ *   <li>Asientos ANULADOS se excluyen del Mayor (es saldo vigente, no historial).</li>
+ *   <li>Saldos en formato absoluto + tag (D/A), no firmado.</li>
+ *   <li>Contracuenta: la cuenta del lado opuesto con mayor monto (o "múltiple").</li>
+ * </ul>
+ *
+ * <h2>Performance</h2>
+ * <ul>
+ *   <li>1 query: plan de cuentas completo.</li>
+ *   <li>Por cuenta: 1 query saldo inicial (SUM) + 1 query asientos del período.</li>
+ *   <li>Filtro de 1 cuenta: solo 2 queries totales.</li>
+ *   <li>Sin filtro: ~2 × N queries donde N es la cantidad de cuentas hoja del plan
+ *       (típicamente 50-100). Si crece mucho, cachear saldos finales en una tabla
+ *       de "estado de cuenta" pre-calculado por el cierre mensual (#272).</li>
+ * </ul>
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GenerarLibroMayorUseCase {
+
+    private final AsientoContableRepository asientoRepository;
+    private final CuentaContableRepository cuentaRepository;
+    private final EntidadProperties entidadProperties;
+
+    @Transactional(readOnly = true)
+    public LibroMayorResponse ejecutar(LibroMayorFilter filter, UUID solicitanteId) {
+        log.info("Generando Libro Mayor: desde={} hasta={} cuenta={} solicitante={}",
+                filter.desde(), filter.hasta(), filter.codigoCuenta(), solicitanteId);
+
+        // 1. Determinar el set de cuentas a procesar
+        List<CuentaContable> cuentasObjetivo = seleccionarCuentas(filter);
+
+        // 2. Index UUID → CuentaContable (para resolver contracuentas)
+        Map<UUID, CuentaContable> indexCuentas = cuentaRepository.listarTodas().stream()
+                .collect(Collectors.toMap(CuentaContable::getId, Function.identity()));
+
+        // 3. Procesar cada cuenta: saldo inicial + movimientos + saldo final
+        List<LibroMayorResponse.CuentaConMovimientos> dtoCuentas = new ArrayList<>();
+        BigDecimal totalDebeAcumulado = BigDecimal.ZERO;
+        BigDecimal totalHaberAcumulado = BigDecimal.ZERO;
+        int totalMovimientosAcumulado = 0;
+
+        for (CuentaContable cuenta : cuentasObjetivo) {
+            LibroMayorResponse.CuentaConMovimientos dto = procesarCuenta(cuenta, filter, indexCuentas);
+            // Filtrar cuentas sin movimientos si el filtro lo pide
+            if (!filter.incluirSinMovimientos() && dto.cantidadMovimientos() == 0) {
+                continue;
+            }
+            dtoCuentas.add(dto);
+            totalDebeAcumulado = totalDebeAcumulado.add(dto.totalDebePeriodo());
+            totalHaberAcumulado = totalHaberAcumulado.add(dto.totalHaberPeriodo());
+            totalMovimientosAcumulado += dto.cantidadMovimientos();
+        }
+
+        LibroMayorResponse.Totales totales = LibroMayorResponse.Totales.builder()
+                .cantidadCuentas(dtoCuentas.size())
+                .cantidadMovimientos(totalMovimientosAcumulado)
+                .totalDebe(totalDebeAcumulado)
+                .totalHaber(totalHaberAcumulado)
+                .balanceado(totalDebeAcumulado.compareTo(totalHaberAcumulado) == 0)
+                .build();
+
+        LibroMayorResponse.Encabezado encabezado = LibroMayorResponse.Encabezado.builder()
+                .razonSocial(entidadProperties.getRazonSocial())
+                .rif(entidadProperties.getRif())
+                .desde(filter.desde())
+                .hasta(filter.hasta())
+                .generadoEn(Instant.now())
+                .generadoPorUsuarioId(solicitanteId)
+                .filtroCuenta(filter.codigoCuenta())
+                .incluyeSinMovimientos(filter.incluirSinMovimientos())
+                .incluyeTotalizadoras(filter.incluirTotalizadoras())
+                .build();
+
+        return LibroMayorResponse.builder()
+                .encabezado(encabezado)
+                .cuentas(dtoCuentas)
+                .totales(totales)
+                .build();
+    }
+
+    // ─── Selección de cuentas ──────────────────────────────────────────────
+
+    private List<CuentaContable> seleccionarCuentas(LibroMayorFilter filter) {
+        if (filter.filtraPorCuenta()) {
+            CuentaContable c = cuentaRepository.buscarPorCodigo(filter.codigoCuenta())
+                    .orElseThrow(() -> new AsientoContableException(
+                            "cuenta no encontrada en el plan: " + filter.codigoCuenta()));
+            return List.of(c);
+        }
+        // Sin filtro de código: todas las hojas, o todas si totalizadoras también.
+        List<CuentaContable> todas = cuentaRepository.listarTodas();
+        return todas.stream()
+                .filter(c -> filter.incluirTotalizadoras() || c.isAceptaMovimientos())
+                .sorted(Comparator.comparing(CuentaContable::getCodigo))
+                .toList();
+    }
+
+    // ─── Procesamiento de una cuenta ───────────────────────────────────────
+
+    private LibroMayorResponse.CuentaConMovimientos procesarCuenta(
+            CuentaContable cuenta, LibroMayorFilter filter,
+            Map<UUID, CuentaContable> indexCuentas) {
+
+        NaturalezaSaldo naturaleza = cuenta.getNaturaleza();
+
+        // a) Saldo inicial = SUM de partidas hasta (desde - 1)
+        SaldoCuenta saldoInicial = asientoRepository
+                .calcularSaldoCuentaHasta(cuenta.getId(), filter.desde().minusDays(1));
+
+        // b) Listar asientos del período que tocaron esta cuenta
+        List<AsientoContable> asientosPeriodo = asientoRepository
+                .listarAsientosDeCuentaEnRango(cuenta.getId(), filter.desde(), filter.hasta());
+
+        // c) Iterar asientos → para cada partida DE ESTA CUENTA, construir un MovimientoMayor
+        //    calculando el saldo acumulado paso a paso.
+        List<LibroMayorResponse.MovimientoMayor> movs = new ArrayList<>();
+        SaldoCuenta acumulador = saldoInicial;
+        BigDecimal totalDebePeriodo = BigDecimal.ZERO;
+        BigDecimal totalHaberPeriodo = BigDecimal.ZERO;
+
+        for (AsientoContable a : asientosPeriodo) {
+            // Una cuenta puede aparecer más de una vez en el mismo asiento si está
+            // en ambos lados (dominio lo permite). Procesamos todas las partidas
+            // que matchean esta cuenta.
+            List<PartidaAsiento> partidasDeEstaCuenta = a.getPartidas().stream()
+                    .filter(p -> p.getCuentaId().equals(cuenta.getId()))
+                    .sorted(Comparator.comparingInt(PartidaAsiento::getOrden))
+                    .toList();
+
+            // Las "partidas opuestas" (lado contrario) son las que NO matchean esta cuenta.
+            List<PartidaAsiento> opuestas = a.getPartidas().stream()
+                    .filter(p -> !p.getCuentaId().equals(cuenta.getId()))
+                    .toList();
+
+            for (PartidaAsiento p : partidasDeEstaCuenta) {
+                // Acumular saldo
+                acumulador = acumulador.mas(new SaldoCuenta(p.getDebe(), p.getHaber()));
+                totalDebePeriodo = totalDebePeriodo.add(p.getDebe());
+                totalHaberPeriodo = totalHaberPeriodo.add(p.getHaber());
+
+                // Resolver contracuenta: si p es DEBE, la opuesta es del HABER (y viceversa).
+                List<PartidaAsiento> opuestasFiltradas = opuestas.stream()
+                        .filter(op -> p.esDeDebe() ? op.esDeHaber() : op.esDeDebe())
+                        .toList();
+                ContracuentaInfo cc = resolverContracuenta(opuestasFiltradas, indexCuentas);
+
+                movs.add(LibroMayorResponse.MovimientoMayor.builder()
+                        .fechaContable(a.getFechaContable())
+                        .numeroAsiento(a.getNumero() == null ? 0L : a.getNumero())
+                        .numeroAsientoFormateado(formatearNumero(a))
+                        .origen(a.getOrigen())
+                        .glosaAsiento(a.getGlosa())
+                        .referenciaExterna(a.getReferenciaExterna())
+                        .contracuentaCodigo(cc.codigo)
+                        .contracuentaNombre(cc.nombre)
+                        .contracuentaResumen(cc.resumen)
+                        .debe(p.getDebe())
+                        .haber(p.getHaber())
+                        .saldoAcumulado(acumulador.saldoNeto(naturaleza))
+                        .build());
+            }
+        }
+
+        // d) Construir DTO con etiquetas D/A según naturaleza y signo
+        BigDecimal saldoIniNeto = saldoInicial.saldoNeto(naturaleza);
+        BigDecimal saldoFinNeto = acumulador.saldoNeto(naturaleza);
+
+        return LibroMayorResponse.CuentaConMovimientos.builder()
+                .codigo(cuenta.getCodigo())
+                .nombre(cuenta.getNombre())
+                .tipo(cuenta.getTipo())
+                .naturaleza(naturaleza)
+                .saldoInicialDebe(saldoInicial.totalDebe())
+                .saldoInicialHaber(saldoInicial.totalHaber())
+                .saldoInicialNeto(saldoIniNeto.abs())
+                .saldoInicialEtiqueta(etiquetaSaldo(saldoIniNeto, naturaleza))
+                .movimientos(movs)
+                .totalDebePeriodo(totalDebePeriodo)
+                .totalHaberPeriodo(totalHaberPeriodo)
+                .cantidadMovimientos(movs.size())
+                .saldoFinalDebe(acumulador.totalDebe())
+                .saldoFinalHaber(acumulador.totalHaber())
+                .saldoFinalNeto(saldoFinNeto.abs())
+                .saldoFinalEtiqueta(etiquetaSaldo(saldoFinNeto, naturaleza))
+                .build();
+    }
+
+    /**
+     * Etiqueta del saldo: "D" si quedó deudor (positivo en cuenta deudora o
+     * negativo en acreedora), "A" si quedó acreedor (positivo en acreedora o
+     * negativo en deudora), "—" si saldo cero.
+     *
+     * <p>El saldo neto pre-firmado por {@link NaturalezaSaldo#calcularSaldo}
+     * ya es positivo cuando "está del lado de su naturaleza". Si es negativo,
+     * la cuenta tiene saldo del lado opuesto (poco usual pero válido).</p>
+     */
+    static String etiquetaSaldo(BigDecimal saldoNeto, NaturalezaSaldo naturaleza) {
+        int signo = saldoNeto.signum();
+        if (signo == 0) return "—";
+        if (signo > 0) {
+            return naturaleza == NaturalezaSaldo.DEUDORA ? "D" : "A";
+        } else {
+            return naturaleza == NaturalezaSaldo.DEUDORA ? "A" : "D";
+        }
+    }
+
+    // ─── Contracuenta ──────────────────────────────────────────────────────
+
+    /** Info resumida de la contracuenta principal del movimiento. */
+    private record ContracuentaInfo(String codigo, String nombre, String resumen) {}
+
+    /**
+     * Resuelve la contracuenta a mostrar. Reglas:
+     * <ul>
+     *   <li>Si hay exactamente 1 partida opuesta → esa cuenta es la contracuenta.</li>
+     *   <li>Si hay > 1 → tomamos la de mayor monto absoluto como "principal" y
+     *       marcamos {@code resumen="múltiple"}.</li>
+     *   <li>Si por alguna razón no hay opuestas (no debería pasar por invariante
+     *       de partida doble) → "(sin contracuenta)".</li>
+     * </ul>
+     */
+    private ContracuentaInfo resolverContracuenta(
+            List<PartidaAsiento> opuestas, Map<UUID, CuentaContable> indexCuentas) {
+        if (opuestas.isEmpty()) {
+            return new ContracuentaInfo("—", "(sin contracuenta)", null);
+        }
+        // Ordenamos por monto descendente y tomamos la primera como principal
+        PartidaAsiento principal = opuestas.stream()
+                .max(Comparator.comparing(PartidaAsiento::monto))
+                .orElse(opuestas.get(0));
+        CuentaContable cuenta = indexCuentas.get(principal.getCuentaId());
+        String codigo = cuenta != null ? cuenta.getCodigo() : "???";
+        String nombre = cuenta != null ? cuenta.getNombre() : "[desconocida " + principal.getCuentaId() + "]";
+        String resumen = opuestas.size() > 1 ? "(múltiple)" : null;
+        return new ContracuentaInfo(codigo, nombre, resumen);
+    }
+
+    /** Mismo formato visual del Libro Diario: "AÑO-NNNNNN". */
+    static String formatearNumero(AsientoContable a) {
+        int anio = a.getFechaContable().getYear();
+        return String.format("%d-%06d", anio,
+                a.getNumero() == null ? 0L : a.getNumero());
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/domain/model/SaldoCuenta.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/domain/model/SaldoCuenta.java
@@ -1,0 +1,56 @@
+package com.tufondo.contabilidad.domain.model;
+
+import com.tufondo.contabilidad.domain.model.enums.NaturalezaSaldo;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * Saldo acumulado de una cuenta a una fecha de corte.
+ *
+ * <p>Es el resultado de sumar todas las partidas DEBE/HABER que tocaron la
+ * cuenta hasta cierta fecha (típicamente excluyendo asientos ANULADOS). El
+ * <strong>saldo neto</strong> con su signo depende de la naturaleza de la
+ * cuenta — ver {@link NaturalezaSaldo#calcularSaldo(BigDecimal, BigDecimal)}.</p>
+ *
+ * <p>Sub-issue #270 (Libro Mayor). Se usa para calcular:</p>
+ * <ul>
+ *   <li>Saldo inicial al comienzo del período (sumando todo lo previo a {@code desde-1}).</li>
+ *   <li>Saldo final al cierre del período (sumando inicial + movimientos del rango).</li>
+ * </ul>
+ *
+ * @param totalDebe  suma de todas las partidas al DEBE
+ * @param totalHaber suma de todas las partidas al HABER
+ */
+public record SaldoCuenta(
+        BigDecimal totalDebe,
+        BigDecimal totalHaber
+) {
+    public SaldoCuenta {
+        Objects.requireNonNull(totalDebe, "totalDebe requerido");
+        Objects.requireNonNull(totalHaber, "totalHaber requerido");
+    }
+
+    /** Saldo cero — útil cuando la cuenta no tiene movimientos. */
+    public static SaldoCuenta cero() {
+        return new SaldoCuenta(BigDecimal.ZERO, BigDecimal.ZERO);
+    }
+
+    /**
+     * Calcula el saldo neto firmado según la naturaleza de la cuenta.
+     * <ul>
+     *   <li>DEUDORA: {@code debe - haber} (positivo = saldo deudor)</li>
+     *   <li>ACREEDORA: {@code haber - debe} (positivo = saldo acreedor)</li>
+     * </ul>
+     */
+    public BigDecimal saldoNeto(NaturalezaSaldo naturaleza) {
+        return naturaleza.calcularSaldo(totalDebe, totalHaber);
+    }
+
+    /** Suma otro saldo al actual (útil para sumar inicial + movimientos del período). */
+    public SaldoCuenta mas(SaldoCuenta otro) {
+        return new SaldoCuenta(
+                this.totalDebe.add(otro.totalDebe),
+                this.totalHaber.add(otro.totalHaber));
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/domain/repository/AsientoContableRepository.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/domain/repository/AsientoContableRepository.java
@@ -1,6 +1,7 @@
 package com.tufondo.contabilidad.domain.repository;
 
 import com.tufondo.contabilidad.domain.model.AsientoContable;
+import com.tufondo.contabilidad.domain.model.SaldoCuenta;
 import com.tufondo.contabilidad.domain.model.enums.EstadoAsiento;
 import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
 
@@ -65,4 +66,35 @@ public interface AsientoContableRepository {
     List<AsientoContable> buscarReversionesDe(UUID asientoOriginalId);
 
     long contar();
+
+    // ─── Queries para el Libro Mayor (#270) ────────────────────────────────
+
+    /**
+     * Calcula el saldo acumulado de una cuenta a una fecha de corte (inclusive).
+     *
+     * <p>Suma TODAS las partidas DEBE/HABER que tocaron la cuenta hasta la
+     * {@code fechaCorte}, excluyendo asientos {@link EstadoAsiento#ANULADO}.
+     * Una sola query SQL agregada — eficiente incluso con miles de partidas.</p>
+     *
+     * <p>Si la cuenta no tiene movimientos hasta esa fecha, devuelve
+     * {@link SaldoCuenta#cero()}.</p>
+     */
+    SaldoCuenta calcularSaldoCuentaHasta(UUID cuentaId, LocalDate fechaCorte);
+
+    /**
+     * Lista los asientos COMPLETOS (con todas sus partidas) que tocaron una
+     * cuenta específica en un rango de fechas.
+     *
+     * <p>Excluye asientos {@link EstadoAsiento#ANULADO} — el Libro Mayor
+     * muestra saldos vigentes, no historial. Para historial de anulados ver
+     * Libro Diario (#269).</p>
+     *
+     * <p>El use case del Libro Mayor extrae las partidas de la cuenta y
+     * resuelve la contracuenta mirando las otras partidas del mismo asiento
+     * (ya cargadas batch — sin N+1).</p>
+     *
+     * <p>Orden: por fecha contable ascendente, luego por número correlativo.</p>
+     */
+    List<AsientoContable> listarAsientosDeCuentaEnRango(
+            UUID cuentaId, LocalDate desde, LocalDate hasta);
 }

--- a/backend/src/main/java/com/tufondo/contabilidad/infrastructure/pdf/LibroDiarioPdfAdapter.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/infrastructure/pdf/LibroDiarioPdfAdapter.java
@@ -1,0 +1,231 @@
+package com.tufondo.contabilidad.infrastructure.pdf;
+
+import com.lowagie.text.*;
+import com.lowagie.text.pdf.*;
+import com.tufondo.contabilidad.application.dto.LibroDiarioResponse;
+import com.tufondo.contabilidad.application.port.output.ContabilidadPdfPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.awt.Color;
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Adapter de generación PDF del Libro Diario (sub-issue #269).
+ *
+ * <p>Implementa {@link ContabilidadPdfPort} usando la librería OpenPDF, la
+ * misma que el módulo {@code documentospdf} (ya está en {@code pom.xml}).</p>
+ *
+ * <h2>Formato</h2>
+ * <ul>
+ *   <li>A4 horizontal — para acomodar 7 columnas legibles.</li>
+ *   <li>Cabecera con razón social, RIF, período, fecha de generación.</li>
+ *   <li>Tabla con columnas: Fecha | Nº Asiento | Origen | Cuenta | Glosa | Debe | Haber.</li>
+ *   <li>Cada asiento se renderiza como una fila "agrupadora" (sin DEBE/HABER)
+ *       seguida de N filas con las partidas (una por renglón).</li>
+ *   <li>Asientos ANULADOS se marcan con fondo rojo claro y la palabra
+ *       "ANULADO" en la columna estado.</li>
+ *   <li>Totales al pie + folio "Página X de Y" en cada página.</li>
+ * </ul>
+ */
+@Component
+@Slf4j
+public class LibroDiarioPdfAdapter implements ContabilidadPdfPort {
+
+    private static final Font TITLE_FONT      = new Font(Font.HELVETICA, 14, Font.BOLD, Color.BLACK);
+    private static final Font SUBTITLE_FONT   = new Font(Font.HELVETICA, 10, Font.NORMAL, Color.DARK_GRAY);
+    private static final Font TABLE_HEADER    = new Font(Font.HELVETICA, 9, Font.BOLD, Color.WHITE);
+    private static final Font ROW_FONT        = new Font(Font.HELVETICA, 8, Font.NORMAL, Color.BLACK);
+    private static final Font ROW_FONT_BOLD   = new Font(Font.HELVETICA, 8, Font.BOLD, Color.BLACK);
+    private static final Font ROW_FONT_ANUL   = new Font(Font.HELVETICA, 8, Font.NORMAL, Color.RED);
+    private static final Font FOOTER_FONT     = new Font(Font.HELVETICA, 7, Font.NORMAL, Color.GRAY);
+
+    private static final Color HEADER_BG          = new Color(70, 70, 70);
+    private static final Color ANULADO_BG         = new Color(255, 230, 230);
+    private static final Color ASIENTO_HEADER_BG  = new Color(230, 240, 255);
+
+    private static final DateTimeFormatter FECHA_FMT = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+    private static final DateTimeFormatter TS_FMT    = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+
+    @Override
+    public byte[] generarLibroDiarioPdf(LibroDiarioResponse libro) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            Document doc = new Document(PageSize.A4.rotate(), 30, 30, 40, 40);
+            PdfWriter writer = PdfWriter.getInstance(doc, baos);
+            writer.setPageEvent(new FolioFooter()); // "Página X de Y" en cada página
+            doc.open();
+
+            // ─── Encabezado ────────────────────────────────────────────────
+            agregarEncabezado(doc, libro.encabezado());
+
+            // ─── Tabla de asientos ─────────────────────────────────────────
+            PdfPTable tabla = construirTabla(libro);
+            doc.add(tabla);
+
+            // ─── Totales ───────────────────────────────────────────────────
+            agregarTotales(doc, libro.totales());
+
+            doc.close();
+            return baos.toByteArray();
+        } catch (Exception e) {
+            log.error("Error generando PDF Libro Diario", e);
+            throw new RuntimeException("No se pudo generar el Libro Diario: " + e.getMessage(), e);
+        }
+    }
+
+    // ─── Construcción de secciones ─────────────────────────────────────────
+
+    private void agregarEncabezado(Document doc, LibroDiarioResponse.Encabezado enc) throws DocumentException {
+        Paragraph razon = new Paragraph(enc.razonSocial(), TITLE_FONT);
+        razon.setAlignment(Element.ALIGN_CENTER);
+        doc.add(razon);
+
+        Paragraph rif = new Paragraph("RIF: " + enc.rif(), SUBTITLE_FONT);
+        rif.setAlignment(Element.ALIGN_CENTER);
+        doc.add(rif);
+
+        Paragraph titulo = new Paragraph("LIBRO DIARIO", TITLE_FONT);
+        titulo.setAlignment(Element.ALIGN_CENTER);
+        titulo.setSpacingBefore(8);
+        doc.add(titulo);
+
+        String periodo = String.format("Período: %s al %s",
+                enc.desde().format(FECHA_FMT), enc.hasta().format(FECHA_FMT));
+        Paragraph per = new Paragraph(periodo, SUBTITLE_FONT);
+        per.setAlignment(Element.ALIGN_CENTER);
+        doc.add(per);
+
+        String gen = String.format("Generado: %s%s",
+                enc.generadoEn().atZone(ZoneId.of("America/Caracas")).format(TS_FMT),
+                enc.incluyeAnulados() ? " — Incluye asientos anulados" : " — Solo registrados");
+        Paragraph genP = new Paragraph(gen, FOOTER_FONT);
+        genP.setAlignment(Element.ALIGN_CENTER);
+        genP.setSpacingAfter(10);
+        doc.add(genP);
+    }
+
+    private PdfPTable construirTabla(LibroDiarioResponse libro) throws DocumentException {
+        // Ancho relativo de columnas: Fecha | Nº | Origen | Código | Cuenta | Glosa | Debe | Haber
+        float[] anchos = {2.2f, 2.2f, 2.2f, 1.5f, 3.5f, 4.5f, 2.0f, 2.0f};
+        PdfPTable tabla = new PdfPTable(anchos);
+        tabla.setWidthPercentage(100);
+        tabla.setHeaderRows(1);
+
+        // Header
+        agregarHeaderTabla(tabla,
+                "Fecha", "Nº Asiento", "Origen", "Código", "Cuenta", "Glosa", "Debe", "Haber");
+
+        // Filas por asiento
+        for (LibroDiarioResponse.AsientoDiario a : libro.asientos()) {
+            boolean anulado = a.estado().name().equals("ANULADO");
+            Color rowBg = anulado ? ANULADO_BG : Color.WHITE;
+            Font rowFont = anulado ? ROW_FONT_ANUL : ROW_FONT;
+
+            // Fila "agrupadora" del asiento (con glosa general y datos de cabecera)
+            String tagAnul = anulado ? " [ANULADO]" : "";
+            String glosaAgr = (a.glosa() == null ? "" : a.glosa())
+                    + (anulado && a.motivoAnulacion() != null
+                        ? " — Motivo: " + a.motivoAnulacion() : "");
+
+            agregarCelda(tabla, a.fechaContable().format(FECHA_FMT), rowFont, ASIENTO_HEADER_BG, Element.ALIGN_LEFT);
+            agregarCelda(tabla, a.numeroFormateado() + tagAnul, ROW_FONT_BOLD, ASIENTO_HEADER_BG, Element.ALIGN_LEFT);
+            agregarCelda(tabla, a.origen().name(), rowFont, ASIENTO_HEADER_BG, Element.ALIGN_LEFT);
+            agregarCelda(tabla, "", rowFont, ASIENTO_HEADER_BG, Element.ALIGN_LEFT);
+            agregarCelda(tabla, a.referenciaExterna() == null ? "" : a.referenciaExterna(),
+                    rowFont, ASIENTO_HEADER_BG, Element.ALIGN_LEFT);
+            agregarCelda(tabla, glosaAgr, rowFont, ASIENTO_HEADER_BG, Element.ALIGN_LEFT);
+            agregarCelda(tabla, "", rowFont, ASIENTO_HEADER_BG, Element.ALIGN_RIGHT);
+            agregarCelda(tabla, "", rowFont, ASIENTO_HEADER_BG, Element.ALIGN_RIGHT);
+
+            // Filas por partida
+            for (LibroDiarioResponse.PartidaDiario p : a.partidas()) {
+                agregarCelda(tabla, "", rowFont, rowBg, Element.ALIGN_LEFT);
+                agregarCelda(tabla, "", rowFont, rowBg, Element.ALIGN_LEFT);
+                agregarCelda(tabla, "", rowFont, rowBg, Element.ALIGN_LEFT);
+                agregarCelda(tabla, p.codigoCuenta(), rowFont, rowBg, Element.ALIGN_LEFT);
+                agregarCelda(tabla, p.nombreCuenta(), rowFont, rowBg, Element.ALIGN_LEFT);
+                agregarCelda(tabla, p.glosa() == null ? "" : p.glosa(), rowFont, rowBg, Element.ALIGN_LEFT);
+                agregarCelda(tabla, formatoMonto(p.debe()), rowFont, rowBg, Element.ALIGN_RIGHT);
+                agregarCelda(tabla, formatoMonto(p.haber()), rowFont, rowBg, Element.ALIGN_RIGHT);
+            }
+        }
+
+        return tabla;
+    }
+
+    private void agregarTotales(Document doc, LibroDiarioResponse.Totales t) throws DocumentException {
+        Paragraph espacio = new Paragraph(" ");
+        espacio.setSpacingBefore(12);
+        doc.add(espacio);
+
+        PdfPTable totales = new PdfPTable(new float[]{14f, 2.0f, 2.0f});
+        totales.setWidthPercentage(100);
+
+        String resumen = String.format(
+                "TOTALES DEL PERÍODO  —  %d asientos%s  —  %s",
+                t.cantidadAsientos(),
+                t.cantidadAnulados() > 0 ? " (" + t.cantidadAnulados() + " anulados)" : "",
+                t.balanceado() ? "BALANCEADO ✓" : "⚠ DESBALANCEADO");
+        Font totalFont = t.balanceado() ? ROW_FONT_BOLD
+                : new Font(Font.HELVETICA, 10, Font.BOLD, Color.RED);
+        agregarCelda(totales, resumen, totalFont, Color.WHITE, Element.ALIGN_LEFT);
+        agregarCelda(totales, formatoMonto(t.totalDebe()), ROW_FONT_BOLD, Color.WHITE, Element.ALIGN_RIGHT);
+        agregarCelda(totales, formatoMonto(t.totalHaber()), ROW_FONT_BOLD, Color.WHITE, Element.ALIGN_RIGHT);
+
+        doc.add(totales);
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────
+
+    private void agregarHeaderTabla(PdfPTable tabla, String... headers) {
+        for (String h : headers) {
+            PdfPCell cell = new PdfPCell(new Phrase(h, TABLE_HEADER));
+            cell.setBackgroundColor(HEADER_BG);
+            cell.setPadding(4);
+            cell.setHorizontalAlignment(Element.ALIGN_CENTER);
+            tabla.addCell(cell);
+        }
+    }
+
+    private void agregarCelda(PdfPTable tabla, String texto, Font font, Color bg, int align) {
+        PdfPCell cell = new PdfPCell(new Phrase(texto == null ? "" : texto, font));
+        cell.setBackgroundColor(bg);
+        cell.setPadding(3);
+        cell.setHorizontalAlignment(align);
+        tabla.addCell(cell);
+    }
+
+    private String formatoMonto(BigDecimal v) {
+        if (v == null || v.signum() == 0) return "";
+        return v.toPlainString();
+    }
+
+    // ─── Folio "Página X de Y" ─────────────────────────────────────────────
+
+    /**
+     * Event handler de OpenPDF que pinta el footer con folio "Página X de Y"
+     * al pie de cada página. SUDECA exige numeración de páginas continua.
+     */
+    private static class FolioFooter extends PdfPageEventHelper {
+        @Override
+        public void onEndPage(PdfWriter writer, Document doc) {
+            try {
+                PdfContentByte cb = writer.getDirectContent();
+                Phrase pieIzq = new Phrase("Libro Diario — Fatrans", FOOTER_FONT);
+                ColumnText.showTextAligned(cb, Element.ALIGN_LEFT, pieIzq,
+                        doc.left(), doc.bottom() - 15, 0);
+
+                Phrase pieDer = new Phrase(String.format("Página %d", writer.getPageNumber()), FOOTER_FONT);
+                ColumnText.showTextAligned(cb, Element.ALIGN_RIGHT, pieDer,
+                        doc.right(), doc.bottom() - 15, 0);
+            } catch (Exception e) {
+                // Defensive: el footer es cosmético — no romper la generación si falla.
+                log.warn("Error escribiendo footer del Libro Diario", e);
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/infrastructure/pdf/LibroDiarioPdfAdapter.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/infrastructure/pdf/LibroDiarioPdfAdapter.java
@@ -3,6 +3,7 @@ package com.tufondo.contabilidad.infrastructure.pdf;
 import com.lowagie.text.*;
 import com.lowagie.text.pdf.*;
 import com.tufondo.contabilidad.application.dto.LibroDiarioResponse;
+import com.tufondo.contabilidad.application.dto.LibroMayorResponse;
 import com.tufondo.contabilidad.application.port.output.ContabilidadPdfPort;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -202,6 +203,181 @@ public class LibroDiarioPdfAdapter implements ContabilidadPdfPort {
     private String formatoMonto(BigDecimal v) {
         if (v == null || v.signum() == 0) return "";
         return v.toPlainString();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // LIBRO MAYOR (sub-issue #270)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Override
+    public byte[] generarLibroMayorPdf(LibroMayorResponse libro) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            Document doc = new Document(PageSize.A4.rotate(), 30, 30, 40, 40);
+            PdfWriter writer = PdfWriter.getInstance(doc, baos);
+            writer.setPageEvent(new FolioFooterMayor());
+            doc.open();
+
+            // Encabezado
+            agregarEncabezadoMayor(doc, libro.encabezado());
+
+            // Una sección por cuenta
+            for (LibroMayorResponse.CuentaConMovimientos cuenta : libro.cuentas()) {
+                agregarSeccionCuenta(doc, cuenta);
+            }
+
+            // Totales generales al pie
+            agregarTotalesMayor(doc, libro.totales());
+
+            doc.close();
+            return baos.toByteArray();
+        } catch (Exception e) {
+            log.error("Error generando PDF Libro Mayor", e);
+            throw new RuntimeException("No se pudo generar el Libro Mayor: " + e.getMessage(), e);
+        }
+    }
+
+    private void agregarEncabezadoMayor(Document doc, LibroMayorResponse.Encabezado enc)
+            throws DocumentException {
+        Paragraph razon = new Paragraph(enc.razonSocial(), TITLE_FONT);
+        razon.setAlignment(Element.ALIGN_CENTER);
+        doc.add(razon);
+
+        Paragraph rif = new Paragraph("RIF: " + enc.rif(), SUBTITLE_FONT);
+        rif.setAlignment(Element.ALIGN_CENTER);
+        doc.add(rif);
+
+        Paragraph titulo = new Paragraph("LIBRO MAYOR", TITLE_FONT);
+        titulo.setAlignment(Element.ALIGN_CENTER);
+        titulo.setSpacingBefore(8);
+        doc.add(titulo);
+
+        String periodo = String.format("Período: %s al %s",
+                enc.desde().format(FECHA_FMT), enc.hasta().format(FECHA_FMT));
+        Paragraph per = new Paragraph(periodo, SUBTITLE_FONT);
+        per.setAlignment(Element.ALIGN_CENTER);
+        doc.add(per);
+
+        StringBuilder sub = new StringBuilder("Generado: ");
+        sub.append(enc.generadoEn().atZone(ZoneId.of("America/Caracas")).format(TS_FMT));
+        if (enc.filtroCuenta() != null && !enc.filtroCuenta().isBlank()) {
+            sub.append(" — Filtrado por cuenta ").append(enc.filtroCuenta());
+        }
+        Paragraph genP = new Paragraph(sub.toString(), FOOTER_FONT);
+        genP.setAlignment(Element.ALIGN_CENTER);
+        genP.setSpacingAfter(10);
+        doc.add(genP);
+    }
+
+    private void agregarSeccionCuenta(Document doc, LibroMayorResponse.CuentaConMovimientos cuenta)
+            throws DocumentException {
+        // Cabecera de la cuenta
+        String cabeceraCuenta = String.format("%s — %s   (%s, naturaleza %s)",
+                cuenta.codigo(), cuenta.nombre(), cuenta.tipo(), cuenta.naturaleza());
+        Paragraph cab = new Paragraph(cabeceraCuenta,
+                new Font(Font.HELVETICA, 10, Font.BOLD, new Color(20, 40, 100)));
+        cab.setSpacingBefore(10);
+        doc.add(cab);
+
+        // Saldo inicial
+        String saldoIni = String.format("Saldo inicial: %s %s",
+                formatoMonto(cuenta.saldoInicialNeto()), cuenta.saldoInicialEtiqueta());
+        Paragraph sIni = new Paragraph(saldoIni, ROW_FONT_BOLD);
+        doc.add(sIni);
+
+        // Tabla de movimientos
+        // Cols: Fecha | Nº Asiento | Origen | Contracuenta | Glosa | Debe | Haber | Saldo Acum
+        float[] anchos = {1.6f, 1.8f, 1.8f, 3.5f, 4.0f, 1.6f, 1.6f, 1.8f};
+        PdfPTable tabla = new PdfPTable(anchos);
+        tabla.setWidthPercentage(100);
+        tabla.setSpacingBefore(4);
+        agregarHeaderTabla(tabla,
+                "Fecha", "Nº Asiento", "Origen", "Contracuenta", "Glosa", "Debe", "Haber", "Saldo");
+
+        if (cuenta.movimientos().isEmpty()) {
+            // Fila única indicando "sin movimientos en el período"
+            PdfPCell vacia = new PdfPCell(new Phrase("(sin movimientos en el período)", ROW_FONT));
+            vacia.setColspan(8);
+            vacia.setHorizontalAlignment(Element.ALIGN_CENTER);
+            vacia.setPadding(6);
+            vacia.setBackgroundColor(Color.WHITE);
+            tabla.addCell(vacia);
+        } else {
+            for (LibroMayorResponse.MovimientoMayor m : cuenta.movimientos()) {
+                String contracuenta = m.contracuentaCodigo() + " " + m.contracuentaNombre();
+                if (m.contracuentaResumen() != null) {
+                    contracuenta = contracuenta + " " + m.contracuentaResumen();
+                }
+                agregarCelda(tabla, m.fechaContable().format(FECHA_FMT), ROW_FONT, Color.WHITE, Element.ALIGN_LEFT);
+                agregarCelda(tabla, m.numeroAsientoFormateado(), ROW_FONT, Color.WHITE, Element.ALIGN_LEFT);
+                agregarCelda(tabla, m.origen().name(), ROW_FONT, Color.WHITE, Element.ALIGN_LEFT);
+                agregarCelda(tabla, contracuenta, ROW_FONT, Color.WHITE, Element.ALIGN_LEFT);
+                agregarCelda(tabla, m.glosaAsiento() == null ? "" : m.glosaAsiento(),
+                        ROW_FONT, Color.WHITE, Element.ALIGN_LEFT);
+                agregarCelda(tabla, formatoMonto(m.debe()), ROW_FONT, Color.WHITE, Element.ALIGN_RIGHT);
+                agregarCelda(tabla, formatoMonto(m.haber()), ROW_FONT, Color.WHITE, Element.ALIGN_RIGHT);
+                // Saldo acumulado siempre con su signo (puede ser negativo si la cuenta
+                // tiene saldo contrario a su naturaleza)
+                String saldoStr = m.saldoAcumulado().abs().toPlainString();
+                if (m.saldoAcumulado().signum() < 0) saldoStr = "(" + saldoStr + ")";
+                agregarCelda(tabla, saldoStr, ROW_FONT_BOLD, Color.WHITE, Element.ALIGN_RIGHT);
+            }
+        }
+        doc.add(tabla);
+
+        // Totales del período de esta cuenta + saldo final
+        String resumen = String.format(
+                "Movimientos: %d  |  Σ Debe período = %s  |  Σ Haber período = %s",
+                cuenta.cantidadMovimientos(),
+                formatoMonto(cuenta.totalDebePeriodo()),
+                formatoMonto(cuenta.totalHaberPeriodo()));
+        Paragraph res = new Paragraph(resumen, ROW_FONT);
+        res.setSpacingBefore(2);
+        doc.add(res);
+
+        String saldoFin = String.format("Saldo final: %s %s",
+                formatoMonto(cuenta.saldoFinalNeto()), cuenta.saldoFinalEtiqueta());
+        Paragraph sFin = new Paragraph(saldoFin, ROW_FONT_BOLD);
+        sFin.setSpacingAfter(8);
+        doc.add(sFin);
+    }
+
+    private void agregarTotalesMayor(Document doc, LibroMayorResponse.Totales t) throws DocumentException {
+        Paragraph espacio = new Paragraph(" ");
+        espacio.setSpacingBefore(12);
+        doc.add(espacio);
+
+        PdfPTable totales = new PdfPTable(new float[]{12f, 2.0f, 2.0f});
+        totales.setWidthPercentage(100);
+
+        String resumen = String.format(
+                "TOTALES GENERALES — %d cuentas | %d movimientos | %s",
+                t.cantidadCuentas(), t.cantidadMovimientos(),
+                t.balanceado() ? "BALANCEADO ✓" : "⚠ DESBALANCEADO");
+        Font totalFont = t.balanceado() ? ROW_FONT_BOLD
+                : new Font(Font.HELVETICA, 10, Font.BOLD, Color.RED);
+        agregarCelda(totales, resumen, totalFont, Color.WHITE, Element.ALIGN_LEFT);
+        agregarCelda(totales, formatoMonto(t.totalDebe()), ROW_FONT_BOLD, Color.WHITE, Element.ALIGN_RIGHT);
+        agregarCelda(totales, formatoMonto(t.totalHaber()), ROW_FONT_BOLD, Color.WHITE, Element.ALIGN_RIGHT);
+        doc.add(totales);
+    }
+
+    /** Footer del Libro Mayor (subclase del de Diario para reutilizar). */
+    private static class FolioFooterMayor extends PdfPageEventHelper {
+        @Override
+        public void onEndPage(PdfWriter writer, Document doc) {
+            try {
+                PdfContentByte cb = writer.getDirectContent();
+                Phrase pieIzq = new Phrase("Libro Mayor — Fatrans", FOOTER_FONT);
+                ColumnText.showTextAligned(cb, Element.ALIGN_LEFT, pieIzq,
+                        doc.left(), doc.bottom() - 15, 0);
+                Phrase pieDer = new Phrase(String.format("Página %d", writer.getPageNumber()), FOOTER_FONT);
+                ColumnText.showTextAligned(cb, Element.ALIGN_RIGHT, pieDer,
+                        doc.right(), doc.bottom() - 15, 0);
+            } catch (Exception e) {
+                log.warn("Error escribiendo footer del Libro Mayor", e);
+            }
+        }
     }
 
     // ─── Folio "Página X de Y" ─────────────────────────────────────────────

--- a/backend/src/main/java/com/tufondo/contabilidad/infrastructure/persistence/adapter/AsientoContableRepositoryImpl.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/infrastructure/persistence/adapter/AsientoContableRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.tufondo.contabilidad.infrastructure.persistence.adapter;
 
 import com.tufondo.contabilidad.domain.model.AsientoContable;
+import com.tufondo.contabilidad.domain.model.SaldoCuenta;
 import com.tufondo.contabilidad.domain.model.enums.EstadoAsiento;
 import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
 import com.tufondo.contabilidad.domain.repository.AsientoContableRepository;
@@ -8,10 +9,13 @@ import com.tufondo.contabilidad.infrastructure.persistence.entity.AsientoContabl
 import com.tufondo.contabilidad.infrastructure.persistence.entity.PartidaAsientoEntity;
 import com.tufondo.contabilidad.infrastructure.persistence.jpa.AsientoContableJpaRepository;
 import com.tufondo.contabilidad.infrastructure.persistence.jpa.PartidaAsientoJpaRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashMap;
@@ -35,6 +39,10 @@ public class AsientoContableRepositoryImpl implements AsientoContableRepository 
 
     private final AsientoContableJpaRepository asientoJpa;
     private final PartidaAsientoJpaRepository partidaJpa;
+
+    /** EntityManager para las queries nativas del Libro Mayor (#270). */
+    @PersistenceContext
+    private EntityManager em;
 
     @Override
     @Transactional
@@ -116,6 +124,77 @@ public class AsientoContableRepositoryImpl implements AsientoContableRepository 
     @Transactional(readOnly = true)
     public long contar() {
         return asientoJpa.count();
+    }
+
+    // ─── Queries para el Libro Mayor (#270) ────────────────────────────────
+
+    @Override
+    @Transactional(readOnly = true)
+    public SaldoCuenta calcularSaldoCuentaHasta(UUID cuentaId, LocalDate fechaCorte) {
+        // Native SQL: SUM agregado en una sola query. Excluye ANULADOS.
+        // COALESCE para devolver 0 si no hay filas (cuenta sin movimientos).
+        Object[] row = (Object[]) em.createNativeQuery(
+                "SELECT COALESCE(SUM(p.debe), 0) AS total_debe, " +
+                "       COALESCE(SUM(p.haber), 0) AS total_haber " +
+                "FROM partidas_asientos p " +
+                "JOIN asientos_contables a ON a.id = p.asiento_id " +
+                "WHERE p.cuenta_id = :cuentaId " +
+                "  AND a.fecha_contable <= :fechaCorte " +
+                "  AND a.estado = 'REGISTRADO'")
+                .setParameter("cuentaId", cuentaId)
+                .setParameter("fechaCorte", fechaCorte)
+                .getSingleResult();
+
+        BigDecimal totalDebe  = toBigDecimal(row[0]);
+        BigDecimal totalHaber = toBigDecimal(row[1]);
+        return new SaldoCuenta(totalDebe, totalHaber);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AsientoContable> listarAsientosDeCuentaEnRango(
+            UUID cuentaId, LocalDate desde, LocalDate hasta) {
+
+        // 1. Identificar IDs de los asientos REGISTRADOS que tocaron esa cuenta.
+        //    Native SQL con DISTINCT para evitar duplicados si la cuenta aparece
+        //    más de una vez en el asiento (cosa rara pero posible si está en
+        //    ambos lados — lo que el dominio permite).
+        @SuppressWarnings("unchecked")
+        List<UUID> asientoIds = em.createNativeQuery(
+                "SELECT DISTINCT a.id " +
+                "FROM asientos_contables a " +
+                "JOIN partidas_asientos p ON p.asiento_id = a.id " +
+                "WHERE p.cuenta_id = :cuentaId " +
+                "  AND a.fecha_contable BETWEEN :desde AND :hasta " +
+                "  AND a.estado = 'REGISTRADO' " +
+                "ORDER BY a.id")
+                .setParameter("cuentaId", cuentaId)
+                .setParameter("desde", desde)
+                .setParameter("hasta", hasta)
+                .getResultList();
+
+        if (asientoIds.isEmpty()) return List.of();
+
+        // 2. Cargar las cabeceras de esos asientos en una sola query JPA
+        //    + hidratar con todas sus partidas (batch).
+        List<AsientoContableEntity> cabeceras = asientoJpa.findAllById(asientoIds);
+        // Ordenar por fechaContable asc, numero asc (no se garantiza por findAllById)
+        cabeceras.sort((a, b) -> {
+            int byFecha = a.getFechaContable().compareTo(b.getFechaContable());
+            if (byFecha != 0) return byFecha;
+            return Long.compare(
+                    a.getNumero() == null ? 0L : a.getNumero(),
+                    b.getNumero() == null ? 0L : b.getNumero());
+        });
+        return hidratarConPartidas(cabeceras);
+    }
+
+    /** Convierte el valor crudo de la BD (puede venir Number o BigDecimal) a BigDecimal. */
+    private static BigDecimal toBigDecimal(Object raw) {
+        if (raw == null) return BigDecimal.ZERO;
+        if (raw instanceof BigDecimal bd) return bd;
+        if (raw instanceof Number n) return new BigDecimal(n.toString());
+        return new BigDecimal(raw.toString());
     }
 
     /**

--- a/backend/src/test/java/com/tufondo/contabilidad/application/dto/LibroDiarioFilterTest.java
+++ b/backend/src/test/java/com/tufondo/contabilidad/application/dto/LibroDiarioFilterTest.java
@@ -1,0 +1,85 @@
+package com.tufondo.contabilidad.application.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests del DTO {@link LibroDiarioFilter} — validaciones de rango.
+ */
+class LibroDiarioFilterTest {
+
+    @Test
+    @DisplayName("filtro válido (1 mes) → OK")
+    void filtro_un_mes_valido() {
+        var f = new LibroDiarioFilter(
+                LocalDate.of(2026, 5, 1),
+                LocalDate.of(2026, 5, 31),
+                true);
+        assertThat(f.desde()).isEqualTo(LocalDate.of(2026, 5, 1));
+        assertThat(f.hasta()).isEqualTo(LocalDate.of(2026, 5, 31));
+        assertThat(f.incluirAnulados()).isTrue();
+    }
+
+    @Test
+    @DisplayName("filtro 366 días (año bisiesto) → OK (límite máximo)")
+    void rango_366_dias_es_aceptado() {
+        // 2024 fue bisiesto: 366 días entre 2024-01-01 y 2024-12-31 = 365 días.
+        // Verifico el máximo absoluto del constructor (366).
+        var f = new LibroDiarioFilter(
+                LocalDate.of(2026, 1, 1),
+                LocalDate.of(2027, 1, 2),  // exactamente 366 días después
+                true);
+        assertThat(f).isNotNull();
+    }
+
+    @Test
+    @DisplayName("rango > 366 días → rechazado")
+    void rango_excesivo_rechazado() {
+        assertThatThrownBy(() -> new LibroDiarioFilter(
+                LocalDate.of(2026, 1, 1),
+                LocalDate.of(2028, 1, 1),  // 2 años
+                true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("excede el máximo");
+    }
+
+    @Test
+    @DisplayName("hasta < desde → rechazado")
+    void rango_invertido_rechazado() {
+        assertThatThrownBy(() -> new LibroDiarioFilter(
+                LocalDate.of(2026, 5, 31),
+                LocalDate.of(2026, 5, 1),
+                true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("anterior");
+    }
+
+    @Test
+    @DisplayName("desde o hasta null → rechazado")
+    void fechas_null_rechazado() {
+        assertThatThrownBy(() -> new LibroDiarioFilter(null, LocalDate.now(), true))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new LibroDiarioFilter(LocalDate.now(), null, true))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("factory de() crea filtro con incluirAnulados=true")
+    void factory_de_default() {
+        var f = LibroDiarioFilter.de(LocalDate.now().minusDays(7), LocalDate.now());
+        assertThat(f.incluirAnulados()).isTrue();
+    }
+
+    @Test
+    @DisplayName("desde = hasta (mismo día) → OK (período de 1 día)")
+    void rango_un_dia_valido() {
+        var d = LocalDate.of(2026, 5, 20);
+        var f = new LibroDiarioFilter(d, d, false);
+        assertThat(f.desde()).isEqualTo(f.hasta());
+    }
+}

--- a/backend/src/test/java/com/tufondo/contabilidad/application/dto/LibroMayorFilterTest.java
+++ b/backend/src/test/java/com/tufondo/contabilidad/application/dto/LibroMayorFilterTest.java
@@ -1,0 +1,91 @@
+package com.tufondo.contabilidad.application.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LibroMayorFilterTest {
+
+    @Test
+    @DisplayName("filtro válido 1 mes — todos los flags default")
+    void filtro_valido_completo() {
+        var f = LibroMayorFilter.completo(
+                LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 31));
+        assertThat(f.codigoCuenta()).isNull();
+        assertThat(f.incluirSinMovimientos()).isFalse();
+        assertThat(f.incluirTotalizadoras()).isFalse();
+        assertThat(f.filtraPorCuenta()).isFalse();
+    }
+
+    @Test
+    @DisplayName("filtro por cuenta específica — flag detectado")
+    void filtro_por_cuenta_detectado() {
+        var f = LibroMayorFilter.deCuenta(
+                LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 31), "1.1.03");
+        assertThat(f.filtraPorCuenta()).isTrue();
+        assertThat(f.incluirSinMovimientos()).isTrue();
+    }
+
+    @Test
+    @DisplayName("codigoCuenta null y vacío se tratan igual (no filtra)")
+    void codigo_null_y_vacio_no_filtran() {
+        var f1 = new LibroMayorFilter(LocalDate.now().minusDays(7), LocalDate.now(), null, false, false);
+        var f2 = new LibroMayorFilter(LocalDate.now().minusDays(7), LocalDate.now(), "", false, false);
+        var f3 = new LibroMayorFilter(LocalDate.now().minusDays(7), LocalDate.now(), "   ", false, false);
+        assertThat(f1.filtraPorCuenta()).isFalse();
+        assertThat(f2.filtraPorCuenta()).isFalse();
+        assertThat(f3.filtraPorCuenta()).isFalse();
+    }
+
+    @Test
+    @DisplayName("rango > 366 días → rechazado")
+    void rango_excesivo_rechazado() {
+        assertThatThrownBy(() -> new LibroMayorFilter(
+                LocalDate.of(2026, 1, 1), LocalDate.of(2028, 1, 1),
+                null, false, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("excede el máximo");
+    }
+
+    @Test
+    @DisplayName("hasta < desde → rechazado")
+    void rango_invertido_rechazado() {
+        assertThatThrownBy(() -> new LibroMayorFilter(
+                LocalDate.of(2026, 5, 31), LocalDate.of(2026, 5, 1),
+                null, false, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("anterior");
+    }
+
+    @Test
+    @DisplayName("fechas null → rechazadas")
+    void fechas_null_rechazadas() {
+        assertThatThrownBy(() -> new LibroMayorFilter(null, LocalDate.now(), null, false, false))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new LibroMayorFilter(LocalDate.now(), null, null, false, false))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("rango exactamente 366 días (año bisiesto) → OK")
+    void rango_limite_366_aceptado() {
+        var f = new LibroMayorFilter(
+                LocalDate.of(2026, 1, 1), LocalDate.of(2027, 1, 2),  // 366 días
+                null, false, false);
+        assertThat(f).isNotNull();
+    }
+
+    @Test
+    @DisplayName("flags incluirSinMovimientos / incluirTotalizadoras se almacenan")
+    void flags_se_almacenan() {
+        var f = new LibroMayorFilter(
+                LocalDate.now().minusDays(7), LocalDate.now(),
+                null, true, true);
+        assertThat(f.incluirSinMovimientos()).isTrue();
+        assertThat(f.incluirTotalizadoras()).isTrue();
+    }
+}

--- a/backend/src/test/java/com/tufondo/contabilidad/application/usecase/GenerarLibroDiarioUseCaseTest.java
+++ b/backend/src/test/java/com/tufondo/contabilidad/application/usecase/GenerarLibroDiarioUseCaseTest.java
@@ -1,0 +1,249 @@
+package com.tufondo.contabilidad.application.usecase;
+
+import com.tufondo.contabilidad.application.config.EntidadProperties;
+import com.tufondo.contabilidad.application.dto.LibroDiarioFilter;
+import com.tufondo.contabilidad.application.dto.LibroDiarioResponse;
+import com.tufondo.contabilidad.domain.model.AsientoContable;
+import com.tufondo.contabilidad.domain.model.CuentaContable;
+import com.tufondo.contabilidad.domain.model.PartidaAsiento;
+import com.tufondo.contabilidad.domain.model.enums.EstadoAsiento;
+import com.tufondo.contabilidad.domain.model.enums.NaturalezaSaldo;
+import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
+import com.tufondo.contabilidad.domain.model.enums.TipoCuentaContable;
+import com.tufondo.contabilidad.domain.repository.AsientoContableRepository;
+import com.tufondo.contabilidad.domain.repository.CuentaContableRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests del {@link GenerarLibroDiarioUseCase} (sub-issue #269).
+ *
+ * <p>Foco: filtros funcionan, totales correctos, asientos anulados se manejan
+ * según parámetro, plan de cuentas se resuelve para mostrar nombres, formato
+ * de número correcto.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class GenerarLibroDiarioUseCaseTest {
+
+    @Mock private AsientoContableRepository asientoRepo;
+    @Mock private CuentaContableRepository cuentaRepo;
+
+    @InjectMocks private GenerarLibroDiarioUseCase useCase;
+
+    private CuentaContable caja;
+    private CuentaContable depositos;
+    private AsientoContable asientoRegistrado;
+    private AsientoContable asientoAnulado;
+    private LocalDate desde = LocalDate.of(2026, 5, 1);
+    private LocalDate hasta = LocalDate.of(2026, 5, 31);
+
+    @BeforeEach
+    void setUp() {
+        // Inyecto EntidadProperties manualmente porque @InjectMocks no lo crea
+        // (no es mock, es un POJO de propiedades). Reemplazo el constructor.
+        EntidadProperties props = new EntidadProperties();
+        props.setRazonSocial("Fatrans Test");
+        props.setRif("J-TEST-0");
+        useCase = new GenerarLibroDiarioUseCase(asientoRepo, cuentaRepo, props);
+
+        caja = CuentaContable.crear(
+                "1.1.03", "Bancos Cta Corriente Bs",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA,
+                UUID.randomUUID(), true, null);
+        depositos = CuentaContable.crear(
+                "2.1.01", "Cuentas de Ahorro Bs",
+                TipoCuentaContable.PASIVO, NaturalezaSaldo.ACREEDORA,
+                UUID.randomUUID(), true, null);
+
+        // Asiento REGISTRADO con número 1 → "2026-000001"
+        asientoRegistrado = AsientoContable.reconstruir(
+                UUID.randomUUID(), 1L,
+                LocalDate.of(2026, 5, 10), "Depósito test",
+                OrigenAsiento.AHORRO_DEPOSITO, "MOV-001",
+                EstadoAsiento.REGISTRADO, null, null, null,
+                List.of(
+                        PartidaAsiento.alDebe(caja.getId(), new BigDecimal("100.00"), 1, "DEBE"),
+                        PartidaAsiento.alHaber(depositos.getId(), new BigDecimal("100.00"), 2, "HABER")
+                ),
+                null, null, 0L);
+
+        // Asiento ANULADO con número 2 → "2026-000002"
+        asientoAnulado = AsientoContable.reconstruir(
+                UUID.randomUUID(), 2L,
+                LocalDate.of(2026, 5, 15), "Depósito que se anuló",
+                OrigenAsiento.AHORRO_DEPOSITO, "MOV-002",
+                EstadoAsiento.ANULADO, null, "Error en monto", null,
+                List.of(
+                        PartidaAsiento.alDebe(caja.getId(), new BigDecimal("200.00"), 1, null),
+                        PartidaAsiento.alHaber(depositos.getId(), new BigDecimal("200.00"), 2, null)
+                ),
+                null, null, 0L);
+
+        when(cuentaRepo.listarTodas()).thenReturn(List.of(caja, depositos));
+    }
+
+    // ─── Happy path ────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("período con 1 asiento → totales y partidas correctos")
+    void happy_path_un_asiento() {
+        when(asientoRepo.listarPorRangoFecha(desde, hasta))
+                .thenReturn(List.of(asientoRegistrado));
+
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, true), UUID.randomUUID());
+
+        assertThat(resp.asientos()).hasSize(1);
+        assertThat(resp.totales().cantidadAsientos()).isEqualTo(1);
+        assertThat(resp.totales().cantidadAnulados()).isZero();
+        assertThat(resp.totales().totalDebe()).isEqualByComparingTo("100.00");
+        assertThat(resp.totales().totalHaber()).isEqualByComparingTo("100.00");
+        assertThat(resp.totales().balanceado()).isTrue();
+    }
+
+    @Test
+    @DisplayName("encabezado incluye razón social, RIF y rango")
+    void encabezado_completo() {
+        when(asientoRepo.listarPorRangoFecha(desde, hasta)).thenReturn(List.of());
+
+        UUID solicitante = UUID.randomUUID();
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, true), solicitante);
+
+        assertThat(resp.encabezado().razonSocial()).isEqualTo("Fatrans Test");
+        assertThat(resp.encabezado().rif()).isEqualTo("J-TEST-0");
+        assertThat(resp.encabezado().desde()).isEqualTo(desde);
+        assertThat(resp.encabezado().hasta()).isEqualTo(hasta);
+        assertThat(resp.encabezado().generadoPorUsuarioId()).isEqualTo(solicitante);
+        assertThat(resp.encabezado().incluyeAnulados()).isTrue();
+        assertThat(resp.encabezado().generadoEn()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("partidas se renderizan con código + nombre de cuenta resuelto")
+    void partidas_resuelven_nombre_cuenta() {
+        when(asientoRepo.listarPorRangoFecha(desde, hasta))
+                .thenReturn(List.of(asientoRegistrado));
+
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, true), UUID.randomUUID());
+
+        LibroDiarioResponse.AsientoDiario a = resp.asientos().get(0);
+        assertThat(a.partidas()).hasSize(2);
+        // DEBE
+        assertThat(a.partidas().get(0).codigoCuenta()).isEqualTo("1.1.03");
+        assertThat(a.partidas().get(0).nombreCuenta()).isEqualTo("Bancos Cta Corriente Bs");
+        assertThat(a.partidas().get(0).debe()).isEqualByComparingTo("100.00");
+        // HABER
+        assertThat(a.partidas().get(1).codigoCuenta()).isEqualTo("2.1.01");
+        assertThat(a.partidas().get(1).nombreCuenta()).isEqualTo("Cuentas de Ahorro Bs");
+        assertThat(a.partidas().get(1).haber()).isEqualByComparingTo("100.00");
+    }
+
+    // ─── Anulados ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("incluirAnulados=true → incluye ambos asientos y cuenta los anulados")
+    void incluye_anulados_true() {
+        when(asientoRepo.listarPorRangoFecha(desde, hasta))
+                .thenReturn(List.of(asientoRegistrado, asientoAnulado));
+
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, true), UUID.randomUUID());
+
+        assertThat(resp.asientos()).hasSize(2);
+        assertThat(resp.totales().cantidadAsientos()).isEqualTo(2);
+        assertThat(resp.totales().cantidadAnulados()).isEqualTo(1);
+        assertThat(resp.totales().totalDebe()).isEqualByComparingTo("300.00");
+        assertThat(resp.totales().totalHaber()).isEqualByComparingTo("300.00");
+    }
+
+    @Test
+    @DisplayName("incluirAnulados=false → filtra los ANULADOS")
+    void incluye_anulados_false() {
+        when(asientoRepo.listarPorRangoFecha(desde, hasta))
+                .thenReturn(List.of(asientoRegistrado, asientoAnulado));
+
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, false), UUID.randomUUID());
+
+        assertThat(resp.asientos()).hasSize(1);
+        assertThat(resp.totales().cantidadAnulados()).isZero();
+        assertThat(resp.totales().totalDebe()).isEqualByComparingTo("100.00");
+    }
+
+    @Test
+    @DisplayName("asiento anulado mantiene motivoAnulacion visible")
+    void asiento_anulado_expone_motivo() {
+        when(asientoRepo.listarPorRangoFecha(desde, hasta))
+                .thenReturn(List.of(asientoAnulado));
+
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, true), UUID.randomUUID());
+
+        LibroDiarioResponse.AsientoDiario a = resp.asientos().get(0);
+        assertThat(a.estado()).isEqualTo(EstadoAsiento.ANULADO);
+        assertThat(a.motivoAnulacion()).isEqualTo("Error en monto");
+    }
+
+    // ─── Formato del número correlativo ────────────────────────────────────
+
+    @Test
+    @DisplayName("numeroFormateado usa formato AÑO-NNNNNN")
+    void numero_formateado_anio_y_seis_digitos() {
+        when(asientoRepo.listarPorRangoFecha(desde, hasta))
+                .thenReturn(List.of(asientoRegistrado));
+
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, true), UUID.randomUUID());
+
+        assertThat(resp.asientos().get(0).numeroFormateado()).isEqualTo("2026-000001");
+    }
+
+    // ─── Casos borde ───────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("período sin asientos → response vacío balanceado en cero")
+    void periodo_vacio() {
+        when(asientoRepo.listarPorRangoFecha(desde, hasta)).thenReturn(List.of());
+
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, true), UUID.randomUUID());
+
+        assertThat(resp.asientos()).isEmpty();
+        assertThat(resp.totales().cantidadAsientos()).isZero();
+        assertThat(resp.totales().totalDebe()).isEqualByComparingTo("0");
+        assertThat(resp.totales().totalHaber()).isEqualByComparingTo("0");
+        assertThat(resp.totales().balanceado()).isTrue();  // 0 = 0
+    }
+
+    @Test
+    @DisplayName("cuenta no encontrada en plan → fallback al UUID (no crashea)")
+    void cuenta_faltante_no_rompe() {
+        // Devolver plan vacío para forzar el fallback
+        when(cuentaRepo.listarTodas()).thenReturn(List.of());
+        when(asientoRepo.listarPorRangoFecha(desde, hasta))
+                .thenReturn(List.of(asientoRegistrado));
+
+        LibroDiarioResponse resp = useCase.ejecutar(
+                new LibroDiarioFilter(desde, hasta, true), UUID.randomUUID());
+
+        // El reporte se genera, pero las partidas tienen el nombre fallback
+        LibroDiarioResponse.PartidaDiario p = resp.asientos().get(0).partidas().get(0);
+        assertThat(p.nombreCuenta()).contains("CUENTA DESCONOCIDA");
+        assertThat(p.codigoCuenta()).isEqualTo("???");
+    }
+}

--- a/backend/src/test/java/com/tufondo/contabilidad/application/usecase/GenerarLibroMayorUseCaseTest.java
+++ b/backend/src/test/java/com/tufondo/contabilidad/application/usecase/GenerarLibroMayorUseCaseTest.java
@@ -1,0 +1,329 @@
+package com.tufondo.contabilidad.application.usecase;
+
+import com.tufondo.contabilidad.application.config.EntidadProperties;
+import com.tufondo.contabilidad.application.dto.LibroMayorFilter;
+import com.tufondo.contabilidad.application.dto.LibroMayorResponse;
+import com.tufondo.contabilidad.application.exception.AsientoContableException;
+import com.tufondo.contabilidad.domain.model.AsientoContable;
+import com.tufondo.contabilidad.domain.model.CuentaContable;
+import com.tufondo.contabilidad.domain.model.PartidaAsiento;
+import com.tufondo.contabilidad.domain.model.SaldoCuenta;
+import com.tufondo.contabilidad.domain.model.enums.EstadoAsiento;
+import com.tufondo.contabilidad.domain.model.enums.NaturalezaSaldo;
+import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
+import com.tufondo.contabilidad.domain.model.enums.TipoCuentaContable;
+import com.tufondo.contabilidad.domain.repository.AsientoContableRepository;
+import com.tufondo.contabilidad.domain.repository.CuentaContableRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests del {@link GenerarLibroMayorUseCase} (sub-issue #270).
+ *
+ * <p>Cobertura: filtros por cuenta, saldo inicial real, contracuenta resuelta,
+ * cuentas sin movimientos (incluir/no incluir), totalizadoras, etiqueta D/A,
+ * saldo acumulado, asientos ANULADOS excluidos por repo.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class GenerarLibroMayorUseCaseTest {
+
+    @Mock private AsientoContableRepository asientoRepo;
+    @Mock private CuentaContableRepository cuentaRepo;
+
+    @InjectMocks private GenerarLibroMayorUseCase useCase;
+
+    private CuentaContable bancos;    // 1.1.03 ACTIVO/DEUDORA  (hoja)
+    private CuentaContable ahorros;   // 2.1.01 PASIVO/ACREEDORA (hoja)
+    private CuentaContable totalizadora;  // 1.1 (no acepta movimientos)
+
+    private final LocalDate desde = LocalDate.of(2026, 5, 1);
+    private final LocalDate hasta = LocalDate.of(2026, 5, 31);
+
+    @BeforeEach
+    void setUp() {
+        EntidadProperties props = new EntidadProperties();
+        props.setRazonSocial("Fatrans Test");
+        props.setRif("J-TEST-0");
+        useCase = new GenerarLibroMayorUseCase(asientoRepo, cuentaRepo, props);
+
+        // Cuenta hoja activa (DEUDORA)
+        bancos = CuentaContable.crear(
+                "1.1.03", "Bancos Cta Corriente Bs",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA,
+                UUID.randomUUID(), true, null);
+
+        // Cuenta hoja pasiva (ACREEDORA)
+        ahorros = CuentaContable.crear(
+                "2.1.01", "Cuentas de Ahorro Bs",
+                TipoCuentaContable.PASIVO, NaturalezaSaldo.ACREEDORA,
+                UUID.randomUUID(), true, null);
+
+        // Cuenta totalizadora (no acepta movimientos)
+        totalizadora = CuentaContable.crear(
+                "1.1", "ACTIVO DISPONIBLE",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA,
+                UUID.randomUUID(), false, null);
+
+        // Index global para resolver contracuentas
+        lenient().when(cuentaRepo.listarTodas()).thenReturn(List.of(bancos, ahorros, totalizadora));
+    }
+
+    // ─── Filtros ───────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("sin filtro: incluye todas las cuentas hoja (excluye totalizadora)")
+    void sin_filtro_solo_hojas() {
+        // Simular ningún movimiento — cada cuenta hoja: saldo cero, sin movimientos
+        when(asientoRepo.calcularSaldoCuentaHasta(any(), any())).thenReturn(SaldoCuenta.cero());
+        when(asientoRepo.listarAsientosDeCuentaEnRango(any(), any(), any())).thenReturn(List.of());
+
+        LibroMayorResponse resp = useCase.ejecutar(
+                LibroMayorFilter.completo(desde, hasta), UUID.randomUUID());
+
+        // No incluyeSinMovimientos default → cuentas vacías filtradas
+        assertThat(resp.cuentas()).isEmpty();
+        assertThat(resp.totales().cantidadCuentas()).isZero();
+    }
+
+    @Test
+    @DisplayName("incluirSinMovimientos=true: muestra hojas aunque no tengan movimientos")
+    void incluir_sin_movimientos_muestra_hojas_vacias() {
+        when(asientoRepo.calcularSaldoCuentaHasta(any(), any())).thenReturn(SaldoCuenta.cero());
+        when(asientoRepo.listarAsientosDeCuentaEnRango(any(), any(), any())).thenReturn(List.of());
+
+        LibroMayorResponse resp = useCase.ejecutar(
+                new LibroMayorFilter(desde, hasta, null, true, false), UUID.randomUUID());
+
+        // 2 cuentas hoja sin la totalizadora
+        assertThat(resp.cuentas()).hasSize(2);
+        assertThat(resp.cuentas()).extracting(LibroMayorResponse.CuentaConMovimientos::codigo)
+                .containsExactly("1.1.03", "2.1.01"); // ordenadas por código
+    }
+
+    @Test
+    @DisplayName("incluirTotalizadoras=true: muestra cuentas no-hoja también")
+    void incluir_totalizadoras() {
+        when(asientoRepo.calcularSaldoCuentaHasta(any(), any())).thenReturn(SaldoCuenta.cero());
+        when(asientoRepo.listarAsientosDeCuentaEnRango(any(), any(), any())).thenReturn(List.of());
+
+        LibroMayorResponse resp = useCase.ejecutar(
+                new LibroMayorFilter(desde, hasta, null, true, true), UUID.randomUUID());
+
+        // 3 cuentas (incluida la totalizadora "1.1")
+        assertThat(resp.cuentas()).hasSize(3);
+        assertThat(resp.cuentas()).extracting(LibroMayorResponse.CuentaConMovimientos::codigo)
+                .containsExactly("1.1", "1.1.03", "2.1.01");
+    }
+
+    @Test
+    @DisplayName("filtro por código de cuenta: solo esa cuenta procesada")
+    void filtro_por_codigo() {
+        when(cuentaRepo.buscarPorCodigo("1.1.03")).thenReturn(Optional.of(bancos));
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(bancos.getId()), any())).thenReturn(SaldoCuenta.cero());
+        when(asientoRepo.listarAsientosDeCuentaEnRango(eq(bancos.getId()), any(), any()))
+                .thenReturn(List.of());
+
+        LibroMayorResponse resp = useCase.ejecutar(
+                LibroMayorFilter.deCuenta(desde, hasta, "1.1.03"), UUID.randomUUID());
+
+        assertThat(resp.cuentas()).hasSize(1);
+        assertThat(resp.cuentas().get(0).codigo()).isEqualTo("1.1.03");
+    }
+
+    @Test
+    @DisplayName("filtro por código inexistente → AsientoContableException")
+    void filtro_codigo_inexistente() {
+        when(cuentaRepo.buscarPorCodigo("9.9.99")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.ejecutar(
+                LibroMayorFilter.deCuenta(desde, hasta, "9.9.99"), UUID.randomUUID()))
+                .isInstanceOf(AsientoContableException.class)
+                .hasMessageContaining("9.9.99");
+    }
+
+    // ─── Saldo inicial real ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("saldo inicial se calcula con calcularSaldoCuentaHasta(desde-1)")
+    void saldo_inicial_pre_periodo() {
+        // Banco arranca con saldo inicial 1000 D (totalDebe=1000, totalHaber=0)
+        SaldoCuenta sIni = new SaldoCuenta(new BigDecimal("1000.00"), BigDecimal.ZERO);
+        when(cuentaRepo.buscarPorCodigo("1.1.03")).thenReturn(Optional.of(bancos));
+        when(asientoRepo.calcularSaldoCuentaHasta(bancos.getId(), desde.minusDays(1)))
+                .thenReturn(sIni);
+        when(asientoRepo.listarAsientosDeCuentaEnRango(bancos.getId(), desde, hasta))
+                .thenReturn(List.of());
+
+        LibroMayorResponse resp = useCase.ejecutar(
+                LibroMayorFilter.deCuenta(desde, hasta, "1.1.03"), UUID.randomUUID());
+
+        var c = resp.cuentas().get(0);
+        assertThat(c.saldoInicialDebe()).isEqualByComparingTo("1000.00");
+        assertThat(c.saldoInicialHaber()).isEqualByComparingTo("0");
+        assertThat(c.saldoInicialNeto()).isEqualByComparingTo("1000.00");
+        assertThat(c.saldoInicialEtiqueta()).isEqualTo("D");
+    }
+
+    @Test
+    @DisplayName("etiqueta saldo: cero → '—', positivo en deudora → 'D', acreedora → 'A'")
+    void etiqueta_saldo_segun_naturaleza() {
+        assertThat(GenerarLibroMayorUseCase.etiquetaSaldo(BigDecimal.ZERO, NaturalezaSaldo.DEUDORA))
+                .isEqualTo("—");
+        assertThat(GenerarLibroMayorUseCase.etiquetaSaldo(new BigDecimal("100"), NaturalezaSaldo.DEUDORA))
+                .isEqualTo("D");
+        assertThat(GenerarLibroMayorUseCase.etiquetaSaldo(new BigDecimal("100"), NaturalezaSaldo.ACREEDORA))
+                .isEqualTo("A");
+        // Casos atípicos: saldo opuesto al esperado por su naturaleza
+        assertThat(GenerarLibroMayorUseCase.etiquetaSaldo(new BigDecimal("-50"), NaturalezaSaldo.DEUDORA))
+                .isEqualTo("A");
+        assertThat(GenerarLibroMayorUseCase.etiquetaSaldo(new BigDecimal("-50"), NaturalezaSaldo.ACREEDORA))
+                .isEqualTo("D");
+    }
+
+    // ─── Movimientos y contracuenta ────────────────────────────────────────
+
+    @Test
+    @DisplayName("asiento con 2 partidas: contracuenta = la otra cuenta del asiento")
+    void contracuenta_dos_partidas() {
+        // Asiento: DEBE bancos 500 / HABER ahorros 500 (depósito típico)
+        AsientoContable a = asientoCon2Partidas(1L,
+                bancos.getId(), new BigDecimal("500.00"),
+                ahorros.getId(), new BigDecimal("500.00"));
+
+        when(cuentaRepo.buscarPorCodigo("1.1.03")).thenReturn(Optional.of(bancos));
+        when(asientoRepo.calcularSaldoCuentaHasta(bancos.getId(), desde.minusDays(1)))
+                .thenReturn(SaldoCuenta.cero());
+        when(asientoRepo.listarAsientosDeCuentaEnRango(bancos.getId(), desde, hasta))
+                .thenReturn(List.of(a));
+
+        LibroMayorResponse resp = useCase.ejecutar(
+                LibroMayorFilter.deCuenta(desde, hasta, "1.1.03"), UUID.randomUUID());
+
+        var movs = resp.cuentas().get(0).movimientos();
+        assertThat(movs).hasSize(1);
+        var m = movs.get(0);
+        assertThat(m.debe()).isEqualByComparingTo("500.00");
+        assertThat(m.haber()).isEqualByComparingTo("0");
+        assertThat(m.contracuentaCodigo()).isEqualTo("2.1.01");
+        assertThat(m.contracuentaNombre()).isEqualTo("Cuentas de Ahorro Bs");
+        assertThat(m.contracuentaResumen()).isNull(); // no es "múltiple"
+    }
+
+    @Test
+    @DisplayName("saldo acumulado se calcula correctamente movimiento a movimiento")
+    void saldo_acumulado_progresivo() {
+        // Banco: saldo inicial = 100 D
+        // Mov 1: DEBE 50 → saldo 150 D
+        // Mov 2: HABER 30 → saldo 120 D
+        AsientoContable a1 = asientoCon2Partidas(1L,
+                bancos.getId(), new BigDecimal("50.00"),
+                ahorros.getId(), new BigDecimal("50.00"));
+        AsientoContable a2 = asientoCon2Partidas(2L,
+                ahorros.getId(), new BigDecimal("30.00"),  // banco va al HABER
+                bancos.getId(), new BigDecimal("30.00"));
+
+        when(cuentaRepo.buscarPorCodigo("1.1.03")).thenReturn(Optional.of(bancos));
+        when(asientoRepo.calcularSaldoCuentaHasta(bancos.getId(), desde.minusDays(1)))
+                .thenReturn(new SaldoCuenta(new BigDecimal("100.00"), BigDecimal.ZERO));
+        when(asientoRepo.listarAsientosDeCuentaEnRango(bancos.getId(), desde, hasta))
+                .thenReturn(List.of(a1, a2));
+
+        LibroMayorResponse resp = useCase.ejecutar(
+                LibroMayorFilter.deCuenta(desde, hasta, "1.1.03"), UUID.randomUUID());
+
+        var c = resp.cuentas().get(0);
+        var movs = c.movimientos();
+        assertThat(movs).hasSize(2);
+        // Saldo acumulado después de cada movimiento (firmado por naturaleza)
+        assertThat(movs.get(0).saldoAcumulado()).isEqualByComparingTo("150.00");
+        assertThat(movs.get(1).saldoAcumulado()).isEqualByComparingTo("120.00");
+        // Saldo final
+        assertThat(c.saldoFinalNeto()).isEqualByComparingTo("120.00");
+        assertThat(c.saldoFinalEtiqueta()).isEqualTo("D");
+        // Totales del período
+        assertThat(c.totalDebePeriodo()).isEqualByComparingTo("50.00");
+        assertThat(c.totalHaberPeriodo()).isEqualByComparingTo("30.00");
+        assertThat(c.cantidadMovimientos()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("encabezado completo con razón social, RIF, filtros aplicados")
+    void encabezado_refleja_filtros() {
+        when(asientoRepo.calcularSaldoCuentaHasta(any(), any())).thenReturn(SaldoCuenta.cero());
+        when(asientoRepo.listarAsientosDeCuentaEnRango(any(), any(), any())).thenReturn(List.of());
+
+        UUID solicitante = UUID.randomUUID();
+        LibroMayorResponse resp = useCase.ejecutar(
+                new LibroMayorFilter(desde, hasta, null, true, false), solicitante);
+
+        assertThat(resp.encabezado().razonSocial()).isEqualTo("Fatrans Test");
+        assertThat(resp.encabezado().rif()).isEqualTo("J-TEST-0");
+        assertThat(resp.encabezado().desde()).isEqualTo(desde);
+        assertThat(resp.encabezado().hasta()).isEqualTo(hasta);
+        assertThat(resp.encabezado().generadoPorUsuarioId()).isEqualTo(solicitante);
+        assertThat(resp.encabezado().incluyeSinMovimientos()).isTrue();
+        assertThat(resp.encabezado().incluyeTotalizadoras()).isFalse();
+        assertThat(resp.encabezado().filtroCuenta()).isNull();
+    }
+
+    @Test
+    @DisplayName("totales generales suman cuentas procesadas")
+    void totales_generales_balanceados() {
+        AsientoContable a = asientoCon2Partidas(1L,
+                bancos.getId(), new BigDecimal("500.00"),
+                ahorros.getId(), new BigDecimal("500.00"));
+
+        when(asientoRepo.calcularSaldoCuentaHasta(any(), any())).thenReturn(SaldoCuenta.cero());
+        when(asientoRepo.listarAsientosDeCuentaEnRango(eq(bancos.getId()), any(), any()))
+                .thenReturn(List.of(a));
+        when(asientoRepo.listarAsientosDeCuentaEnRango(eq(ahorros.getId()), any(), any()))
+                .thenReturn(List.of(a));
+
+        LibroMayorResponse resp = useCase.ejecutar(
+                LibroMayorFilter.completo(desde, hasta), UUID.randomUUID());
+
+        // El asiento aparece en ambas cuentas → totales contabilizan ambas vistas
+        assertThat(resp.totales().cantidadCuentas()).isEqualTo(2);
+        assertThat(resp.totales().cantidadMovimientos()).isEqualTo(2); // 1 en cada cuenta
+        // bancos: DEBE 500 / ahorros: HABER 500
+        assertThat(resp.totales().totalDebe()).isEqualByComparingTo("500.00");
+        assertThat(resp.totales().totalHaber()).isEqualByComparingTo("500.00");
+        assertThat(resp.totales().balanceado()).isTrue();
+    }
+
+    // ─── Helper ────────────────────────────────────────────────────────────
+
+    private AsientoContable asientoCon2Partidas(
+            long numero,
+            UUID cuentaDebeId, BigDecimal montoDebe,
+            UUID cuentaHaberId, BigDecimal montoHaber) {
+        return AsientoContable.reconstruir(
+                UUID.randomUUID(), numero,
+                LocalDate.of(2026, 5, 10), "Asiento test " + numero,
+                OrigenAsiento.MANUAL, "REF-" + numero,
+                EstadoAsiento.REGISTRADO, null, null, null,
+                List.of(
+                        PartidaAsiento.alDebe(cuentaDebeId, montoDebe, 1, null),
+                        PartidaAsiento.alHaber(cuentaHaberId, montoHaber, 2, null)
+                ),
+                null, null, 0L);
+    }
+}

--- a/backend/src/test/java/com/tufondo/contabilidad/infrastructure/pdf/LibroDiarioPdfAdapterTest.java
+++ b/backend/src/test/java/com/tufondo/contabilidad/infrastructure/pdf/LibroDiarioPdfAdapterTest.java
@@ -1,0 +1,218 @@
+package com.tufondo.contabilidad.infrastructure.pdf;
+
+import com.tufondo.contabilidad.application.dto.LibroDiarioResponse;
+import com.tufondo.contabilidad.domain.model.enums.EstadoAsiento;
+import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests del {@link LibroDiarioPdfAdapter}.
+ *
+ * <p>Verifica que el PDF se genera (bytes válidos) sin crashear ante
+ * variaciones: período vacío, asientos anulados, muchas filas, decimales,
+ * desbalance (caso defensivo).</p>
+ */
+class LibroDiarioPdfAdapterTest {
+
+    private final LibroDiarioPdfAdapter adapter = new LibroDiarioPdfAdapter();
+
+    @Test
+    @DisplayName("período vacío genera PDF con cabecera y totales en cero")
+    void pdf_periodo_vacio() {
+        byte[] pdf = adapter.generarLibroDiarioPdf(libroVacio());
+
+        assertThat(pdf).isNotEmpty();
+        assertThat(esPdfValido(pdf)).isTrue();
+        assertThat(pdf.length).isGreaterThan(500); // al menos cabecera + estructura mínima
+    }
+
+    @Test
+    @DisplayName("PDF con 1 asiento normal — bytes válidos y mayor que el vacío")
+    void pdf_un_asiento() {
+        var libro = libroConAsientos(List.of(asientoNormal(1, "2026-000001")));
+        byte[] pdf = adapter.generarLibroDiarioPdf(libro);
+
+        assertThat(esPdfValido(pdf)).isTrue();
+        assertThat(pdf.length).isGreaterThan(1000);
+    }
+
+    @Test
+    @DisplayName("PDF con asiento ANULADO se genera (marca visual no rompe)")
+    void pdf_con_anulado() {
+        var libro = libroConAsientos(List.of(
+                asientoNormal(1, "2026-000001"),
+                asientoAnulado(2, "2026-000002")));
+        byte[] pdf = adapter.generarLibroDiarioPdf(libro);
+
+        assertThat(esPdfValido(pdf)).isTrue();
+    }
+
+    @Test
+    @DisplayName("PDF con muchos asientos (paginación) genera sin OOM")
+    void pdf_muchos_asientos_pagina() {
+        // 50 asientos cada uno con 2 partidas → ~100 filas; debe paginar
+        var asientos = java.util.stream.IntStream.rangeClosed(1, 50)
+                .mapToObj(i -> asientoNormal((long) i, String.format("2026-%06d", i)))
+                .toList();
+        var libro = libroConAsientos(asientos);
+
+        byte[] pdf = adapter.generarLibroDiarioPdf(libro);
+
+        assertThat(esPdfValido(pdf)).isTrue();
+        // PDF con 50 asientos debe ser visiblemente más grande
+        assertThat(pdf.length).isGreaterThan(5000);
+    }
+
+    @Test
+    @DisplayName("PDF con desbalance (caso defensivo) marca visualmente sin crashear")
+    void pdf_desbalance_se_renderiza() {
+        // Simular un desbalance manual en los totales para asegurar que el adapter
+        // no asume balance; solo lo marca visualmente.
+        var enc = encabezado();
+        var asiento = asientoNormal(1, "2026-000001");
+        var totalesDesbalanceados = LibroDiarioResponse.Totales.builder()
+                .cantidadAsientos(1)
+                .cantidadAnulados(0)
+                .totalDebe(new BigDecimal("100.00"))
+                .totalHaber(new BigDecimal("90.00"))  // diferencia
+                .balanceado(false)
+                .build();
+        var libro = LibroDiarioResponse.builder()
+                .encabezado(enc)
+                .asientos(List.of(asiento))
+                .totales(totalesDesbalanceados)
+                .build();
+
+        byte[] pdf = adapter.generarLibroDiarioPdf(libro);
+        assertThat(esPdfValido(pdf)).isTrue();
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────
+
+    /** Verifica que el byte array empiece con "%PDF" — header de PDF. */
+    private boolean esPdfValido(byte[] pdf) {
+        if (pdf == null || pdf.length < 4) return false;
+        return pdf[0] == '%' && pdf[1] == 'P' && pdf[2] == 'D' && pdf[3] == 'F';
+    }
+
+    private LibroDiarioResponse libroVacio() {
+        return LibroDiarioResponse.builder()
+                .encabezado(encabezado())
+                .asientos(List.of())
+                .totales(LibroDiarioResponse.Totales.builder()
+                        .cantidadAsientos(0)
+                        .cantidadAnulados(0)
+                        .totalDebe(BigDecimal.ZERO)
+                        .totalHaber(BigDecimal.ZERO)
+                        .balanceado(true)
+                        .build())
+                .build();
+    }
+
+    private LibroDiarioResponse libroConAsientos(List<LibroDiarioResponse.AsientoDiario> asientos) {
+        BigDecimal totalDebe = asientos.stream()
+                .map(LibroDiarioResponse.AsientoDiario::totalDebe)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal totalHaber = asientos.stream()
+                .map(LibroDiarioResponse.AsientoDiario::totalHaber)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        int anulados = (int) asientos.stream()
+                .filter(a -> a.estado() == EstadoAsiento.ANULADO).count();
+        return LibroDiarioResponse.builder()
+                .encabezado(encabezado())
+                .asientos(asientos)
+                .totales(LibroDiarioResponse.Totales.builder()
+                        .cantidadAsientos(asientos.size())
+                        .cantidadAnulados(anulados)
+                        .totalDebe(totalDebe)
+                        .totalHaber(totalHaber)
+                        .balanceado(totalDebe.compareTo(totalHaber) == 0)
+                        .build())
+                .build();
+    }
+
+    private LibroDiarioResponse.Encabezado encabezado() {
+        return LibroDiarioResponse.Encabezado.builder()
+                .razonSocial("Fatrans Test")
+                .rif("J-12345678-9")
+                .desde(LocalDate.of(2026, 5, 1))
+                .hasta(LocalDate.of(2026, 5, 31))
+                .generadoEn(Instant.now())
+                .generadoPorUsuarioId(UUID.randomUUID())
+                .incluyeAnulados(true)
+                .build();
+    }
+
+    private LibroDiarioResponse.AsientoDiario asientoNormal(long numero, String formateado) {
+        return LibroDiarioResponse.AsientoDiario.builder()
+                .numero(numero)
+                .numeroFormateado(formateado)
+                .fechaContable(LocalDate.of(2026, 5, 10))
+                .origen(OrigenAsiento.AHORRO_DEPOSITO)
+                .estado(EstadoAsiento.REGISTRADO)
+                .glosa("Depósito de prueba " + numero)
+                .referenciaExterna("MOV-" + numero)
+                .motivoAnulacion(null)
+                .totalDebe(new BigDecimal("100.00"))
+                .totalHaber(new BigDecimal("100.00"))
+                .partidas(List.of(
+                        LibroDiarioResponse.PartidaDiario.builder()
+                                .codigoCuenta("1.1.03")
+                                .nombreCuenta("Bancos Cta Corriente Bs")
+                                .debe(new BigDecimal("100.00"))
+                                .haber(BigDecimal.ZERO)
+                                .glosa("Ingreso")
+                                .orden(1)
+                                .build(),
+                        LibroDiarioResponse.PartidaDiario.builder()
+                                .codigoCuenta("2.1.01")
+                                .nombreCuenta("Cuentas de Ahorro Bs")
+                                .debe(BigDecimal.ZERO)
+                                .haber(new BigDecimal("100.00"))
+                                .glosa("Crédito ahorro")
+                                .orden(2)
+                                .build()))
+                .build();
+    }
+
+    private LibroDiarioResponse.AsientoDiario asientoAnulado(long numero, String formateado) {
+        return LibroDiarioResponse.AsientoDiario.builder()
+                .numero(numero)
+                .numeroFormateado(formateado)
+                .fechaContable(LocalDate.of(2026, 5, 12))
+                .origen(OrigenAsiento.AHORRO_RETIRO)
+                .estado(EstadoAsiento.ANULADO)
+                .glosa("Retiro que se anuló")
+                .referenciaExterna("MOV-" + numero)
+                .motivoAnulacion("Error en el monto registrado")
+                .totalDebe(new BigDecimal("250.00"))
+                .totalHaber(new BigDecimal("250.00"))
+                .partidas(List.of(
+                        LibroDiarioResponse.PartidaDiario.builder()
+                                .codigoCuenta("2.1.01")
+                                .nombreCuenta("Cuentas de Ahorro Bs")
+                                .debe(new BigDecimal("250.00"))
+                                .haber(BigDecimal.ZERO)
+                                .glosa("")
+                                .orden(1)
+                                .build(),
+                        LibroDiarioResponse.PartidaDiario.builder()
+                                .codigoCuenta("1.1.03")
+                                .nombreCuenta("Bancos Cta Corriente Bs")
+                                .debe(BigDecimal.ZERO)
+                                .haber(new BigDecimal("250.00"))
+                                .glosa("")
+                                .orden(2)
+                                .build()))
+                .build();
+    }
+}

--- a/backend/src/test/java/com/tufondo/contabilidad/infrastructure/pdf/LibroMayorPdfAdapterTest.java
+++ b/backend/src/test/java/com/tufondo/contabilidad/infrastructure/pdf/LibroMayorPdfAdapterTest.java
@@ -1,0 +1,215 @@
+package com.tufondo.contabilidad.infrastructure.pdf;
+
+import com.tufondo.contabilidad.application.dto.LibroMayorResponse;
+import com.tufondo.contabilidad.domain.model.enums.NaturalezaSaldo;
+import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
+import com.tufondo.contabilidad.domain.model.enums.TipoCuentaContable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests del método {@code generarLibroMayorPdf} del adapter unificado.
+ *
+ * <p>El adapter {@link LibroDiarioPdfAdapter} implementa todo el
+ * {@code ContabilidadPdfPort} (Diario + Mayor). Tests del Libro Diario
+ * en {@link LibroDiarioPdfAdapterTest}.</p>
+ */
+class LibroMayorPdfAdapterTest {
+
+    private final LibroDiarioPdfAdapter adapter = new LibroDiarioPdfAdapter();
+
+    @Test
+    @DisplayName("período vacío (sin cuentas) genera PDF con encabezado y totales en cero")
+    void pdf_vacio() {
+        var libro = LibroMayorResponse.builder()
+                .encabezado(encabezado(null, false, false))
+                .cuentas(List.of())
+                .totales(totalesCero())
+                .build();
+
+        byte[] pdf = adapter.generarLibroMayorPdf(libro);
+
+        assertThat(pdf).isNotEmpty();
+        assertThat(esPdfValido(pdf)).isTrue();
+    }
+
+    @Test
+    @DisplayName("una cuenta sin movimientos (incluida) muestra '(sin movimientos)'")
+    void cuenta_sin_movimientos() {
+        var cuenta = LibroMayorResponse.CuentaConMovimientos.builder()
+                .codigo("1.1.03").nombre("Bancos")
+                .tipo(TipoCuentaContable.ACTIVO).naturaleza(NaturalezaSaldo.DEUDORA)
+                .saldoInicialDebe(BigDecimal.ZERO).saldoInicialHaber(BigDecimal.ZERO)
+                .saldoInicialNeto(BigDecimal.ZERO).saldoInicialEtiqueta("—")
+                .movimientos(List.of())
+                .totalDebePeriodo(BigDecimal.ZERO).totalHaberPeriodo(BigDecimal.ZERO)
+                .cantidadMovimientos(0)
+                .saldoFinalDebe(BigDecimal.ZERO).saldoFinalHaber(BigDecimal.ZERO)
+                .saldoFinalNeto(BigDecimal.ZERO).saldoFinalEtiqueta("—")
+                .build();
+        var libro = LibroMayorResponse.builder()
+                .encabezado(encabezado(null, true, false))
+                .cuentas(List.of(cuenta))
+                .totales(totalesCero())
+                .build();
+
+        byte[] pdf = adapter.generarLibroMayorPdf(libro);
+        assertThat(esPdfValido(pdf)).isTrue();
+    }
+
+    @Test
+    @DisplayName("cuenta con varios movimientos y contracuentas se renderiza")
+    void cuenta_con_movimientos() {
+        var movs = List.of(
+                movimiento(LocalDate.of(2026, 5, 3), 1L, "2026-000001",
+                        OrigenAsiento.AHORRO_DEPOSITO, "Depósito",
+                        "2.1.01", "Cuentas de Ahorro Bs", null,
+                        new BigDecimal("100.00"), BigDecimal.ZERO,
+                        new BigDecimal("100.00")),
+                movimiento(LocalDate.of(2026, 5, 5), 2L, "2026-000002",
+                        OrigenAsiento.AHORRO_RETIRO, "Retiro",
+                        "2.1.01", "Cuentas de Ahorro Bs", null,
+                        BigDecimal.ZERO, new BigDecimal("40.00"),
+                        new BigDecimal("60.00")),
+                movimiento(LocalDate.of(2026, 5, 10), 3L, "2026-000003",
+                        OrigenAsiento.CREDITO_DESEMBOLSO, "Desembolso",
+                        "1.3.01", "Créditos", "(múltiple)",
+                        BigDecimal.ZERO, new BigDecimal("500.00"),
+                        new BigDecimal("-440.00")));  // saldo negativo: lado opuesto a naturaleza
+
+        var cuenta = LibroMayorResponse.CuentaConMovimientos.builder()
+                .codigo("1.1.03").nombre("Bancos")
+                .tipo(TipoCuentaContable.ACTIVO).naturaleza(NaturalezaSaldo.DEUDORA)
+                .saldoInicialDebe(BigDecimal.ZERO).saldoInicialHaber(BigDecimal.ZERO)
+                .saldoInicialNeto(BigDecimal.ZERO).saldoInicialEtiqueta("—")
+                .movimientos(movs)
+                .totalDebePeriodo(new BigDecimal("100.00"))
+                .totalHaberPeriodo(new BigDecimal("540.00"))
+                .cantidadMovimientos(3)
+                .saldoFinalDebe(new BigDecimal("100.00")).saldoFinalHaber(new BigDecimal("540.00"))
+                .saldoFinalNeto(new BigDecimal("440.00")).saldoFinalEtiqueta("A") // opuesto a su naturaleza
+                .build();
+
+        var libro = LibroMayorResponse.builder()
+                .encabezado(encabezado("1.1.03", true, false))
+                .cuentas(List.of(cuenta))
+                .totales(LibroMayorResponse.Totales.builder()
+                        .cantidadCuentas(1).cantidadMovimientos(3)
+                        .totalDebe(new BigDecimal("100.00")).totalHaber(new BigDecimal("540.00"))
+                        .balanceado(false)
+                        .build())
+                .build();
+
+        byte[] pdf = adapter.generarLibroMayorPdf(libro);
+        assertThat(esPdfValido(pdf)).isTrue();
+        // PDF con 3 movimientos visibles
+        assertThat(pdf.length).isGreaterThan(2000);
+    }
+
+    @Test
+    @DisplayName("múltiples cuentas con paginación se renderizan sin OOM")
+    void muchas_cuentas_pagina() {
+        var cuentas = java.util.stream.IntStream.rangeClosed(1, 20)
+                .mapToObj(i -> LibroMayorResponse.CuentaConMovimientos.builder()
+                        .codigo(String.format("1.%d.%02d", i / 10, i % 100))
+                        .nombre("Cuenta " + i)
+                        .tipo(TipoCuentaContable.ACTIVO).naturaleza(NaturalezaSaldo.DEUDORA)
+                        .saldoInicialDebe(BigDecimal.ZERO).saldoInicialHaber(BigDecimal.ZERO)
+                        .saldoInicialNeto(BigDecimal.ZERO).saldoInicialEtiqueta("—")
+                        .movimientos(List.of(
+                                movimiento(LocalDate.now(), (long) i, "2026-000" + i,
+                                        OrigenAsiento.MANUAL, "Mov",
+                                        "2.1.01", "Contra", null,
+                                        new BigDecimal("10.00"), BigDecimal.ZERO,
+                                        new BigDecimal("10.00"))))
+                        .totalDebePeriodo(new BigDecimal("10.00"))
+                        .totalHaberPeriodo(BigDecimal.ZERO).cantidadMovimientos(1)
+                        .saldoFinalDebe(new BigDecimal("10.00")).saldoFinalHaber(BigDecimal.ZERO)
+                        .saldoFinalNeto(new BigDecimal("10.00")).saldoFinalEtiqueta("D")
+                        .build())
+                .toList();
+
+        var libro = LibroMayorResponse.builder()
+                .encabezado(encabezado(null, false, false))
+                .cuentas(cuentas)
+                .totales(LibroMayorResponse.Totales.builder()
+                        .cantidadCuentas(20).cantidadMovimientos(20)
+                        .totalDebe(new BigDecimal("200.00")).totalHaber(BigDecimal.ZERO)
+                        .balanceado(false).build())
+                .build();
+
+        byte[] pdf = adapter.generarLibroMayorPdf(libro);
+        assertThat(esPdfValido(pdf)).isTrue();
+        assertThat(pdf.length).isGreaterThan(5000);
+    }
+
+    @Test
+    @DisplayName("totales con balance desbalanceado se marca visualmente sin crashear")
+    void totales_desbalanceados() {
+        var libro = LibroMayorResponse.builder()
+                .encabezado(encabezado(null, false, false))
+                .cuentas(List.of())
+                .totales(LibroMayorResponse.Totales.builder()
+                        .cantidadCuentas(0).cantidadMovimientos(0)
+                        .totalDebe(new BigDecimal("100"))
+                        .totalHaber(new BigDecimal("90"))
+                        .balanceado(false)
+                        .build())
+                .build();
+
+        byte[] pdf = adapter.generarLibroMayorPdf(libro);
+        assertThat(esPdfValido(pdf)).isTrue();
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────
+
+    private boolean esPdfValido(byte[] pdf) {
+        if (pdf == null || pdf.length < 4) return false;
+        return pdf[0] == '%' && pdf[1] == 'P' && pdf[2] == 'D' && pdf[3] == 'F';
+    }
+
+    private LibroMayorResponse.Encabezado encabezado(
+            String filtroCuenta, boolean sinMov, boolean tot) {
+        return LibroMayorResponse.Encabezado.builder()
+                .razonSocial("Fatrans Test")
+                .rif("J-12345678-9")
+                .desde(LocalDate.of(2026, 5, 1))
+                .hasta(LocalDate.of(2026, 5, 31))
+                .generadoEn(Instant.now())
+                .generadoPorUsuarioId(UUID.randomUUID())
+                .filtroCuenta(filtroCuenta)
+                .incluyeSinMovimientos(sinMov)
+                .incluyeTotalizadoras(tot)
+                .build();
+    }
+
+    private LibroMayorResponse.Totales totalesCero() {
+        return LibroMayorResponse.Totales.builder()
+                .cantidadCuentas(0).cantidadMovimientos(0)
+                .totalDebe(BigDecimal.ZERO).totalHaber(BigDecimal.ZERO)
+                .balanceado(true)
+                .build();
+    }
+
+    private LibroMayorResponse.MovimientoMayor movimiento(
+            LocalDate fecha, long numero, String numeroFmt, OrigenAsiento origen,
+            String glosa, String contraCodigo, String contraNombre, String contraResumen,
+            BigDecimal debe, BigDecimal haber, BigDecimal saldoAcum) {
+        return LibroMayorResponse.MovimientoMayor.builder()
+                .fechaContable(fecha)
+                .numeroAsiento(numero).numeroAsientoFormateado(numeroFmt)
+                .origen(origen).glosaAsiento(glosa).referenciaExterna("REF-" + numero)
+                .contracuentaCodigo(contraCodigo).contracuentaNombre(contraNombre)
+                .contracuentaResumen(contraResumen)
+                .debe(debe).haber(haber).saldoAcumulado(saldoAcum)
+                .build();
+    }
+}

--- a/backend/src/test/java/com/tufondo/contabilidad/infrastructure/persistence/adapter/AsientoContableRepositoryLibroMayorTest.java
+++ b/backend/src/test/java/com/tufondo/contabilidad/infrastructure/persistence/adapter/AsientoContableRepositoryLibroMayorTest.java
@@ -1,0 +1,220 @@
+package com.tufondo.contabilidad.infrastructure.persistence.adapter;
+
+import com.tufondo.contabilidad.domain.model.AsientoContable;
+import com.tufondo.contabilidad.domain.model.CuentaContable;
+import com.tufondo.contabilidad.domain.model.PartidaAsiento;
+import com.tufondo.contabilidad.domain.model.SaldoCuenta;
+import com.tufondo.contabilidad.domain.model.enums.EstadoAsiento;
+import com.tufondo.contabilidad.domain.model.enums.NaturalezaSaldo;
+import com.tufondo.contabilidad.domain.model.enums.OrigenAsiento;
+import com.tufondo.contabilidad.domain.model.enums.TipoCuentaContable;
+import com.tufondo.contabilidad.infrastructure.persistence.entity.AsientoContableEntity;
+import com.tufondo.contabilidad.infrastructure.persistence.entity.PartidaAsientoEntity;
+import com.tufondo.contabilidad.infrastructure.persistence.jpa.AsientoContableJpaRepository;
+import com.tufondo.contabilidad.infrastructure.persistence.jpa.CuentaContableJpaRepository;
+import com.tufondo.contabilidad.infrastructure.persistence.jpa.PartidaAsientoJpaRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests del adapter — queries nuevas del Libro Mayor (#270).
+ *
+ * <p>Verifica con BD H2 real (modo Postgres) que las queries nativas
+ * calcularSaldoCuentaHasta() y listarAsientosDeCuentaEnRango() devuelven
+ * los datos correctos, especialmente:</p>
+ * <ul>
+ *   <li>SUM de DEBE/HABER excluyendo asientos ANULADOS.</li>
+ *   <li>Rango de fechas inclusive en ambos extremos.</li>
+ *   <li>Filtrado solo por la cuenta solicitada (no devuelve otras).</li>
+ *   <li>Cuenta sin movimientos → SaldoCuenta.cero(), lista vacía.</li>
+ * </ul>
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase
+@ActiveProfiles("test")
+@Import(AsientoContableRepositoryImpl.class)
+@DisplayName("AsientoContableRepositoryImpl - queries del Libro Mayor")
+class AsientoContableRepositoryLibroMayorTest {
+
+    @Autowired private AsientoContableRepositoryImpl repo;
+    @Autowired private AsientoContableJpaRepository asientoJpa;
+    @Autowired private PartidaAsientoJpaRepository partidaJpa;
+    @Autowired private CuentaContableJpaRepository cuentaJpa;
+    @Autowired private EntityManager em;
+
+    private UUID bancoId, ahorrosId;
+    private final AtomicLong correlativo = new AtomicLong(1);
+
+    @BeforeEach
+    void setUp() {
+        partidaJpa.deleteAll();
+        asientoJpa.deleteAll();
+        cuentaJpa.deleteAll();
+
+        UUID rubroA = persistirCuenta("1", "ACTIVO", TipoCuentaContable.ACTIVO,
+                NaturalezaSaldo.DEUDORA, null, false);
+        UUID grupoA = persistirCuenta("1.1", "DISPONIBLE", TipoCuentaContable.ACTIVO,
+                NaturalezaSaldo.DEUDORA, rubroA, false);
+        bancoId = persistirCuenta("1.1.03", "Bancos Bs", TipoCuentaContable.ACTIVO,
+                NaturalezaSaldo.DEUDORA, grupoA, true);
+
+        UUID rubroP = persistirCuenta("2", "PASIVO", TipoCuentaContable.PASIVO,
+                NaturalezaSaldo.ACREEDORA, null, false);
+        UUID grupoP = persistirCuenta("2.1", "DEPÓSITOS", TipoCuentaContable.PASIVO,
+                NaturalezaSaldo.ACREEDORA, rubroP, false);
+        ahorrosId = persistirCuenta("2.1.01", "Ahorros Bs", TipoCuentaContable.PASIVO,
+                NaturalezaSaldo.ACREEDORA, grupoP, true);
+    }
+
+    // ─── calcularSaldoCuentaHasta ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("cuenta sin movimientos → saldo cero")
+    void saldo_cuenta_sin_movimientos() {
+        SaldoCuenta s = repo.calcularSaldoCuentaHasta(bancoId, LocalDate.now());
+        assertThat(s.totalDebe()).isEqualByComparingTo("0");
+        assertThat(s.totalHaber()).isEqualByComparingTo("0");
+    }
+
+    @Test
+    @DisplayName("SUM acumulado hasta fecha de corte")
+    void saldo_suma_hasta_corte() {
+        // 3 asientos: 2 dentro del corte, 1 después
+        persistirAsiento(LocalDate.of(2026, 5, 1), bancoId, ahorrosId, "100.00", EstadoAsiento.REGISTRADO);
+        persistirAsiento(LocalDate.of(2026, 5, 10), bancoId, ahorrosId, "200.00", EstadoAsiento.REGISTRADO);
+        persistirAsiento(LocalDate.of(2026, 5, 20), bancoId, ahorrosId, "50.00", EstadoAsiento.REGISTRADO);
+
+        // Corte al 2026-05-15 → debe sumar solo los dos primeros (100 + 200)
+        SaldoCuenta s = repo.calcularSaldoCuentaHasta(bancoId, LocalDate.of(2026, 5, 15));
+        assertThat(s.totalDebe()).isEqualByComparingTo("300.00");
+        assertThat(s.totalHaber()).isEqualByComparingTo("0");
+    }
+
+    @Test
+    @DisplayName("excluye asientos ANULADOS")
+    void saldo_excluye_anulados() {
+        persistirAsiento(LocalDate.of(2026, 5, 1), bancoId, ahorrosId, "100.00", EstadoAsiento.REGISTRADO);
+        persistirAsiento(LocalDate.of(2026, 5, 2), bancoId, ahorrosId, "500.00", EstadoAsiento.ANULADO);  // no debe contar
+        persistirAsiento(LocalDate.of(2026, 5, 3), bancoId, ahorrosId, "200.00", EstadoAsiento.REGISTRADO);
+
+        SaldoCuenta s = repo.calcularSaldoCuentaHasta(bancoId, LocalDate.of(2026, 5, 31));
+        assertThat(s.totalDebe()).isEqualByComparingTo("300.00");
+    }
+
+    @Test
+    @DisplayName("la cuenta puede aparecer en HABER también (suma a totalHaber)")
+    void saldo_acumula_haber_si_cuenta_en_lado_acreedor() {
+        // Asiento 1: banco al DEBE 100
+        persistirAsiento(LocalDate.of(2026, 5, 1), bancoId, ahorrosId, "100.00", EstadoAsiento.REGISTRADO);
+        // Asiento 2: banco al HABER 30 (retiro)
+        persistirAsiento(LocalDate.of(2026, 5, 5), ahorrosId, bancoId, "30.00", EstadoAsiento.REGISTRADO);
+
+        SaldoCuenta s = repo.calcularSaldoCuentaHasta(bancoId, LocalDate.of(2026, 5, 31));
+        assertThat(s.totalDebe()).isEqualByComparingTo("100.00");
+        assertThat(s.totalHaber()).isEqualByComparingTo("30.00");
+        // Saldo neto deudor = 100 - 30 = 70
+        assertThat(s.saldoNeto(NaturalezaSaldo.DEUDORA)).isEqualByComparingTo("70.00");
+    }
+
+    // ─── listarAsientosDeCuentaEnRango ─────────────────────────────────────
+
+    @Test
+    @DisplayName("rango sin movimientos → lista vacía")
+    void rango_vacio() {
+        List<AsientoContable> r = repo.listarAsientosDeCuentaEnRango(
+                bancoId, LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 31));
+        assertThat(r).isEmpty();
+    }
+
+    @Test
+    @DisplayName("solo asientos REGISTRADOS dentro del rango (excluye ANULADOS y fuera de rango)")
+    void rango_filtra_correctamente() {
+        persistirAsiento(LocalDate.of(2026, 4, 30), bancoId, ahorrosId, "10.00", EstadoAsiento.REGISTRADO); // antes
+        persistirAsiento(LocalDate.of(2026, 5, 5), bancoId, ahorrosId, "20.00", EstadoAsiento.REGISTRADO);  // ok
+        persistirAsiento(LocalDate.of(2026, 5, 10), bancoId, ahorrosId, "30.00", EstadoAsiento.ANULADO);    // anulado
+        persistirAsiento(LocalDate.of(2026, 5, 20), bancoId, ahorrosId, "40.00", EstadoAsiento.REGISTRADO); // ok
+        persistirAsiento(LocalDate.of(2026, 6, 1), bancoId, ahorrosId, "50.00", EstadoAsiento.REGISTRADO);  // después
+
+        List<AsientoContable> r = repo.listarAsientosDeCuentaEnRango(
+                bancoId, LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 31));
+
+        // Solo los 2 REGISTRADOS dentro del rango
+        assertThat(r).hasSize(2);
+        // Ordenados por fecha asc
+        assertThat(r.get(0).getFechaContable()).isEqualTo(LocalDate.of(2026, 5, 5));
+        assertThat(r.get(1).getFechaContable()).isEqualTo(LocalDate.of(2026, 5, 20));
+        // Las partidas están hidratadas (no N+1)
+        assertThat(r.get(0).getPartidas()).hasSize(2);
+        assertThat(r.get(1).getPartidas()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("solo asientos donde la cuenta tiene partida — no devuelve asientos de otras cuentas")
+    void filtro_solo_cuenta_solicitada() {
+        // Asiento de bancos
+        persistirAsiento(LocalDate.of(2026, 5, 1), bancoId, ahorrosId, "100.00", EstadoAsiento.REGISTRADO);
+        // Asiento que NO toca bancos (solo entre ahorros y otra)
+        UUID otraCuenta = persistirCuenta("2.1.02", "USD",
+                TipoCuentaContable.PASIVO, NaturalezaSaldo.ACREEDORA,
+                cuentaJpa.findAll().stream()
+                        .filter(c -> c.getCodigo().equals("2.1"))
+                        .findFirst().get().getId(),
+                true);
+        persistirAsiento(LocalDate.of(2026, 5, 5), ahorrosId, otraCuenta, "50.00", EstadoAsiento.REGISTRADO);
+
+        // Solo debe devolver el primero (el que toca bancos)
+        List<AsientoContable> r = repo.listarAsientosDeCuentaEnRango(
+                bancoId, LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 31));
+        assertThat(r).hasSize(1);
+        assertThat(r.get(0).getFechaContable()).isEqualTo(LocalDate.of(2026, 5, 1));
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────
+
+    private UUID persistirCuenta(String codigo, String nombre, TipoCuentaContable tipo,
+                                  NaturalezaSaldo naturaleza, UUID padre, boolean aceptaMov) {
+        CuentaContable c = CuentaContable.crear(codigo, nombre, tipo, naturaleza, padre, aceptaMov, null);
+        cuentaJpa.save(com.tufondo.contabilidad.infrastructure.persistence.entity
+                .CuentaContableEntity.fromDomain(c));
+        return c.getId();
+    }
+
+    /**
+     * Persiste un asiento mínimo con 2 partidas (DEBE / HABER del mismo monto).
+     * @param estado REGISTRADO o ANULADO
+     */
+    private void persistirAsiento(LocalDate fecha, UUID cuentaDebeId, UUID cuentaHaberId,
+                                   String monto, EstadoAsiento estado) {
+        BigDecimal m = new BigDecimal(monto);
+        AsientoContable a = AsientoContable.reconstruir(
+                UUID.randomUUID(), correlativo.getAndIncrement(),
+                fecha, "test", OrigenAsiento.MANUAL, "REF-" + monto,
+                estado, null,
+                estado == EstadoAsiento.ANULADO ? "test" : null, null,
+                List.of(
+                        PartidaAsiento.alDebe(cuentaDebeId, m, 1, null),
+                        PartidaAsiento.alHaber(cuentaHaberId, m, 2, null)),
+                null, null, 0L);
+        AsientoContableEntity savedCab = asientoJpa.save(AsientoContableEntity.fromDomain(a));
+        List<PartidaAsientoEntity> partidas = a.getPartidas().stream()
+                .map(p -> PartidaAsientoEntity.fromDomain(p, savedCab.getId()))
+                .toList();
+        partidaJpa.saveAll(partidas);
+        em.flush();
+    }
+}

--- a/docs/modulos/contabilidad/00-overview.md
+++ b/docs/modulos/contabilidad/00-overview.md
@@ -28,11 +28,11 @@ contable de partida doble. Eso significa:
 El EPIC #263 cierra esa brecha desde la base (plan de cuentas) hasta los
 reportes finales.
 
-## Estado actual (2026-05-20, post #269)
+## Estado actual (2026-05-20, post #270)
 
 ```
-Plan de cuentas (#264) ──► Asientos (#265+#266) ──► Hooks Ahorros (#267) ──► Hooks Créditos (#268) ──► Libro Diario (#269) ──► Resto reportes (#270-#271) ──► Cierre (#272+#273)
-       ✅                       ✅                        ✅                        ✅                     🚧 PR #317              ⏳                           ⏳
+Plan de cuentas (#264) ──► Asientos (#265+#266) ──► Hooks Ahorros (#267) ──► Hooks Créditos (#268) ──► Libro Diario (#269) ──► Libro Mayor (#270) ──► Balance General (#271) ──► Cierre (#272+#273)
+       ✅                       ✅                        ✅                        ✅                     🚧 PR #317              🚧 PR #318              ⏳                          ⏳
 ```
 
 ## Timeline cronológico de decisiones y entregas
@@ -154,11 +154,40 @@ y `/pdf` (descarga). Solo ADMIN/SUPER_ADMIN/SISTEMA por ahora.
 - Crear rol `CONTADOR` dedicado (P2)
 - Firma digital del PDF (sub-issue futuro)
 
-## Lo que viene después de #269
+### 2026-05-20 — #270 Libro Mayor (PR — saldos por cuenta)
+
+**[[06-libro-mayor|#270 — Libro Mayor]]** (PR en revisión)
+
+Segundo reporte SUDECA. Agrupa movimientos por cuenta (no por asiento como
+el Diario), con saldo inicial real al comienzo del período, contracuenta
+resuelta por movimiento, saldo acumulado por línea, y saldo final.
+
+**Decisiones tomadas** ([[_decisiones-contables#D-007|D-007]]):
+- Saldo inicial REAL: `SUM` agregado de partidas previas a `desde-1`.
+- Solo cuentas hoja por default (totalizadoras para Balance General).
+- Cuentas sin movimientos excluidas por default (`incluirSinMovimientos=true` opt).
+- Asientos ANULADOS **excluidos** del Mayor (diferencia clave con Diario).
+- Saldos formato absoluto + tag `D/A/—` (convención SUDECA).
+- Contracuenta visible por movimiento (cuenta principal del lado opuesto).
+- Adapter PDF unificado en `LibroDiarioPdfAdapter` (renombre a futuro).
+
+**2 queries nuevas al port**:
+- `calcularSaldoCuentaHasta(cuentaId, fechaCorte)` — native SQL `SUM` agregado.
+- `listarAsientosDeCuentaEnRango(cuentaId, desde, hasta)` — JOIN + hidratación batch.
+
+**31 tests nuevos, todos verde**:
+- `LibroMayorFilterTest` (8) — validaciones rango y flags
+- `GenerarLibroMayorUseCaseTest` (11) — Mockito, saldo inicial, contracuenta, etiquetas
+- `LibroMayorPdfAdapterTest` (5) — verificación bytes PDF, casos borde
+- `AsientoContableRepositoryLibroMayorTest` (7) — `@DataJpaTest` H2: SUM, filtros, exclusión ANULADOS
+
+**Pendientes nuevos**:
+- Cachear saldos cerrados al cierre mensual (parte de #272) para performance.
+
+## Lo que viene después de #270
 
 | # | Tema | Comentario |
 |---|---|---|
-| #270 | Libro Mayor | Saldos acumulados por cuenta a una fecha de corte |
 | #271 | Balance General + Estado de Resultados | Reportes finales VEN-NIF |
 | #272 | Cierre mensual/anual | Bloqueo de período + asientos de cierre |
 | #273 | Reversión de asientos | Generación automática de asiento inverso para anulación |

--- a/docs/modulos/contabilidad/00-overview.md
+++ b/docs/modulos/contabilidad/00-overview.md
@@ -28,11 +28,11 @@ contable de partida doble. Eso significa:
 El EPIC #263 cierra esa brecha desde la base (plan de cuentas) hasta los
 reportes finales.
 
-## Estado actual (2026-05-20, post #268)
+## Estado actual (2026-05-20, post #269)
 
 ```
-Plan de cuentas (#264) ──► Asientos (#265+#266) ──► Hooks Ahorros (#267) ──► Hooks Créditos (#268) ──► Reportes (#269-#271) ──► Cierre (#272+#273)
-       ✅                       ✅                        ✅                        🚧 (PR)                  ⏳                        ⏳
+Plan de cuentas (#264) ──► Asientos (#265+#266) ──► Hooks Ahorros (#267) ──► Hooks Créditos (#268) ──► Libro Diario (#269) ──► Resto reportes (#270-#271) ──► Cierre (#272+#273)
+       ✅                       ✅                        ✅                        ✅                     🚧 PR #317              ⏳                           ⏳
 ```
 
 ## Timeline cronológico de decisiones y entregas
@@ -107,9 +107,9 @@ Este hallazgo desencadenó:
 3. La identificación de varios pendientes regulatorios que documenté en
    [[_pendientes-criticos]].
 
-### 2026-05-20 — #268 Hooks de Créditos (IMPLEMENTADO)
+### 2026-05-20 — #268 Hooks de Créditos (PR #316, MERGED)
 
-**[[04-hooks-creditos|#268 — Hooks Créditos]]** (PR en revisión)
+**[[04-hooks-creditos|#268 — Hooks Créditos]]** (merged)
 
 Mismo patrón que #267 aplicado al módulo Créditos, con mapping previamente
 aprobado por [[_contador-fatrans]] ([[_decisiones-contables#D-003|D-003]] y
@@ -129,11 +129,35 @@ aprobado por [[_contador-fatrans]] ([[_decisiones-contables#D-003|D-003]] y
 - Ejecución de colateral (use case existe pero sin hook)
 - Pago parcial (flujo actual exige completo)
 
-## Lo que viene después de #268
+### 2026-05-20 — #269 Libro Diario (PR #317 — primer reporte SUDECA)
+
+**[[05-libro-diario|#269 — Libro Diario]]** (PR en revisión)
+
+Primer reporte contable exigido por SUDECA: listado secuencial de todos los
+asientos del período. Endpoint `GET /api/v1/contabilidad/libro-diario` (JSON)
+y `/pdf` (descarga). Solo ADMIN/SUPER_ADMIN/SISTEMA por ahora.
+
+**Decisiones tomadas** ([[_decisiones-contables#D-006|D-006]]):
+- Incluir asientos ANULADOS por defecto con marca visual (SUDECA exige auditoría completa, no censura).
+- Correlativo formateado como `AÑO-NNNNNN` visualmente. Reset anual real
+  queda como pendiente P1 antes del primer cierre fiscal.
+- Puerto PDF dedicado al módulo contabilidad (no reutilizar `documentospdf`).
+- Razón social y RIF vía properties configurables en `application.yml`.
+
+**21 tests nuevos, todos verde**:
+- `LibroDiarioFilterTest` (7) — validaciones de rango
+- `GenerarLibroDiarioUseCaseTest` (9) — Mockito
+- `LibroDiarioPdfAdapterTest` (5) — verificación de bytes PDF
+
+**Pendientes abiertos**:
+- Reset anual real del correlativo (P1, antes de cierre fiscal)
+- Crear rol `CONTADOR` dedicado (P2)
+- Firma digital del PDF (sub-issue futuro)
+
+## Lo que viene después de #269
 
 | # | Tema | Comentario |
 |---|---|---|
-| #269 | Libro Diario + PDF SUDECA | Reporte por rango de fechas con totales del período |
 | #270 | Libro Mayor | Saldos acumulados por cuenta a una fecha de corte |
 | #271 | Balance General + Estado de Resultados | Reportes finales VEN-NIF |
 | #272 | Cierre mensual/anual | Bloqueo de período + asientos de cierre |

--- a/docs/modulos/contabilidad/05-libro-diario.md
+++ b/docs/modulos/contabilidad/05-libro-diario.md
@@ -1,0 +1,230 @@
+---
+tags: [contabilidad, reporte, libro-diario, sudeca, ven-nif]
+sub-issue: "#269"
+pr: en-curso
+estado: implementado
+created: 2026-05-20
+---
+
+# 📖 Libro Diario — primer reporte SUDECA
+
+> [!summary] Sub-issue [[Home|#269]] — IMPLEMENTADO
+> Genera el Libro Diario contable: listado secuencial completo de todos los
+> asientos del período por orden de número correlativo. **Primer reporte
+> exigido por SUDECA** para auditoría regulatoria.
+
+## Endpoint
+
+```http
+GET /api/v1/contabilidad/libro-diario
+GET /api/v1/contabilidad/libro-diario/pdf
+```
+
+**Permisos**: solo `ROLE_ADMIN`, `ROLE_SUPER_ADMIN`, `ROLE_SISTEMA`.
+
+> [!note] ROL_CONTADOR pendiente
+> Idealmente este endpoint debería ser accesible también a un `ROLE_CONTADOR`
+> dedicado. El enum `Rol` actual no lo contempla. Ver pendiente "Crear rol
+> CONTADOR" en [[_pendientes-criticos]].
+
+### Query parameters
+
+| Parámetro | Tipo | Default | Descripción |
+|---|---|---|---|
+| `desde` | `LocalDate` (`YYYY-MM-DD`) | **obligatorio** | Inicio del período (inclusive) |
+| `hasta` | `LocalDate` (`YYYY-MM-DD`) | **obligatorio** | Fin del período (inclusive) |
+| `incluirAnulados` | `boolean` | `true` | Si incluir asientos anulados con marca visual ([[_decisiones-contables#D-006\|D-006]]) |
+
+### Validaciones de rango
+
+- `hasta >= desde` — sino `400 Bad Request`
+- `(hasta - desde) ≤ 366 días` — sino `400 Bad Request`. Para reportes más largos, dividir consulta.
+
+## Estructura del response JSON
+
+```json
+{
+  "encabezado": {
+    "razonSocial": "Asociación Fatrans de Ahorro y Crédito",
+    "rif": "J-XXXXXXXX-X",
+    "desde": "2026-05-01",
+    "hasta": "2026-05-31",
+    "generadoEn": "2026-05-20T14:30:00Z",
+    "generadoPorUsuarioId": "...",
+    "incluyeAnulados": true
+  },
+  "asientos": [
+    {
+      "numero": 1,
+      "numeroFormateado": "2026-000001",
+      "fechaContable": "2026-05-01",
+      "origen": "AHORRO_DEPOSITO",
+      "estado": "REGISTRADO",
+      "glosa": "Depósito MOV-... en cuenta AHO-...",
+      "referenciaExterna": "MOV-2026-000001",
+      "motivoAnulacion": null,
+      "totalDebe": "1500.00",
+      "totalHaber": "1500.00",
+      "partidas": [
+        {
+          "codigoCuenta": "1.1.03",
+          "nombreCuenta": "Bancos Cta Corriente Bs",
+          "debe": "1500.00",
+          "haber": "0.00",
+          "glosa": "Ingreso por transferencia del socio",
+          "orden": 1
+        },
+        {
+          "codigoCuenta": "2.1.01",
+          "nombreCuenta": "Cuentas de Ahorro Bs",
+          "debe": "0.00",
+          "haber": "1500.00",
+          "glosa": "Crédito en cuenta de ahorro",
+          "orden": 2
+        }
+      ]
+    }
+  ],
+  "totales": {
+    "cantidadAsientos": 1,
+    "cantidadAnulados": 0,
+    "totalDebe": "1500.00",
+    "totalHaber": "1500.00",
+    "balanceado": true
+  }
+}
+```
+
+## Formato del PDF
+
+- **Tamaño**: A4 horizontal (paisaje) — para acomodar 7 columnas legibles.
+- **Cabecera**: razón social + RIF + título "LIBRO DIARIO" + período + fecha generación.
+- **Tabla**: columnas `Fecha | Nº Asiento | Origen | Código | Cuenta | Glosa | Debe | Haber`.
+- **Asientos**: fila "agrupadora" con datos de cabecera (fecha, número, origen, glosa) en gris claro, seguida de N filas con cada partida.
+- **Asientos ANULADOS**: fondo rojo claro + texto rojo + tag `[ANULADO]` + motivo.
+- **Totales**: al pie del documento — cantidad, total DEBE, total HABER, indicador BALANCEADO ✓ / ⚠ DESBALANCEADO.
+- **Folio**: `Página N` al pie de cada página (event handler PdfWriter).
+
+## Decisiones de diseño tomadas
+
+### Asientos anulados se incluyen por defecto ([[_decisiones-contables#D-006|D-006]])
+
+SUDECA exige el libro **completo** — la inmutabilidad legal aplica a TODO lo
+registrado, no solo a lo activo. Los anulados se muestran con marca visual
+(fondo rojo, tag `[ANULADO]`, motivo). El parámetro `incluirAnulados=false`
+permite ocultarlos solo si se necesita una vista limpia para fines internos.
+
+### Formato del número correlativo: `AÑO-NNNNNN`
+
+El `numeroFormateado` se construye como `{año de fechaContable}-{numero a 6 dígitos}` (ej. `"2026-000001"`). Esto presenta el número de forma "anual" sin
+requerir cambio del modelo de BD.
+
+> [!warning] Pendiente regulatorio
+> La SEQUENCE BD (`seq_asiento_numero`) actualmente NO se resetea por año
+> fiscal. SUDECA exige reset anual real. Para esta iteración solo formateamos
+> visualmente. **Antes del primer cierre fiscal serio** hay que implementar
+> el reset real — ver [[_pendientes-criticos#Reset-anual-del-correlativo-de-asientos|P1]].
+
+### Properties configurables para identidad de la entidad
+
+Razón social y RIF se configuran vía `application.yml`:
+
+```yaml
+entidad:
+  razonSocial: "Asociación Fatrans de Ahorro y Crédito"
+  rif: "J-XXXXXXXX-X"
+  direccion: "..."
+  sigla: "FATRANS"
+```
+
+Defaults documentan que es necesario configurar (`"(configurar)"`). Si en el
+futuro se necesita UI de admin para editarlos, sub-issue dedicado migra a
+`parametros_sistema` en BD.
+
+### Puerto PDF dedicado al módulo contabilidad
+
+Se creó `ContabilidadPdfPort` propio del módulo en lugar de reutilizar el
+`PdfGeneratorPort` de `documentospdf`. Razón:
+
+- `PdfGeneratorPort` está acoplado a `TipoDocumento` enum del otro módulo (acoplaría módulos).
+- Los reportes contables tienen contrato distinto (DTO tipado vs `Map<String, Object>`).
+- Misma librería (OpenPDF) puede compartirse — solo el contrato es separado.
+
+## Arquitectura (3 capas)
+
+```
+LibroDiarioController (api/controller)
+        │
+        │ GET /api/v1/contabilidad/libro-diario[?...formato=PDF]
+        ▼
+GenerarLibroDiarioUseCase (application/usecase)
+        │   - valida filtro vía LibroDiarioFilter
+        │   - lookup asientos vía AsientoContableRepository.listarPorRangoFecha
+        │   - lookup nombres de cuenta vía CuentaContableRepository.listarTodas
+        │   - construye LibroDiarioResponse con totales
+        ▼ (si pidieron PDF)
+ContabilidadPdfPort (application/port/output)
+        │
+        ▼
+LibroDiarioPdfAdapter (infrastructure/pdf — OpenPDF)
+```
+
+## Tests (21 nuevos, todos verde)
+
+| Test class | Casos | Estrategia |
+|---|---|---|
+| `LibroDiarioFilterTest` | 7 | Validaciones de rango (≤ 1 año, hasta ≥ desde, null check) |
+| `GenerarLibroDiarioUseCaseTest` | 9 | Mockito — happy path, encabezado, partidas resueltas, anulados con/sin, período vacío, cuenta faltante (fallback), formato del número |
+| `LibroDiarioPdfAdapterTest` | 5 | Verificación de bytes PDF (header `%PDF`), períodos vacíos / con asientos / con anulados / con muchas filas (paginación) / desbalance defensivo |
+
+### Casos cubiertos
+
+> [!check] Garantías
+> - ✅ Rango ≤ 1 año fiscal (366 días). Rangos mayores rechazados.
+> - ✅ `hasta < desde` rechazado.
+> - ✅ Encabezado completo (razón social, RIF, período, auditoría).
+> - ✅ Partidas resuelven nombre de cuenta vía lookup (1 query, indexado en memoria).
+> - ✅ Asientos anulados con marca visual + motivo de anulación visible.
+> - ✅ `incluirAnulados=false` filtra los ANULADOS.
+> - ✅ Período sin asientos: response vacío balanceado en cero (no rompe).
+> - ✅ Cuenta no encontrada en plan: fallback a UUID + nombre genérico (no rompe).
+> - ✅ Totales del período son la suma exacta de cada asiento.
+> - ✅ PDF se genera con bytes válidos `%PDF`, escala a 50+ asientos sin OOM.
+> - ✅ PDF marca visualmente desbalances (caso defensivo, no debería ocurrir).
+
+## Pendientes intencionalmente fuera de scope
+
+- ⏳ **Reset anual real del correlativo** ([[_pendientes-criticos#Reset-anual-del-correlativo-de-asientos|P1]]) — actualmente solo formateamos visualmente, BD usa SEQUENCE continua.
+- ⏳ **Firma digital del PDF** — SUDECA exige firma del contador y representante legal en formato impreso. Versión digital con FEA queda como sub-issue dedicado.
+- ⏳ **Rol `CONTADOR` dedicado** — actualmente solo admins acceden. Sub-issue para agregar al enum `Rol`.
+- ⏳ **Razón social en BD** — actualmente properties. Si se necesita UI de admin, migrar a `parametros_sistema`.
+
+## Cómo usar
+
+### Desde un cliente HTTP (admin autenticado)
+
+```bash
+# JSON
+curl -X GET \
+  -H "Authorization: Bearer $JWT" \
+  "https://qa-api.fatrans.com.ve/api/v1/contabilidad/libro-diario?desde=2026-05-01&hasta=2026-05-31"
+
+# PDF
+curl -X GET \
+  -H "Authorization: Bearer $JWT" \
+  -o LibroDiario_Mayo2026.pdf \
+  "https://qa-api.fatrans.com.ve/api/v1/contabilidad/libro-diario/pdf?desde=2026-05-01&hasta=2026-05-31"
+```
+
+### Desde el frontend admin (cuando se construya)
+
+El frontend de admin puede:
+1. Mostrar tabla con los asientos del JSON, paginada client-side.
+2. Botón "Descargar PDF" que invoca el endpoint `/pdf` con los mismos filtros.
+
+## Referencias
+
+- Issue: [[Home|#269]]
+- Decisión: [[_decisiones-contables#D-006|D-006 — incluir anulados, formato anual del correlativo]]
+- Dependencias: [[01-plan-cuentas|#264]], [[02-asientos-contables|#265+#266]]
+- Próximo: [[06-libro-mayor]] (#270) — saldos acumulados por cuenta

--- a/docs/modulos/contabilidad/06-libro-mayor.md
+++ b/docs/modulos/contabilidad/06-libro-mayor.md
@@ -1,0 +1,251 @@
+---
+tags: [contabilidad, reporte, libro-mayor, sudeca, ven-nif]
+sub-issue: "#270"
+pr: en-curso
+estado: implementado
+created: 2026-05-20
+---
+
+# 📚 Libro Mayor — saldos y movimientos por cuenta
+
+> [!summary] Sub-issue [[Home|#270]] — IMPLEMENTADO
+> Reporte SUDECA que agrupa los movimientos contables **por cuenta**: para
+> cada cuenta muestra saldo inicial al comienzo del período, todos los
+> movimientos del rango con su contracuenta, saldo acumulado por línea, y
+> saldo final. Base de los reportes superiores ([[07-balance-general|#271]]).
+
+## Endpoint
+
+```http
+GET /api/v1/contabilidad/libro-mayor
+GET /api/v1/contabilidad/libro-mayor/pdf
+```
+
+**Permisos**: `ROLE_ADMIN`, `ROLE_SUPER_ADMIN`, `ROLE_SISTEMA`. Falta rol
+`CONTADOR` dedicado — pendiente P2 documentado.
+
+### Query parameters
+
+| Parámetro | Tipo | Default | Descripción |
+|---|---|---|---|
+| `desde` | `LocalDate` | **obligatorio** | Inicio del período (inclusive) |
+| `hasta` | `LocalDate` | **obligatorio** | Fin del período (inclusive) |
+| `codigoCuenta` | `String` | `null` | Filtra a una sola cuenta (ej. `1.1.03`) |
+| `incluirSinMovimientos` | `boolean` | `false` | Si `true`, muestra cuentas sin movimientos en el período |
+| `incluirTotalizadoras` | `boolean` | `false` | Si `true`, muestra también cuentas no-hoja |
+
+### Validaciones de rango
+
+- `hasta >= desde` — sino `400 Bad Request`
+- `(hasta - desde) ≤ 366 días` — sino `400 Bad Request`
+
+## Diferencia con Libro Diario
+
+| Aspecto | [[05-libro-diario\|Libro Diario]] (#269) | Libro Mayor (#270) |
+|---|---|---|
+| Agrupación | Por **asiento** cronológico | Por **cuenta** alfabético |
+| Asientos ANULADOS | **Incluidos** con marca visual | **Excluidos** (saldos vigentes) |
+| Para qué sirve | Historial / auditoría | Saldos por cuenta / base de reportes |
+| Saldo acumulado | No aplica | Sí, por línea de movimiento |
+
+> [!note] Por qué los ANULADOS se excluyen en el Mayor pero se incluyen en el Diario
+> El Libro Diario es **historial** (la verdad histórica de lo que pasó, incluso si se anuló). El Libro Mayor es **saldo vigente** — un asiento anulado no debe afectar saldos. Esta diferencia es clave por exigencia VEN-NIF.
+
+## Estructura del response JSON
+
+```json
+{
+  "encabezado": {
+    "razonSocial": "Asociación Fatrans de Ahorro y Crédito",
+    "rif": "J-XXXXXXXX-X",
+    "desde": "2026-05-01",
+    "hasta": "2026-05-31",
+    "generadoEn": "2026-05-20T14:30:00Z",
+    "generadoPorUsuarioId": "...",
+    "filtroCuenta": null,
+    "incluyeSinMovimientos": false,
+    "incluyeTotalizadoras": false
+  },
+  "cuentas": [
+    {
+      "codigo": "1.1.03",
+      "nombre": "Bancos Cuenta Corriente Bs",
+      "tipo": "ACTIVO",
+      "naturaleza": "DEUDORA",
+      "saldoInicialDebe": "5000.00",
+      "saldoInicialHaber": "0.00",
+      "saldoInicialNeto": "5000.00",
+      "saldoInicialEtiqueta": "D",
+      "movimientos": [
+        {
+          "fechaContable": "2026-05-03",
+          "numeroAsiento": 5,
+          "numeroAsientoFormateado": "2026-000005",
+          "origen": "AHORRO_DEPOSITO",
+          "glosaAsiento": "Depósito MOV-001 en cuenta AHO-001",
+          "referenciaExterna": "MOV-2026-000001",
+          "contracuentaCodigo": "2.1.01",
+          "contracuentaNombre": "Cuentas de Ahorro Bs",
+          "contracuentaResumen": null,
+          "debe": "1500.00",
+          "haber": "0.00",
+          "saldoAcumulado": "6500.00"
+        }
+      ],
+      "totalDebePeriodo": "1500.00",
+      "totalHaberPeriodo": "0.00",
+      "cantidadMovimientos": 1,
+      "saldoFinalDebe": "6500.00",
+      "saldoFinalHaber": "0.00",
+      "saldoFinalNeto": "6500.00",
+      "saldoFinalEtiqueta": "D"
+    }
+  ],
+  "totales": {
+    "cantidadCuentas": 1,
+    "cantidadMovimientos": 1,
+    "totalDebe": "1500.00",
+    "totalHaber": "0.00",
+    "balanceado": false
+  }
+}
+```
+
+> [!info] Sobre `totales.balanceado`
+> Cuando se filtran solo algunas cuentas (no todo el plan), el total puede no estar balanceado — es esperado. Solo cuando se generar el Mayor SIN filtros (todas las cuentas hoja) los totales deberían cuadrar porque cada partida DEBE de un asiento tiene su HABER correspondiente en otra cuenta.
+
+## Formato del PDF
+
+- **Tamaño**: A4 horizontal.
+- **Cabecera**: razón social, RIF, "LIBRO MAYOR", período, filtro aplicado.
+- **Por cada cuenta**:
+  - Cabecera con código + nombre + tipo + naturaleza
+  - "Saldo inicial: X.XX D/A/—"
+  - Tabla con 8 columnas: `Fecha | Nº Asiento | Origen | Contracuenta | Glosa | Debe | Haber | Saldo`
+  - Si no hay movimientos: fila única "(sin movimientos en el período)"
+  - Línea de resumen con totales del período + saldo final
+- **Totales generales** al pie con cantidad de cuentas, movimientos, Σ Debe, Σ Haber.
+- **Folio "Página N"** al pie de cada página.
+
+## Decisiones de diseño (D-007)
+
+### 1. Saldo inicial real (no asumir cero)
+
+Se calcula con `SUM` agregado de todas las partidas previas a `desde-1`,
+excluyendo asientos ANULADOS. Una sola query SQL eficiente por cuenta.
+
+**Razón**: el Libro Mayor sin saldo inicial real es un dato falso. SUDECA y
+VEN-NIF lo exigen.
+
+### 2. Solo cuentas hoja por default
+
+Las totalizadoras (nivel 1-2) se calculan sumando hijas — eso es trabajo del
+**Balance General** (#271), no del Mayor. Aquí solo cuentas operativas
+(con `acepta_movimientos=true`). Parámetro `incluirTotalizadoras=true`
+para verlas igual.
+
+### 3. Cuentas sin movimientos excluidas por default
+
+Reporte limpio. Si el contador necesita ver TODAS las cuentas (ej. mostrar
+`1.1.03 = saldo 0`), toggle `incluirSinMovimientos=true`.
+
+### 4. Saldo en formato absoluto + tag (D/A/—)
+
+Convención SUDECA: `3,800.00 (D)` en lugar de `+3,800.00` o `-3,800.00`.
+La cuenta sabe por su naturaleza si el saldo es "esperado" (D para deudoras,
+A para acreedoras). Si el saldo queda del lado opuesto (caso atípico pero
+válido), el tag se invierte.
+
+### 5. Contracuenta visible en cada movimiento
+
+Para cada partida de la cuenta del mayor, se busca la **cuenta principal del lado opuesto** en el mismo asiento (la de mayor monto si hay varias). Esto mejora masivamente la legibilidad: "esta partida de Bancos vino de un depósito en Ahorros". Si el asiento tiene > 2 partidas en el lado opuesto, se muestra la principal + tag `(múltiple)`.
+
+### 6. Asientos ANULADOS excluidos del Mayor
+
+A diferencia del Diario, el Mayor es saldo vigente, no historial. Los
+anulados no afectan saldos. Si el contador quiere ver el historial completo
+con anulados, va al Libro Diario.
+
+### 7. Adapter PDF unificado en `LibroDiarioPdfAdapter`
+
+El archivo se llama `LibroDiarioPdfAdapter` por razones históricas (creado
+en #269) pero implementa **todo el `ContabilidadPdfPort`** — Diario y Mayor.
+Cuando #269 esté mergeado en develop, vale la pena un commit de refactor
+que renombre a `ContabilidadPdfAdapter`. Por ahora, evita diff masivo entre
+PRs hermanos.
+
+## Performance
+
+| Operación | Costo |
+|---|---|
+| Plan de cuentas | 1 query (cacheable en memoria) |
+| Saldo inicial por cuenta | 1 query SQL `SUM` agregada |
+| Movimientos del período por cuenta | 1 query JPA con hidratación batch (sin N+1) |
+| **Total para N cuentas** | `2N + 1` queries |
+
+Para ~50 cuentas operativas típicas: ~100 queries. Aceptable.
+
+**Optimización futura** (si se vuelve lento): cachear saldos cerrados al
+final de cada mes en una tabla `saldos_mensuales` poblada por el job de
+cierre (#272). El Mayor solo lee del último cierre + movimientos posteriores.
+
+## Tests (31 nuevos, todos verde)
+
+| Test class | Casos | Estrategia |
+|---|---|---|
+| `LibroMayorFilterTest` | 8 | Unit — validaciones de rango, flags, factories |
+| `GenerarLibroMayorUseCaseTest` | 11 | Mockito — filtros, saldo inicial, contracuenta, saldo acumulado, totales |
+| `LibroMayorPdfAdapterTest` | 5 | Verificación bytes PDF, casos borde (vacío, sin movimientos, muchas cuentas, desbalanceado) |
+| `AsientoContableRepositoryLibroMayorTest` | 7 | `@DataJpaTest` con H2 — queries nativas SUM + JOIN, filtrado por cuenta y estado |
+
+### Garantías verificadas
+
+> [!check]
+> - ✅ Rango ≤ 1 año fiscal validado
+> - ✅ Sin filtro → solo hojas por default (totalizadora 1.1 excluida)
+> - ✅ `incluirSinMovimientos=true` muestra cuentas vacías
+> - ✅ `incluirTotalizadoras=true` incluye cuentas no-hoja
+> - ✅ Filtro por código devuelve solo esa cuenta
+> - ✅ Código inexistente → `AsientoContableException`
+> - ✅ Saldo inicial se calcula con SUM hasta `desde-1`
+> - ✅ Etiqueta D/A/— según naturaleza y signo del saldo
+> - ✅ Contracuenta correctamente resuelta (cuenta opuesta del asiento)
+> - ✅ Saldo acumulado calculado progresivamente movimiento a movimiento
+> - ✅ Asientos ANULADOS excluidos por la query (no aparecen en saldo ni movimientos)
+> - ✅ SUM agregado a fecha de corte funciona en H2
+> - ✅ Rango inclusive en ambos extremos
+> - ✅ Cuenta no involucrada en el asiento no aparece en sus resultados
+> - ✅ Decimales NUMERIC(18,4) preservados
+
+## Cómo usar
+
+```bash
+# Mayor completo del mes de mayo (solo cuentas con movimientos)
+curl -X GET \
+  -H "Authorization: Bearer $JWT" \
+  "https://qa-api.fatrans.com.ve/api/v1/contabilidad/libro-mayor?desde=2026-05-01&hasta=2026-05-31"
+
+# Mayor de una cuenta específica con saldo aunque sea cero
+curl -X GET \
+  -H "Authorization: Bearer $JWT" \
+  "https://qa-api.fatrans.com.ve/api/v1/contabilidad/libro-mayor?desde=2026-05-01&hasta=2026-05-31&codigoCuenta=1.1.03&incluirSinMovimientos=true"
+
+# Descargar PDF
+curl -X GET -H "Authorization: Bearer $JWT" \
+  -o LibroMayor_Mayo2026.pdf \
+  "https://qa-api.fatrans.com.ve/api/v1/contabilidad/libro-mayor/pdf?desde=2026-05-01&hasta=2026-05-31"
+```
+
+## Pendientes intencionalmente fuera de scope
+
+- ⏳ **Tabla `saldos_mensuales` cacheada** — para acelerar el Mayor cuando crezcan los volúmenes. Parte del cierre mensual (#272).
+- ⏳ **Rol `CONTADOR` dedicado** ([[_pendientes-criticos|P2]]).
+- ⏳ **Firma digital del PDF** — sub-issue futuro.
+- ⏳ **Reset anual real del correlativo** ([[_pendientes-criticos|P1]]).
+
+## Referencias
+
+- Issue: [[Home|#270]]
+- Decisión: [[_decisiones-contables#D-007|D-007 — saldo real, solo hojas, anulados excluidos]]
+- Dependencias: [[01-plan-cuentas|#264]], [[02-asientos-contables|#265+#266]], [[05-libro-diario|#269]] (reutiliza `EntidadProperties` y `ContabilidadPdfPort`)
+- Próximo: [[07-balance-general]] (#271)

--- a/docs/modulos/contabilidad/Home.md
+++ b/docs/modulos/contabilidad/Home.md
@@ -28,7 +28,8 @@ estado: en-construccion
 - 📋 [[01-plan-cuentas]] — #264 — Plan de cuentas VEN-NIF (V21, ~55 cuentas)
 - 🧾 [[02-asientos-contables]] — #265 + #266 — Tablas + dominio + service partida doble
 - 🔌 [[03-hooks-ahorros]] — #267 — Hooks Ahorros: depósito/retiro → asiento auto
-- 🔌 [[04-hooks-creditos]] — #268 — Hooks Créditos: desembolso/cobro → asiento auto (en diseño)
+- 🔌 [[04-hooks-creditos]] — #268 — Hooks Créditos: desembolso/cobro → asiento auto
+- 📖 [[05-libro-diario]] — #269 — Reporte Libro Diario JSON + PDF SUDECA
 
 ## Mapa del módulo (código)
 
@@ -67,8 +68,8 @@ backend/src/main/java/com/tufondo/ahorros/
 | [[01-plan-cuentas\|#264]] | ✅ Merged (PR #313) | Plan de cuentas VEN-NIF (V21) — ~55 cuentas seed | [[_decisiones-contables#D-001\|D-001]] V21 congelado |
 | [[02-asientos-contables\|#265 + #266]] | ✅ Merged (PR #314) | Tablas + dominio + service + 50+ tests | Asientos inmutables, ON DELETE RESTRICT |
 | [[03-hooks-ahorros\|#267]] | ✅ Merged (PR #315) | Hooks de Ahorros: depósito/retiro → asiento auto | [[_decisiones-contables#D-002\|D-002]] usar `1.1.03` no `1.1.01` |
-| [[04-hooks-creditos\|#268]] | 🚧 En PR | Hooks de Créditos: desembolso + pago cuota → asiento auto | [[_decisiones-contables#D-003\|D-003]] [[_decisiones-contables#D-004\|D-004]] |
-| #269 | ⏳ Pending | Libro Diario + export PDF SUDECA | |
+| [[04-hooks-creditos\|#268]] | ✅ Merged (PR #316) | Hooks de Créditos: desembolso/cobro → asiento auto | [[_decisiones-contables#D-003\|D-003]] [[_decisiones-contables#D-004\|D-004]] |
+| [[05-libro-diario\|#269]] | 🚧 PR #317 abierto | Libro Diario JSON + PDF SUDECA | [[_decisiones-contables#D-006\|D-006]] incluir anulados |
 | #270 | ⏳ Pending | Libro Mayor (saldos por cuenta) | |
 | #271 | ⏳ Pending | Balance General + Estado de Resultados | |
 | #272 | ⏳ Pending | Cierre mensual / anual con bloqueo de período | |

--- a/docs/modulos/contabilidad/Home.md
+++ b/docs/modulos/contabilidad/Home.md
@@ -30,6 +30,7 @@ estado: en-construccion
 - 🔌 [[03-hooks-ahorros]] — #267 — Hooks Ahorros: depósito/retiro → asiento auto
 - 🔌 [[04-hooks-creditos]] — #268 — Hooks Créditos: desembolso/cobro → asiento auto
 - 📖 [[05-libro-diario]] — #269 — Reporte Libro Diario JSON + PDF SUDECA
+- 📚 [[06-libro-mayor]] — #270 — Reporte Libro Mayor (saldos y movimientos por cuenta)
 
 ## Mapa del módulo (código)
 
@@ -70,7 +71,7 @@ backend/src/main/java/com/tufondo/ahorros/
 | [[03-hooks-ahorros\|#267]] | ✅ Merged (PR #315) | Hooks de Ahorros: depósito/retiro → asiento auto | [[_decisiones-contables#D-002\|D-002]] usar `1.1.03` no `1.1.01` |
 | [[04-hooks-creditos\|#268]] | ✅ Merged (PR #316) | Hooks de Créditos: desembolso/cobro → asiento auto | [[_decisiones-contables#D-003\|D-003]] [[_decisiones-contables#D-004\|D-004]] |
 | [[05-libro-diario\|#269]] | 🚧 PR #317 abierto | Libro Diario JSON + PDF SUDECA | [[_decisiones-contables#D-006\|D-006]] incluir anulados |
-| #270 | ⏳ Pending | Libro Mayor (saldos por cuenta) | |
+| [[06-libro-mayor\|#270]] | 🚧 PR #318 abierto | Libro Mayor JSON + PDF (saldos por cuenta) | [[_decisiones-contables#D-007\|D-007]] saldo real, solo hojas |
 | #271 | ⏳ Pending | Balance General + Estado de Resultados | |
 | #272 | ⏳ Pending | Cierre mensual / anual con bloqueo de período | |
 | #273 | ⏳ Pending | Reversión de asientos (asiento inverso, sin DELETE) | |

--- a/docs/modulos/contabilidad/_decisiones-contables.md
+++ b/docs/modulos/contabilidad/_decisiones-contables.md
@@ -237,6 +237,50 @@ HABER 4.1.05 Comisiones Otras (cuenta a crear)
 
 ---
 
+## D-006 — Libro Diario incluye anulados por defecto + formato visual anual del correlativo
+
+**Fecha:** 2026-05-20
+**Sub-issue:** [[05-libro-diario|#269]]
+**Estado:** ✅ Aprobada e implementada
+**Revisor:** [[_contador-fatrans|contador-fatrans]] (rol asumido en sesión, archivo activo)
+
+### Contexto
+Al diseñar el Libro Diario surgieron dos preguntas:
+1. ¿Incluir asientos ANULADOS o solo REGISTRADOS?
+2. ¿El correlativo debe resetearse anualmente como exige SUDECA?
+
+### Decisión
+
+**1. Incluir ANULADOS por defecto, con marca visual.**
+
+El parámetro `incluirAnulados` default es `true`. Los anulados aparecen con
+fondo rojo claro, texto rojo, tag `[ANULADO]` y motivo visible.
+
+**Razón regulatoria**: SUDECA exige auditoría completa. La inmutabilidad legal
+aplica a TODO lo registrado, no solo a lo activo. Censurar anulados del Libro
+Diario sería hallazgo de auditoría.
+
+**2. Formato anual visual del correlativo (sin cambiar BD por ahora).**
+
+El campo `numeroFormateado` muestra el número como `AÑO-NNNNNN` (ej. `2026-000001`),
+construido como `{año de fechaContable}-{numero a 6 dígitos}`. La SEQUENCE
+BD `seq_asiento_numero` sigue corriendo continua.
+
+**Razón temporal**: cambiar la SEQUENCE para reset anual requiere migration
++ posiblemente cambio del modelo `AsientoContable` (agregar campo `año_fiscal`).
+Es trabajo no trivial. Para esta iteración, formateamos visualmente como
+quick win. Bloqueante real: antes del primer cierre fiscal serio.
+
+### Consecuencias
+
+- Endpoint `GET /libro-diario?incluirAnulados=true|false` permite a admin
+  toggear si necesita vista limpia.
+- PDF marca visualmente los anulados.
+- **Pendiente P1 abierto**: "Reset anual del correlativo de asientos" en
+  [[_pendientes-criticos]]. Sub-issue dedicado antes del primer cierre.
+
+---
+
 ## D-005 — (PENDIENTE) Criterio de caja vs devengo para intereses de cartera
 
 **Fecha:** 2026-05-20

--- a/docs/modulos/contabilidad/_decisiones-contables.md
+++ b/docs/modulos/contabilidad/_decisiones-contables.md
@@ -281,6 +281,72 @@ quick win. Bloqueante real: antes del primer cierre fiscal serio.
 
 ---
 
+## D-007 — Libro Mayor: saldo inicial real, solo hojas, ANULADOS excluidos
+
+**Fecha:** 2026-05-20
+**Sub-issue:** [[06-libro-mayor|#270]]
+**Estado:** ✅ Aprobada e implementada
+**Revisor:** [[_contador-fatrans|contador-fatrans]] (rol asumido en sesión)
+
+### Contexto
+Al diseñar el Libro Mayor (siguiente reporte después del Diario), surgieron
+varias decisiones clave que cambian el comportamiento respecto al Diario.
+
+### Decisiones
+
+**1. Saldo inicial REAL (no asumir cero).**
+
+Se calcula con `SUM` agregado de todas las partidas previas a `desde-1`,
+una sola query nativa SQL por cuenta. Excluye ANULADOS.
+
+*Razón*: el Libro Mayor sin saldo inicial real es un dato falso. Si pides
+el Mayor de Mayo, necesitas ver el saldo arrastrado desde antes. Exigencia
+VEN-NIF.
+
+**2. Solo cuentas HOJA (operativas) por default.**
+
+Las totalizadoras (nivel 1-2) se calculan sumando hijas — eso pertenece al
+Balance General (#271), no al Mayor. Parámetro `incluirTotalizadoras=true`
+opcional.
+
+**3. Cuentas SIN movimientos excluidas por default.**
+
+Reporte limpio. Parámetro `incluirSinMovimientos=true` para vista completa.
+
+**4. Asientos ANULADOS EXCLUIDOS del Mayor.**
+
+A diferencia del Diario (que los incluye con marca para auditoría completa),
+el Mayor refleja saldos vigentes — un asiento anulado NO afecta saldos.
+Esto se enforza a nivel query: el repo solo cuenta los `REGISTRADO`.
+
+*Razón*: separación clara Diario (historial) vs Mayor (saldo). El contador
+que quiere ver el historial completo va al Diario.
+
+**5. Saldos en formato absoluto + tag (D/A/—).**
+
+Convención SUDECA: `3,800.00 (D)` en lugar de signos. La cuenta sabe por su
+naturaleza si el saldo es "esperado" (D para deudoras, A para acreedoras).
+Si el saldo queda del lado opuesto (caso atípico pero válido), el tag se
+invierte.
+
+**6. Contracuenta resuelta y visible por movimiento.**
+
+Para cada partida de la cuenta del mayor, se busca la cuenta del lado
+opuesto en el mismo asiento. Si hay > 1 (ej. desembolso con comisión),
+se toma la de mayor monto + tag `(múltiple)`. Mejora UX masivamente.
+
+### Consecuencias
+
+- 2 queries nuevas en `AsientoContableRepository` port:
+  `calcularSaldoCuentaHasta()` y `listarAsientosDeCuentaEnRango()`.
+- Record nuevo `SaldoCuenta` en `domain.model`.
+- DTOs nuevos `LibroMayorFilter` y `LibroMayorResponse`.
+- Performance: `2N+1` queries para N cuentas. Aceptable para ~50 cuentas
+  hoja típicas. Optimización futura: cachear saldos cerrados (parte de #272).
+- Adapter PDF unificado en `LibroDiarioPdfAdapter` (renombre a futuro).
+
+---
+
 ## D-005 — (PENDIENTE) Criterio de caja vs devengo para intereses de cartera
 
 **Fecha:** 2026-05-20

--- a/docs/modulos/contabilidad/_pendientes-criticos.md
+++ b/docs/modulos/contabilidad/_pendientes-criticos.md
@@ -98,6 +98,57 @@ HABER 2.1.01 Cuentas de Ahorro Bs (o el destino real del pago)
 - [ ] Implementar `DevengarInteresesAhorrosJob`.
 - [ ] Cuando #267 madure: hook `OrigenAsiento.AHORRO_INTERES` para el pago.
 
+### Reset anual del correlativo de asientos
+**Decisión origen:** [[_decisiones-contables#D-006|D-006]]
+**Sub-issue:** sin asignar — abrir antes del primer cierre fiscal
+**Prioridad:** P1 (bloqueante antes del primer cierre)
+
+SUDECA exige que el correlativo del Libro Diario se reinicie en 1 al inicio
+de cada año fiscal. Actualmente la SEQUENCE `seq_asiento_numero` corre
+continua desde siempre y nunca se resetea.
+
+El sub-issue **#269** parchó esto visualmente formateando el número como
+`AÑO-NNNNNN` (ej. `2026-000123` aunque internamente el número sea `47891`).
+Esto es aceptable para mostrar reportes pero NO para auditoría formal.
+
+**Implementación correcta**:
+
+**Opción A — Cambiar el modelo**: agregar campo `año_fiscal` y `numero_anual`
+a `asientos_contables`. SEQUENCE separada por año o lógica de aplicación
+para asignar el siguiente número del año en curso.
+
+**Opción B — Reset físico de SEQUENCE**: job al inicio de cada año fiscal:
+```sql
+ALTER SEQUENCE seq_asiento_numero RESTART WITH 1;
+```
+Combinado con un campo `numero_anual` que se inserta en el asiento.
+
+**Tareas**:
+- [ ] Decidir opción A vs B con contador colegiado.
+- [ ] Migration nueva (V23+) con el cambio.
+- [ ] Modificar `AsientoContableRepositoryImpl` para usar el nuevo correlativo.
+- [ ] Actualizar `GenerarLibroDiarioUseCase.formatearNumero()` para usar el
+  campo persistido en lugar del cálculo visual.
+- [ ] Job `@Scheduled` que ejecute el reset el 1 de enero a las 00:00 UTC-4.
+
+### Crear rol CONTADOR dedicado
+**Sub-issue:** sin asignar
+**Prioridad:** P2 (mejora de control de acceso)
+
+El enum `Rol` actual tiene `SOCIO, ADMIN, SUPER_ADMIN, CAJERO, ANALISTA_KYC,
+ANALISTA_CREDITO, SISTEMA`. Falta `CONTADOR` dedicado.
+
+Hoy los endpoints contables (`/libro-diario`, futuros `/libro-mayor`,
+`/balance-general`) usan `ADMIN/SUPER_ADMIN/SISTEMA`. Ideal: `CONTADOR`
+puede leer reportes pero NO ejecutar operaciones operativas como crear
+socios, modificar tasas, etc.
+
+**Tareas**:
+- [ ] Agregar `CONTADOR` al enum `Rol`.
+- [ ] Definir permisos en `SecurityConfig` (lectura contable + asientos manuales).
+- [ ] Actualizar `@PreAuthorize` de controllers contables.
+- [ ] UI admin: pantalla para asignar rol CONTADOR.
+
 ### Provisión de cartera de créditos
 **Prioridad:** P1
 


### PR DESCRIPTION
## Resumen

Sub-issue **#270** del EPIC Contabilidad **#263**. **Segundo reporte SUDECA** después del Libro Diario (#269). Agrupa los movimientos contables **por cuenta**: para cada una muestra saldo inicial real, lista de movimientos con contracuenta resuelta, saldo acumulado por línea, y saldo final.

> [!warning] Branch basada en `feat/contab-libro-diario-269`
> Este PR depende del PR #317 (Libro Diario) que también está abierto. Cuando #317 mergee, este PR queda limpio; sino, hay que rebasear (`git rebase develop`).

## Endpoints

```http
GET /api/v1/contabilidad/libro-mayor          (JSON)
GET /api/v1/contabilidad/libro-mayor/pdf      (descarga A4 horizontal)
```

| Query param | Default | Descripción |
|---|---|---|
| `desde` / `hasta` | obligatorio | Rango ≤ 1 año fiscal |
| `codigoCuenta` | `null` | Filtra a una sola cuenta (ej. `1.1.03`) |
| `incluirSinMovimientos` | `false` | Muestra cuentas sin movimientos en el período |
| `incluirTotalizadoras` | `false` | Incluye cuentas no-hoja (nivel 1-2) |

**Permisos**: `ROLE_ADMIN`, `ROLE_SUPER_ADMIN`, `ROLE_SISTEMA`.

## Diferencias clave con Libro Diario

| | Libro Diario (#269) | Libro Mayor (#270) |
|---|---|---|
| Agrupación | Por **asiento** cronológico | Por **cuenta** alfabético |
| Anulados | **Incluidos** con marca | **Excluidos** (saldo vigente, no historial) |
| Saldo acumulado | No aplica | Sí, por línea |
| Filtros | rango + incluir anulados | rango + cuenta + sin mov + totalizadoras |

## Decisiones tomadas (D-007)

| # | Decisión | Razón |
|---|---|---|
| 1 | Saldo inicial REAL (SUM partidas previas) | Sin saldo de arrastre, el reporte es falso. Exigencia VEN-NIF. |
| 2 | Solo cuentas HOJA por default | Totalizadoras pertenecen al Balance General (#271). Toggle opcional. |
| 3 | Cuentas sin movimientos excluidas por default | Reporte limpio. Toggle `incluirSinMovimientos`. |
| 4 | Asientos ANULADOS EXCLUIDOS | Diferencia clave con Diario. El Mayor refleja saldo vigente. |
| 5 | Saldos formato absoluto + tag `D/A/—` | Convención SUDECA. |
| 6 | Contracuenta visible por movimiento | Mejora UX. `(múltiple)` si > 1 cuenta opuesta. |

## Arquitectura nueva

**Repository (extiende port)**:
- `calcularSaldoCuentaHasta(cuentaId, fechaCorte) → SaldoCuenta` — query SQL nativa `SUM` agregada
- `listarAsientosDeCuentaEnRango(cuentaId, desde, hasta)` — JOIN + hidratación batch

**Dominio**:
- record `SaldoCuenta(totalDebe, totalHaber)` con `saldoNeto(naturaleza)`, `mas()`, `cero()`

**Application**:
- `LibroMayorFilter` (record, validación rango)
- `LibroMayorResponse` (records anidados: Encabezado, CuentaConMovimientos, MovimientoMayor, Totales)
- `GenerarLibroMayorUseCase` (orquesta saldo + movimientos + contracuenta + acumulado)

**Port + Adapter**:
- `ContabilidadPdfPort.generarLibroMayorPdf()` (método nuevo)
- Implementado en mismo `LibroDiarioPdfAdapter` (ambos métodos en un solo bean)

**API**:
- `LibroMayorController` con JSON + PDF

## Tests reales — 31 nuevos, todos verde

Corridos en Docker (`maven:3.9-eclipse-temurin-21`) con BD H2 modo Postgres:

| Test class | Casos | Tipo |
|---|---|---|
| `LibroMayorFilterTest` | 8 | Unit — validaciones de rango y flags |
| `GenerarLibroMayorUseCaseTest` | 11 | Mockito — filtros, saldo inicial, contracuenta, saldo acumulado, totales |
| `LibroMayorPdfAdapterTest` | 5 | Verificación bytes PDF (`%PDF`), escalado, casos defensivos |
| `AsientoContableRepositoryLibroMayorTest` | 7 | **`@DataJpaTest` con H2 real** — verifica las queries nativas SUM + JOIN con datos reales |

**Suite completa backend: 607 tests / 0 failures / 0 errors** ✅

### Casos cubiertos exhaustivamente

- ✅ Rango ≤ 1 año fiscal, `hasta >= desde`, null check
- ✅ Sin filtro: solo hojas (totalizadora `1.1` excluida)
- ✅ `incluirSinMovimientos=true` muestra cuentas vacías
- ✅ `incluirTotalizadoras=true` incluye cuentas no-hoja
- ✅ Filtro por código devuelve solo esa cuenta
- ✅ Código inexistente → `AsientoContableException` clara
- ✅ Saldo inicial = SUM partidas previas a `desde-1` (verificado con H2)
- ✅ Etiqueta D/A/— según naturaleza y signo, incluso casos atípicos
- ✅ Contracuenta resuelta correctamente (2 partidas, > 2 con marca "(múltiple)")
- ✅ Saldo acumulado calculado progresivamente movimiento a movimiento
- ✅ Asientos ANULADOS excluidos por la query SQL
- ✅ SUM nativo funciona en H2 con `MODE=PostgreSQL`
- ✅ Rango inclusive en ambos extremos
- ✅ Cuentas ajenas al asiento no aparecen
- ✅ Decimales NUMERIC(18,4) preservados
- ✅ PDF se genera con bytes válidos `%PDF`
- ✅ PDF escala a 20+ cuentas sin OOM
- ✅ PDF marca desbalances defensivamente
- ✅ "(sin movimientos en el período)" se renderiza para cuentas vacías

## Performance

`2N + 1` queries para N cuentas hoja (~50-100 típicas). Aceptable para
volúmenes actuales. Optimización futura: cachear saldos cerrados al cierre
mensual (parte de #272).

## Documentación

- [`06-libro-mayor.md`](https://github.com/gamijoam/fatrans/blob/feat/contab-libro-mayor-270/docs/modulos/contabilidad/06-libro-mayor.md) (nuevo) — referencia completa
- `Home.md` + `00-overview.md` — estado actualizado
- `_decisiones-contables.md` — D-007 nuevo

## Pendientes documentados

- **Cachear saldos cerrados** al cierre mensual (parte de #272 — mejora performance del Mayor).
- **Refactor `LibroDiarioPdfAdapter` → `ContabilidadPdfAdapter`** (renombre cosmético — adapter unificado, nombre histórico).
- **Rol CONTADOR dedicado** (P2 ya documentado).

## Test plan (post-merge en QA)

- [ ] Generar Libro Mayor JSON del mes en curso sin filtros → ver todas las cuentas hoja con movimientos.
- [ ] Comparar saldos contra Libro Diario del mismo período (deben cuadrar).
- [ ] Filtrar por `codigoCuenta=1.1.03` (Bancos Bs) → ver solo esa cuenta con contracuentas resueltas.
- [ ] Generar PDF → abrir en visor → verificar formato tabular, saldos por línea, totales al pie.
- [ ] Anular un asiento → re-generar Mayor → verificar que el saldo se ajusta (no incluye el anulado).
- [ ] Probar con `incluirSinMovimientos=true` → ver cuentas con saldo cero explícito.
- [ ] Probar acceso con rol SOCIO → debe rechazar 403.