### PR TITLE
feat(contab #271): Balance General + Estado de Resultados — reportes finales VEN-NIF

### DIFF
--- a/backend/src/main/java/com/tufondo/contabilidad/api/controller/BalanceGeneralController.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/api/controller/BalanceGeneralController.java
@@ -1,0 +1,96 @@
+package com.tufondo.contabilidad.api.controller;
+
+import com.tufondo.contabilidad.application.dto.BalanceGeneralFilter;
+import com.tufondo.contabilidad.application.dto.BalanceGeneralResponse;
+import com.tufondo.contabilidad.application.port.output.ContabilidadPdfPort;
+import com.tufondo.contabilidad.application.usecase.GenerarBalanceGeneralUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+/**
+ * Controller del Balance General (sub-issue #271).
+ *
+ * <p>Reporte VEN-NIF de la situación patrimonial a una fecha. Endpoints:</p>
+ * <ul>
+ *   <li>{@code GET /api/v1/contabilidad/balance-general}      — JSON</li>
+ *   <li>{@code GET /api/v1/contabilidad/balance-general/pdf}  — descarga PDF</li>
+ * </ul>
+ */
+@RestController
+@RequestMapping("/api/v1/contabilidad/balance-general")
+@RequiredArgsConstructor
+@Tag(name = "Contabilidad - Balance General",
+        description = "Reporte VEN-NIF de la situación patrimonial a una fecha")
+public class BalanceGeneralController {
+
+    private final GenerarBalanceGeneralUseCase useCase;
+    private final ContabilidadPdfPort pdfPort;
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN','SUPER_ADMIN','SISTEMA')")
+    @Operation(summary = "Genera el Balance General en JSON",
+            description = "Permisos: ADMIN/SUPER_ADMIN/SISTEMA. fechaCorte obligatoria. " +
+                    "inicioEjercicio default = 1-enero del año del corte.")
+    public ResponseEntity<BalanceGeneralResponse> generar(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaCorte,
+            @RequestParam(required = false)
+                @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate inicioEjercicio,
+            @RequestParam(defaultValue = "false") boolean incluirCeros,
+            Authentication authentication) {
+
+        UUID solicitanteId = extraerUsuarioId(authentication);
+        BalanceGeneralFilter filter = new BalanceGeneralFilter(fechaCorte, inicioEjercicio, incluirCeros);
+        return ResponseEntity.ok(useCase.ejecutar(filter, solicitanteId));
+    }
+
+    @GetMapping("/pdf")
+    @PreAuthorize("hasAnyRole('ADMIN','SUPER_ADMIN','SISTEMA')")
+    @Operation(summary = "Genera el Balance General en PDF para descarga")
+    public ResponseEntity<byte[]> generarPdf(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fechaCorte,
+            @RequestParam(required = false)
+                @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate inicioEjercicio,
+            @RequestParam(defaultValue = "false") boolean incluirCeros,
+            Authentication authentication) {
+
+        UUID solicitanteId = extraerUsuarioId(authentication);
+        BalanceGeneralFilter filter = new BalanceGeneralFilter(fechaCorte, inicioEjercicio, incluirCeros);
+        BalanceGeneralResponse data = useCase.ejecutar(filter, solicitanteId);
+        byte[] pdf = pdfPort.generarBalanceGeneralPdf(data);
+
+        String filename = "BalanceGeneral_" + fechaCorte.format(DateTimeFormatter.BASIC_ISO_DATE) + ".pdf";
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_PDF_VALUE)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+                .header(HttpHeaders.CACHE_CONTROL, "no-store, no-cache, must-revalidate, private")
+                .body(pdf);
+    }
+
+    private UUID extraerUsuarioId(Authentication authentication) {
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof com.tufondo.auth.infrastructure.security.AuthenticatedUser authUser) {
+            UUID socioId = authUser.getSocioId();
+            if (socioId != null) return socioId;
+        }
+        try {
+            return UUID.fromString(authentication.getName());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/api/controller/EstadoResultadosController.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/api/controller/EstadoResultadosController.java
@@ -1,0 +1,91 @@
+package com.tufondo.contabilidad.api.controller;
+
+import com.tufondo.contabilidad.application.dto.EstadoResultadosFilter;
+import com.tufondo.contabilidad.application.dto.EstadoResultadosResponse;
+import com.tufondo.contabilidad.application.port.output.ContabilidadPdfPort;
+import com.tufondo.contabilidad.application.usecase.GenerarEstadoResultadosUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+/**
+ * Controller del Estado de Resultados (sub-issue #271).
+ *
+ * <p>Reporte VEN-NIF del excedente/déficit del período.</p>
+ */
+@RestController
+@RequestMapping("/api/v1/contabilidad/estado-resultados")
+@RequiredArgsConstructor
+@Tag(name = "Contabilidad - Estado de Resultados",
+        description = "Reporte VEN-NIF del excedente/déficit del período")
+public class EstadoResultadosController {
+
+    private final GenerarEstadoResultadosUseCase useCase;
+    private final ContabilidadPdfPort pdfPort;
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN','SUPER_ADMIN','SISTEMA')")
+    @Operation(summary = "Genera el Estado de Resultados en JSON",
+            description = "Rango ≤ 1 año fiscal. Permisos: ADMIN/SUPER_ADMIN/SISTEMA.")
+    public ResponseEntity<EstadoResultadosResponse> generar(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate desde,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hasta,
+            @RequestParam(defaultValue = "false") boolean incluirCeros,
+            Authentication authentication) {
+
+        UUID solicitanteId = extraerUsuarioId(authentication);
+        EstadoResultadosFilter filter = new EstadoResultadosFilter(desde, hasta, incluirCeros);
+        return ResponseEntity.ok(useCase.ejecutar(filter, solicitanteId));
+    }
+
+    @GetMapping("/pdf")
+    @PreAuthorize("hasAnyRole('ADMIN','SUPER_ADMIN','SISTEMA')")
+    @Operation(summary = "Genera el Estado de Resultados en PDF para descarga")
+    public ResponseEntity<byte[]> generarPdf(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate desde,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hasta,
+            @RequestParam(defaultValue = "false") boolean incluirCeros,
+            Authentication authentication) {
+
+        UUID solicitanteId = extraerUsuarioId(authentication);
+        EstadoResultadosFilter filter = new EstadoResultadosFilter(desde, hasta, incluirCeros);
+        EstadoResultadosResponse data = useCase.ejecutar(filter, solicitanteId);
+        byte[] pdf = pdfPort.generarEstadoResultadosPdf(data);
+
+        String filename = String.format("EstadoResultados_%s_a_%s.pdf",
+                desde.format(DateTimeFormatter.BASIC_ISO_DATE),
+                hasta.format(DateTimeFormatter.BASIC_ISO_DATE));
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_PDF_VALUE)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+                .header(HttpHeaders.CACHE_CONTROL, "no-store, no-cache, must-revalidate, private")
+                .body(pdf);
+    }
+
+    private UUID extraerUsuarioId(Authentication authentication) {
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof com.tufondo.auth.infrastructure.security.AuthenticatedUser authUser) {
+            UUID socioId = authUser.getSocioId();
+            if (socioId != null) return socioId;
+        }
+        try {
+            return UUID.fromString(authentication.getName());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/dto/BalanceGeneralFilter.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/dto/BalanceGeneralFilter.java
@@ -1,0 +1,48 @@
+package com.tufondo.contabilidad.application.dto;
+
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Filtros para el Balance General (sub-issue #271).
+ *
+ * <p>El Balance es una <strong>foto a una fecha</strong> (no rango). El
+ * "Excedente del Ejercicio" se calcula entre {@code inicioEjercicio} y
+ * {@code fechaCorte} (ver D-008.5).</p>
+ *
+ * @param fechaCorte       fecha a la que se evalúa el balance (inclusive)
+ * @param inicioEjercicio  inicio del ejercicio fiscal para calcular el Excedente.
+ *                         Si null, default = {@code 1-enero del año de fechaCorte}.
+ * @param incluirCeros     si {@code true}, muestra TODAS las cuentas aunque tengan saldo cero.
+ */
+public record BalanceGeneralFilter(
+        LocalDate fechaCorte,
+        LocalDate inicioEjercicio,
+        boolean incluirCeros
+) {
+
+    public BalanceGeneralFilter {
+        if (fechaCorte == null) {
+            throw new IllegalArgumentException("fechaCorte es obligatoria");
+        }
+        if (inicioEjercicio != null && inicioEjercicio.isAfter(fechaCorte)) {
+            throw new IllegalArgumentException(
+                    "inicioEjercicio no puede ser posterior a fechaCorte");
+        }
+    }
+
+    /** Factory default: ejercicio fiscal calendario (1-enero del año del corte). */
+    public static BalanceGeneralFilter al(LocalDate fechaCorte) {
+        return new BalanceGeneralFilter(fechaCorte, null, false);
+    }
+
+    /**
+     * Inicio del ejercicio: si no se proveyó, default = 1-enero del año del corte.
+     * Si Fatrans operara con ejercicio fiscal no calendario (ej. julio-junio),
+     * el contador debe pasar {@code inicioEjercicio} explícito.
+     */
+    public LocalDate inicioEjercicioResuelto() {
+        if (inicioEjercicio != null) return inicioEjercicio;
+        return LocalDate.of(fechaCorte.getYear(), Month.JANUARY, 1);
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/dto/BalanceGeneralResponse.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/dto/BalanceGeneralResponse.java
@@ -1,0 +1,88 @@
+package com.tufondo.contabilidad.application.dto;
+
+import com.tufondo.contabilidad.domain.model.enums.NaturalezaSaldo;
+import com.tufondo.contabilidad.domain.model.enums.TipoCuentaContable;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Response del Balance General (sub-issue #271).
+ *
+ * <p>Estructura jerárquica: el balance se organiza en dos columnas
+ * conceptuales (ACTIVO | PASIVO+PATRIMONIO) cada una con un árbol
+ * Rubro → Grupo → Cuenta hoja. El use case ya hace el roll-up de saldos
+ * desde las hojas hacia arriba.</p>
+ *
+ * <p>Decisiones formales en D-008 (ver {@code _decisiones-contables.md}).</p>
+ */
+@Builder
+public record BalanceGeneralResponse(
+        Encabezado encabezado,
+        Seccion activo,
+        Seccion pasivo,
+        Seccion patrimonio,
+        BigDecimal excedenteEjercicio,    // del Estado de Resultados implícito
+        String excedenteEtiqueta,         // "EXCEDENTE" / "DÉFICIT" / "—"
+        Totales totales
+) {
+
+    @Builder
+    public record Encabezado(
+            String razonSocial,
+            String rif,
+            LocalDate fechaCorte,
+            LocalDate inicioEjercicio,
+            Instant generadoEn,
+            UUID generadoPorUsuarioId,
+            boolean incluyeCeros
+    ) {}
+
+    /**
+     * Sección del balance (Activo, Pasivo o Patrimonio). Contiene el árbol
+     * jerárquico de cuentas que aplican y el total agregado.
+     */
+    @Builder
+    public record Seccion(
+            TipoCuentaContable tipo,
+            String titulo,                // "ACTIVO" / "PASIVO" / "PATRIMONIO"
+            List<NodoCuenta> rubros,
+            BigDecimal total
+    ) {}
+
+    /**
+     * Nodo del árbol del balance. Las cuentas hoja tienen {@code hijos}
+     * vacío. Las cuentas correctoras tienen {@code esCorrectora=true} y
+     * se renderizan con signo negativo restando del padre.
+     */
+    @Builder
+    public record NodoCuenta(
+            String codigo,
+            String nombre,
+            int nivel,                    // 1=rubro, 2=grupo, 3=cuenta hoja
+            NaturalezaSaldo naturaleza,
+            boolean esCorrectora,         // ej. 1.3.99 Provisión Cartera (ACTIVO + ACREEDORA)
+            BigDecimal saldoNeto,         // YA con su signo según naturaleza
+            BigDecimal saldoPresentacion, // valor absoluto (las correctoras se muestran negativo en PDF)
+            List<NodoCuenta> hijos
+    ) {}
+
+    /**
+     * Validación crítica de cuadre.
+     * {@code balanceado=true} ↔ {@code totalActivo = totalPasivo + totalPatrimonio + excedente}.
+     */
+    @Builder
+    public record Totales(
+            BigDecimal totalActivo,
+            BigDecimal totalPasivo,
+            BigDecimal totalPatrimonio,
+            BigDecimal excedenteEjercicio,
+            BigDecimal totalPasivoMasPatrimonio,    // pasivo + patrimonio + excedente
+            BigDecimal diferencia,                   // activo - (pasivo+patrimonio+excedente)
+            boolean balanceado
+    ) {}
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/dto/EstadoResultadosFilter.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/dto/EstadoResultadosFilter.java
@@ -1,0 +1,37 @@
+package com.tufondo.contabilidad.application.dto;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Filtros para el Estado de Resultados (sub-issue #271).
+ *
+ * <p>A diferencia del Balance General (foto a una fecha), el Estado de
+ * Resultados es <strong>por rango</strong>: ingresos y egresos del período.</p>
+ */
+public record EstadoResultadosFilter(
+        LocalDate desde,
+        LocalDate hasta,
+        boolean incluirCeros
+) {
+    public static final int RANGO_MAX_DIAS = 366; // 1 año bisiesto
+
+    public EstadoResultadosFilter {
+        if (desde == null || hasta == null) {
+            throw new IllegalArgumentException("desde y hasta son obligatorios");
+        }
+        if (hasta.isBefore(desde)) {
+            throw new IllegalArgumentException("hasta no puede ser anterior a desde");
+        }
+        long dias = ChronoUnit.DAYS.between(desde, hasta);
+        if (dias > RANGO_MAX_DIAS) {
+            throw new IllegalArgumentException(String.format(
+                    "rango de %d días excede el máximo de %d (1 año fiscal)",
+                    dias, RANGO_MAX_DIAS));
+        }
+    }
+
+    public static EstadoResultadosFilter de(LocalDate desde, LocalDate hasta) {
+        return new EstadoResultadosFilter(desde, hasta, false);
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/dto/EstadoResultadosResponse.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/dto/EstadoResultadosResponse.java
@@ -1,0 +1,64 @@
+package com.tufondo.contabilidad.application.dto;
+
+import com.tufondo.contabilidad.domain.model.enums.NaturalezaSaldo;
+import com.tufondo.contabilidad.domain.model.enums.TipoCuentaContable;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Response del Estado de Resultados (sub-issue #271).
+ *
+ * <p>Reporte del excedente/déficit del período. Solo cuentas de
+ * INGRESO (4) y EGRESO (5). El resultado neto (ingresos − egresos) es el
+ * "Excedente del Ejercicio" que también aparece en el Balance General.</p>
+ */
+@Builder
+public record EstadoResultadosResponse(
+        Encabezado encabezado,
+        Seccion ingresos,
+        Seccion egresos,
+        BigDecimal excedente,           // ingresos.total - egresos.total
+        String excedenteEtiqueta        // "EXCEDENTE" / "DÉFICIT" / "—"
+) {
+
+    @Builder
+    public record Encabezado(
+            String razonSocial,
+            String rif,
+            LocalDate desde,
+            LocalDate hasta,
+            Instant generadoEn,
+            UUID generadoPorUsuarioId,
+            boolean incluyeCeros
+    ) {}
+
+    /** Sección INGRESOS o EGRESOS con su árbol jerárquico y total. */
+    @Builder
+    public record Seccion(
+            TipoCuentaContable tipo,
+            String titulo,
+            List<NodoCuenta> rubros,
+            BigDecimal total
+    ) {}
+
+    /**
+     * Nodo jerárquico de cuenta para el Estado de Resultados.
+     * <p>Reutiliza el mismo concepto que {@code BalanceGeneralResponse.NodoCuenta}
+     * pero se mantiene como tipo distinto para no acoplar los dos reportes.</p>
+     */
+    @Builder
+    public record NodoCuenta(
+            String codigo,
+            String nombre,
+            int nivel,
+            NaturalezaSaldo naturaleza,
+            BigDecimal saldoNeto,
+            BigDecimal saldoPresentacion,
+            List<NodoCuenta> hijos
+    ) {}
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/port/output/ContabilidadPdfPort.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/port/output/ContabilidadPdfPort.java
@@ -1,5 +1,7 @@
 package com.tufondo.contabilidad.application.port.output;
 
+import com.tufondo.contabilidad.application.dto.BalanceGeneralResponse;
+import com.tufondo.contabilidad.application.dto.EstadoResultadosResponse;
 import com.tufondo.contabilidad.application.dto.LibroDiarioResponse;
 import com.tufondo.contabilidad.application.dto.LibroMayorResponse;
 
@@ -38,4 +40,20 @@ public interface ContabilidadPdfPort {
      * @return bytes del PDF listo para descarga
      */
     byte[] generarLibroMayorPdf(LibroMayorResponse libroMayor);
+
+    /**
+     * Genera el PDF del Balance General (sub-issue #271).
+     * Formato vertical clásico VEN-NIF en dos columnas (Activo |
+     * Pasivo+Patrimonio) con jerarquía Rubro→Grupo→Cuenta. Excedente
+     * del Ejercicio incluido en Patrimonio. Validación visual de cuadre
+     * al pie ("BALANCEADO ✓" / "⚠ DESBALANCEADO").
+     */
+    byte[] generarBalanceGeneralPdf(BalanceGeneralResponse balance);
+
+    /**
+     * Genera el PDF del Estado de Resultados (sub-issue #271).
+     * Formato columnar: secciones INGRESOS y EGRESOS con sus rubros,
+     * grupos y cuentas; al pie el Excedente/Déficit del período.
+     */
+    byte[] generarEstadoResultadosPdf(EstadoResultadosResponse estadoResultados);
 }

--- a/backend/src/main/java/com/tufondo/contabilidad/application/usecase/GenerarBalanceGeneralUseCase.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/usecase/GenerarBalanceGeneralUseCase.java
@@ -1,0 +1,245 @@
+package com.tufondo.contabilidad.application.usecase;
+
+import com.tufondo.contabilidad.application.config.EntidadProperties;
+import com.tufondo.contabilidad.application.dto.BalanceGeneralFilter;
+import com.tufondo.contabilidad.application.dto.BalanceGeneralResponse;
+import com.tufondo.contabilidad.application.dto.EstadoResultadosFilter;
+import com.tufondo.contabilidad.application.dto.EstadoResultadosResponse;
+import com.tufondo.contabilidad.domain.model.CuentaContable;
+import com.tufondo.contabilidad.domain.model.SaldoCuenta;
+import com.tufondo.contabilidad.domain.model.enums.TipoCuentaContable;
+import com.tufondo.contabilidad.domain.repository.AsientoContableRepository;
+import com.tufondo.contabilidad.domain.repository.CuentaContableRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Genera el Balance General (sub-issue #271).
+ *
+ * <p>Reporte VEN-NIF de la situación patrimonial a una fecha. Estructura:</p>
+ * <pre>
+ *  ACTIVO              |  PASIVO
+ *    rubros / grupos   |    rubros / grupos
+ *                      |  PATRIMONIO
+ *                      |    rubros / grupos
+ *                      |    Excedente del Ejercicio (calculado)
+ *
+ *  Σ Activo  ==  Σ Pasivo + Σ Patrimonio + Excedente   ← debe cuadrar
+ * </pre>
+ *
+ * <h2>Decisiones formales (D-008)</h2>
+ * <ul>
+ *   <li><strong>Roll-up por jerarquía</strong>: rubros = suma de grupos, grupos = suma de hojas.</li>
+ *   <li><strong>Cuentas correctoras</strong> (ej. 1.3.99 Provisión, 1.5.99 Depreciación):
+ *       saldo acreedor dentro de un rubro deudor. Se muestran restando.</li>
+ *   <li><strong>Excedente calculado on-the-fly</strong>: invoca al use case del Estado de
+ *       Resultados del año fiscal y suma el excedente al patrimonio. Cuando #272 (Cierre)
+ *       se implemente y persista el excedente en {@code 3.3.02}, este cálculo se
+ *       reemplaza por lectura del saldo persistido.</li>
+ *   <li><strong>Asientos ANULADOS excluidos</strong> (mismo criterio que Libro Mayor).</li>
+ *   <li><strong>Poda de ceros</strong>: cuentas con saldo cero NO se muestran salvo {@code incluirCeros=true}.</li>
+ * </ul>
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GenerarBalanceGeneralUseCase {
+
+    private final AsientoContableRepository asientoRepository;
+    private final CuentaContableRepository cuentaRepository;
+    private final EntidadProperties entidadProperties;
+    private final GenerarEstadoResultadosUseCase estadoResultadosUseCase;
+
+    @Transactional(readOnly = true)
+    public BalanceGeneralResponse ejecutar(BalanceGeneralFilter filter, UUID solicitanteId) {
+        log.info("Generando Balance General: fechaCorte={} inicioEjercicio={} incluyeCeros={} solicitante={}",
+                filter.fechaCorte(), filter.inicioEjercicioResuelto(),
+                filter.incluirCeros(), solicitanteId);
+
+        List<CuentaContable> plan = cuentaRepository.listarTodas();
+        Map<UUID, BigDecimal> saldosHoja = calcularSaldosHojas(plan, filter);
+
+        BalanceGeneralResponse.Seccion activo = construirSeccion(
+                plan, TipoCuentaContable.ACTIVO, "ACTIVO", saldosHoja, filter.incluirCeros());
+        BalanceGeneralResponse.Seccion pasivo = construirSeccion(
+                plan, TipoCuentaContable.PASIVO, "PASIVO", saldosHoja, filter.incluirCeros());
+        BalanceGeneralResponse.Seccion patrimonio = construirSeccion(
+                plan, TipoCuentaContable.PATRIMONIO, "PATRIMONIO", saldosHoja, filter.incluirCeros());
+
+        // Excedente del ejercicio: invoca al use case del Estado de Resultados
+        BigDecimal excedente = calcularExcedenteEjercicio(filter, solicitanteId);
+        String etiqueta;
+        if (excedente.signum() > 0) etiqueta = "EXCEDENTE";
+        else if (excedente.signum() < 0) etiqueta = "DÉFICIT";
+        else etiqueta = "—";
+
+        // Validación crítica de cuadre
+        BigDecimal totalPasivoPatExc = pasivo.total().add(patrimonio.total()).add(excedente);
+        BigDecimal diferencia = activo.total().subtract(totalPasivoPatExc);
+        boolean balanceado = diferencia.signum() == 0;
+
+        if (!balanceado) {
+            log.error("⚠ Balance General DESBALANCEADO al {}: " +
+                    "activo={} pasivo+patrimonio+excedente={} diferencia={}",
+                    filter.fechaCorte(), activo.total(), totalPasivoPatExc, diferencia);
+        }
+
+        return BalanceGeneralResponse.builder()
+                .encabezado(BalanceGeneralResponse.Encabezado.builder()
+                        .razonSocial(entidadProperties.getRazonSocial())
+                        .rif(entidadProperties.getRif())
+                        .fechaCorte(filter.fechaCorte())
+                        .inicioEjercicio(filter.inicioEjercicioResuelto())
+                        .generadoEn(Instant.now())
+                        .generadoPorUsuarioId(solicitanteId)
+                        .incluyeCeros(filter.incluirCeros())
+                        .build())
+                .activo(activo)
+                .pasivo(pasivo)
+                .patrimonio(patrimonio)
+                .excedenteEjercicio(excedente.abs())
+                .excedenteEtiqueta(etiqueta)
+                .totales(BalanceGeneralResponse.Totales.builder()
+                        .totalActivo(activo.total())
+                        .totalPasivo(pasivo.total())
+                        .totalPatrimonio(patrimonio.total())
+                        .excedenteEjercicio(excedente)
+                        .totalPasivoMasPatrimonio(totalPasivoPatExc)
+                        .diferencia(diferencia)
+                        .balanceado(balanceado)
+                        .build())
+                .build();
+    }
+
+    /**
+     * Saldo acumulado a la fecha de corte para cada cuenta hoja de tipos
+     * 1/2/3 (Activo/Pasivo/Patrimonio). Excluye ANULADOS por delegación
+     * al repositorio.
+     */
+    private Map<UUID, BigDecimal> calcularSaldosHojas(
+            List<CuentaContable> plan, BalanceGeneralFilter filter) {
+        Map<UUID, BigDecimal> saldos = new HashMap<>();
+        for (CuentaContable c : plan) {
+            if (!c.isAceptaMovimientos()) continue;
+            if (c.getTipo() != TipoCuentaContable.ACTIVO
+                    && c.getTipo() != TipoCuentaContable.PASIVO
+                    && c.getTipo() != TipoCuentaContable.PATRIMONIO) continue;
+
+            SaldoCuenta saldoCuenta = asientoRepository.calcularSaldoCuentaHasta(
+                    c.getId(), filter.fechaCorte());
+            // IMPORTANTE: usamos la naturaleza del TIPO de cuenta (no de la cuenta
+            // individual) para que el saldo se integre correctamente al rubro padre.
+            // Una cuenta correctora (ej. 1.3.99 Provisión Cartera: tipo ACTIVO con
+            // naturaleza ACREEDORA) debe contribuir con saldo NEGATIVO al rubro
+            // ACTIVO, no positivo. Si usáramos c.getNaturaleza() la provisión
+            // sumaría en lugar de restar — D-008.2.
+            BigDecimal saldoNeto = c.getTipo().naturalezaNatural().calcularSaldo(
+                    saldoCuenta.totalDebe(), saldoCuenta.totalHaber());
+            saldos.put(c.getId(), saldoNeto);
+        }
+        return saldos;
+    }
+
+    /**
+     * Invoca {@link GenerarEstadoResultadosUseCase} para el rango
+     * {@code inicioEjercicio → fechaCorte} y extrae el excedente.
+     */
+    private BigDecimal calcularExcedenteEjercicio(BalanceGeneralFilter filter, UUID solicitanteId) {
+        EstadoResultadosFilter erFilter = new EstadoResultadosFilter(
+                filter.inicioEjercicioResuelto(), filter.fechaCorte(), false);
+        EstadoResultadosResponse er = estadoResultadosUseCase.ejecutar(erFilter, solicitanteId);
+        // er.excedente() es valor absoluto; recuperamos el signo
+        BigDecimal valor = er.excedente();
+        if ("DÉFICIT".equals(er.excedenteEtiqueta())) valor = valor.negate();
+        return valor;
+    }
+
+    /**
+     * Construye la sección con árbol jerárquico. Reglas:
+     * <ul>
+     *   <li>Si cuenta es totalizadora: suma recursivamente sus hijas.</li>
+     *   <li>Si cuenta es hoja: usa saldo del map.</li>
+     *   <li>Cuenta correctora (naturaleza opuesta al tipo): se marca y se considera
+     *       en el roll-up tal cual su saldo firmado (que será negativo para el padre).</li>
+     *   <li>Poda: si saldo es cero y no incluirCeros, no se incluye.</li>
+     * </ul>
+     */
+    private BalanceGeneralResponse.Seccion construirSeccion(
+            List<CuentaContable> plan, TipoCuentaContable tipo, String titulo,
+            Map<UUID, BigDecimal> saldosHoja, boolean incluirCeros) {
+
+        List<CuentaContable> cuentas = plan.stream()
+                .filter(c -> c.getTipo() == tipo)
+                .toList();
+
+        List<BalanceGeneralResponse.NodoCuenta> rubros = cuentas.stream()
+                .filter(c -> c.getNivel() == 1)
+                .sorted(Comparator.comparing(CuentaContable::getCodigo))
+                .map(rubro -> construirNodo(rubro, cuentas, saldosHoja, incluirCeros, tipo))
+                .filter(n -> n != null)
+                .toList();
+
+        BigDecimal total = rubros.stream()
+                .map(BalanceGeneralResponse.NodoCuenta::saldoNeto)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return BalanceGeneralResponse.Seccion.builder()
+                .tipo(tipo).titulo(titulo).rubros(rubros).total(total)
+                .build();
+    }
+
+    private BalanceGeneralResponse.NodoCuenta construirNodo(
+            CuentaContable cuenta, List<CuentaContable> todasDelTipo,
+            Map<UUID, BigDecimal> saldosHoja, boolean incluirCeros, TipoCuentaContable tipoRubro) {
+
+        List<CuentaContable> hijas = todasDelTipo.stream()
+                .filter(c -> cuenta.getId().equals(c.getCuentaPadreId()))
+                .sorted(Comparator.comparing(CuentaContable::getCodigo))
+                .toList();
+
+        BigDecimal saldoNeto;
+        List<BalanceGeneralResponse.NodoCuenta> hijosDto = new ArrayList<>();
+
+        if (cuenta.isAceptaMovimientos()) {
+            saldoNeto = saldosHoja.getOrDefault(cuenta.getId(), BigDecimal.ZERO);
+        } else {
+            BigDecimal acumulado = BigDecimal.ZERO;
+            for (CuentaContable hija : hijas) {
+                BalanceGeneralResponse.NodoCuenta nodoHija = construirNodo(
+                        hija, todasDelTipo, saldosHoja, incluirCeros, tipoRubro);
+                if (nodoHija != null) {
+                    hijosDto.add(nodoHija);
+                    acumulado = acumulado.add(nodoHija.saldoNeto());
+                }
+            }
+            saldoNeto = acumulado;
+        }
+
+        if (!incluirCeros && saldoNeto.signum() == 0) return null;
+
+        // Detectar cuenta correctora: naturaleza opuesta al tipo natural del rubro
+        boolean esCorrectora = cuenta.getNaturaleza() != tipoRubro.naturalezaNatural();
+
+        return BalanceGeneralResponse.NodoCuenta.builder()
+                .codigo(cuenta.getCodigo())
+                .nombre(cuenta.getNombre())
+                .nivel(cuenta.getNivel())
+                .naturaleza(cuenta.getNaturaleza())
+                .esCorrectora(esCorrectora)
+                .saldoNeto(saldoNeto)
+                .saldoPresentacion(saldoNeto.abs())
+                .hijos(hijosDto)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/application/usecase/GenerarEstadoResultadosUseCase.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/application/usecase/GenerarEstadoResultadosUseCase.java
@@ -1,0 +1,193 @@
+package com.tufondo.contabilidad.application.usecase;
+
+import com.tufondo.contabilidad.application.config.EntidadProperties;
+import com.tufondo.contabilidad.application.dto.EstadoResultadosFilter;
+import com.tufondo.contabilidad.application.dto.EstadoResultadosResponse;
+import com.tufondo.contabilidad.domain.model.CuentaContable;
+import com.tufondo.contabilidad.domain.model.SaldoCuenta;
+import com.tufondo.contabilidad.domain.model.enums.TipoCuentaContable;
+import com.tufondo.contabilidad.domain.repository.AsientoContableRepository;
+import com.tufondo.contabilidad.domain.repository.CuentaContableRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Genera el Estado de Resultados (sub-issue #271).
+ *
+ * <p>Muestra ingresos (cuentas tipo 4) y egresos (cuentas tipo 5) del
+ * período, con jerarquía Rubro → Grupo → Cuenta hoja. El excedente
+ * (o déficit) del período es {@code Σ ingresos − Σ egresos}.</p>
+ *
+ * <p>El saldo de cada cuenta hoja se calcula como movimientos del período
+ * (excluyendo ANULADOS): saldo del período = saldo al {@code hasta} − saldo al {@code desde-1}.
+ * Esa resta da los movimientos netos del período sin importar saldos previos.</p>
+ *
+ * <p>Excluye asientos {@link com.tufondo.contabilidad.domain.model.enums.EstadoAsiento#ANULADO}
+ * por delegación a {@code calcularSaldoCuentaHasta} (consistente con D-007 del Libro Mayor).</p>
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GenerarEstadoResultadosUseCase {
+
+    private final AsientoContableRepository asientoRepository;
+    private final CuentaContableRepository cuentaRepository;
+    private final EntidadProperties entidadProperties;
+
+    @Transactional(readOnly = true)
+    public EstadoResultadosResponse ejecutar(EstadoResultadosFilter filter, UUID solicitanteId) {
+        log.info("Generando Estado de Resultados: desde={} hasta={} incluyeCeros={} solicitante={}",
+                filter.desde(), filter.hasta(), filter.incluirCeros(), solicitanteId);
+
+        List<CuentaContable> plan = cuentaRepository.listarTodas();
+        // Saldo de período por cuenta hoja: hasta - (desde-1)
+        Map<UUID, BigDecimal> saldosHoja = calcularSaldosPeriodoHojas(plan, filter);
+
+        EstadoResultadosResponse.Seccion ingresos = construirSeccion(
+                plan, TipoCuentaContable.INGRESO, "INGRESOS", saldosHoja, filter.incluirCeros());
+        EstadoResultadosResponse.Seccion egresos = construirSeccion(
+                plan, TipoCuentaContable.EGRESO, "EGRESOS", saldosHoja, filter.incluirCeros());
+
+        BigDecimal excedente = ingresos.total().subtract(egresos.total());
+        String etiqueta;
+        if (excedente.signum() > 0) etiqueta = "EXCEDENTE";
+        else if (excedente.signum() < 0) etiqueta = "DÉFICIT";
+        else etiqueta = "—";
+
+        return EstadoResultadosResponse.builder()
+                .encabezado(EstadoResultadosResponse.Encabezado.builder()
+                        .razonSocial(entidadProperties.getRazonSocial())
+                        .rif(entidadProperties.getRif())
+                        .desde(filter.desde())
+                        .hasta(filter.hasta())
+                        .generadoEn(Instant.now())
+                        .generadoPorUsuarioId(solicitanteId)
+                        .incluyeCeros(filter.incluirCeros())
+                        .build())
+                .ingresos(ingresos)
+                .egresos(egresos)
+                .excedente(excedente.abs())
+                .excedenteEtiqueta(etiqueta)
+                .build();
+    }
+
+    /**
+     * Calcula movimientos del período para cada cuenta hoja de tipos 4 y 5.
+     * Formula: {@code saldo_periodo = saldo_hasta - saldo_(desde-1)}
+     * — esto da el efecto neto del período sin importar saldos previos.
+     */
+    private Map<UUID, BigDecimal> calcularSaldosPeriodoHojas(
+            List<CuentaContable> plan, EstadoResultadosFilter filter) {
+        Map<UUID, BigDecimal> saldos = new HashMap<>();
+        for (CuentaContable c : plan) {
+            if (!c.isAceptaMovimientos()) continue;
+            if (c.getTipo() != TipoCuentaContable.INGRESO
+                    && c.getTipo() != TipoCuentaContable.EGRESO) continue;
+
+            SaldoCuenta hasta = asientoRepository.calcularSaldoCuentaHasta(c.getId(), filter.hasta());
+            SaldoCuenta antesDesde = asientoRepository.calcularSaldoCuentaHasta(
+                    c.getId(), filter.desde().minusDays(1));
+
+            // Diferencia DEBE - HABER del período, ya firmado por naturaleza
+            BigDecimal periodoDebe = hasta.totalDebe().subtract(antesDesde.totalDebe());
+            BigDecimal periodoHaber = hasta.totalHaber().subtract(antesDesde.totalHaber());
+            BigDecimal saldoPeriodo = c.getNaturaleza().calcularSaldo(periodoDebe, periodoHaber);
+            saldos.put(c.getId(), saldoPeriodo);
+        }
+        return saldos;
+    }
+
+    /**
+     * Construye la sección con árbol jerárquico de cuentas filtradas por tipo.
+     * Hace roll-up de saldos: padres son la suma de las hojas descendientes.
+     */
+    private EstadoResultadosResponse.Seccion construirSeccion(
+            List<CuentaContable> plan, TipoCuentaContable tipo, String titulo,
+            Map<UUID, BigDecimal> saldosHoja, boolean incluirCeros) {
+
+        // Filtrar por tipo
+        List<CuentaContable> cuentas = plan.stream()
+                .filter(c -> c.getTipo() == tipo)
+                .toList();
+
+        // Index por id
+        Map<UUID, CuentaContable> porId = cuentas.stream()
+                .collect(Collectors.toMap(CuentaContable::getId, Function.identity()));
+
+        // Encontrar los rubros (nivel 1) y construir sus árboles
+        List<EstadoResultadosResponse.NodoCuenta> rubros = cuentas.stream()
+                .filter(c -> c.getNivel() == 1)
+                .sorted(Comparator.comparing(CuentaContable::getCodigo))
+                .map(rubro -> construirNodo(rubro, cuentas, saldosHoja, incluirCeros))
+                .filter(n -> n != null) // null = todo cero y no incluirCeros
+                .toList();
+
+        BigDecimal total = rubros.stream()
+                .map(EstadoResultadosResponse.NodoCuenta::saldoNeto)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return EstadoResultadosResponse.Seccion.builder()
+                .tipo(tipo).titulo(titulo).rubros(rubros).total(total)
+                .build();
+    }
+
+    /**
+     * Construye recursivamente el nodo de una cuenta, sumando hijas.
+     * Devuelve null si saldo=0 y no incluirCeros (poda).
+     */
+    private EstadoResultadosResponse.NodoCuenta construirNodo(
+            CuentaContable cuenta, List<CuentaContable> todasDelTipo,
+            Map<UUID, BigDecimal> saldosHoja, boolean incluirCeros) {
+
+        List<CuentaContable> hijas = todasDelTipo.stream()
+                .filter(c -> cuenta.getId().equals(c.getCuentaPadreId()))
+                .sorted(Comparator.comparing(CuentaContable::getCodigo))
+                .toList();
+
+        BigDecimal saldoNeto;
+        List<EstadoResultadosResponse.NodoCuenta> hijosDto = new ArrayList<>();
+
+        if (cuenta.isAceptaMovimientos()) {
+            // Hoja operativa: usa saldo directo del map
+            saldoNeto = saldosHoja.getOrDefault(cuenta.getId(), BigDecimal.ZERO);
+        } else {
+            // Totalizadora: suma hijas recursivamente
+            BigDecimal acumulado = BigDecimal.ZERO;
+            for (CuentaContable hija : hijas) {
+                EstadoResultadosResponse.NodoCuenta nodoHija = construirNodo(
+                        hija, todasDelTipo, saldosHoja, incluirCeros);
+                if (nodoHija != null) {
+                    hijosDto.add(nodoHija);
+                    acumulado = acumulado.add(nodoHija.saldoNeto());
+                }
+            }
+            saldoNeto = acumulado;
+        }
+
+        // Poda si saldo cero y no se piden ceros
+        if (!incluirCeros && saldoNeto.signum() == 0) return null;
+
+        return EstadoResultadosResponse.NodoCuenta.builder()
+                .codigo(cuenta.getCodigo())
+                .nombre(cuenta.getNombre())
+                .nivel(cuenta.getNivel())
+                .naturaleza(cuenta.getNaturaleza())
+                .saldoNeto(saldoNeto)
+                .saldoPresentacion(saldoNeto.abs())
+                .hijos(hijosDto)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/tufondo/contabilidad/infrastructure/pdf/LibroDiarioPdfAdapter.java
+++ b/backend/src/main/java/com/tufondo/contabilidad/infrastructure/pdf/LibroDiarioPdfAdapter.java
@@ -2,6 +2,8 @@ package com.tufondo.contabilidad.infrastructure.pdf;
 
 import com.lowagie.text.*;
 import com.lowagie.text.pdf.*;
+import com.tufondo.contabilidad.application.dto.BalanceGeneralResponse;
+import com.tufondo.contabilidad.application.dto.EstadoResultadosResponse;
 import com.tufondo.contabilidad.application.dto.LibroDiarioResponse;
 import com.tufondo.contabilidad.application.dto.LibroMayorResponse;
 import com.tufondo.contabilidad.application.port.output.ContabilidadPdfPort;
@@ -376,6 +378,323 @@ public class LibroDiarioPdfAdapter implements ContabilidadPdfPort {
                         doc.right(), doc.bottom() - 15, 0);
             } catch (Exception e) {
                 log.warn("Error escribiendo footer del Libro Mayor", e);
+            }
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // BALANCE GENERAL (sub-issue #271)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Override
+    public byte[] generarBalanceGeneralPdf(BalanceGeneralResponse balance) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            Document doc = new Document(PageSize.A4, 30, 30, 40, 40);  // vertical
+            PdfWriter writer = PdfWriter.getInstance(doc, baos);
+            writer.setPageEvent(new FolioFooterBalance());
+            doc.open();
+
+            agregarEncabezadoBalance(doc, balance.encabezado());
+
+            // 2 columnas paralelas: ACTIVO | PASIVO + PATRIMONIO
+            PdfPTable layout = new PdfPTable(new float[]{1f, 1f});
+            layout.setWidthPercentage(100);
+
+            PdfPCell celdaActivo = new PdfPCell(construirColumnaSeccion(balance.activo()));
+            celdaActivo.setBorder(Rectangle.NO_BORDER);
+            celdaActivo.setPadding(4);
+            layout.addCell(celdaActivo);
+
+            PdfPCell celdaPasivoPat = new PdfPCell(construirColumnaPasivoPatrimonio(
+                    balance.pasivo(), balance.patrimonio(),
+                    balance.excedenteEjercicio(), balance.excedenteEtiqueta()));
+            celdaPasivoPat.setBorder(Rectangle.NO_BORDER);
+            celdaPasivoPat.setPadding(4);
+            layout.addCell(celdaPasivoPat);
+
+            doc.add(layout);
+
+            agregarTotalesBalance(doc, balance.totales());
+
+            doc.close();
+            return baos.toByteArray();
+        } catch (Exception e) {
+            log.error("Error generando PDF Balance General", e);
+            throw new RuntimeException("No se pudo generar el Balance General: " + e.getMessage(), e);
+        }
+    }
+
+    private void agregarEncabezadoBalance(Document doc, BalanceGeneralResponse.Encabezado enc)
+            throws DocumentException {
+        Paragraph razon = new Paragraph(enc.razonSocial(), TITLE_FONT);
+        razon.setAlignment(Element.ALIGN_CENTER);
+        doc.add(razon);
+
+        Paragraph rif = new Paragraph("RIF: " + enc.rif(), SUBTITLE_FONT);
+        rif.setAlignment(Element.ALIGN_CENTER);
+        doc.add(rif);
+
+        Paragraph titulo = new Paragraph("BALANCE GENERAL", TITLE_FONT);
+        titulo.setAlignment(Element.ALIGN_CENTER);
+        titulo.setSpacingBefore(8);
+        doc.add(titulo);
+
+        Paragraph fecha = new Paragraph("Al " + enc.fechaCorte().format(FECHA_FMT), SUBTITLE_FONT);
+        fecha.setAlignment(Element.ALIGN_CENTER);
+        fecha.setSpacingAfter(10);
+        doc.add(fecha);
+    }
+
+    /** Construye un mini-documento con el árbol de una sección (lo embebemos en una celda de layout). */
+    private PdfPTable construirColumnaSeccion(BalanceGeneralResponse.Seccion seccion) {
+        PdfPTable t = new PdfPTable(new float[]{4f, 2f});
+        t.setWidthPercentage(100);
+
+        // Título de la sección
+        PdfPCell titulo = new PdfPCell(new Phrase(seccion.titulo(), TABLE_HEADER));
+        titulo.setColspan(2);
+        titulo.setBackgroundColor(HEADER_BG);
+        titulo.setPadding(4);
+        titulo.setHorizontalAlignment(Element.ALIGN_CENTER);
+        t.addCell(titulo);
+
+        // Renderizar árbol recursivamente
+        for (BalanceGeneralResponse.NodoCuenta rubro : seccion.rubros()) {
+            agregarNodoBalance(t, rubro, 0);
+        }
+
+        // Total de la sección
+        agregarCelda(t, "TOTAL " + seccion.titulo(), ROW_FONT_BOLD,
+                new Color(220, 230, 240), Element.ALIGN_LEFT);
+        agregarCelda(t, formatoMonto(seccion.total()), ROW_FONT_BOLD,
+                new Color(220, 230, 240), Element.ALIGN_RIGHT);
+        return t;
+    }
+
+    /** Columna derecha: Pasivo + Patrimonio + Excedente del Ejercicio. */
+    private PdfPTable construirColumnaPasivoPatrimonio(
+            BalanceGeneralResponse.Seccion pasivo, BalanceGeneralResponse.Seccion patrimonio,
+            BigDecimal excedente, String etiquetaExc) {
+        PdfPTable t = new PdfPTable(new float[]{4f, 2f});
+        t.setWidthPercentage(100);
+
+        // PASIVO
+        PdfPCell tPas = new PdfPCell(new Phrase(pasivo.titulo(), TABLE_HEADER));
+        tPas.setColspan(2);
+        tPas.setBackgroundColor(HEADER_BG);
+        tPas.setPadding(4);
+        tPas.setHorizontalAlignment(Element.ALIGN_CENTER);
+        t.addCell(tPas);
+        for (BalanceGeneralResponse.NodoCuenta rubro : pasivo.rubros()) {
+            agregarNodoBalance(t, rubro, 0);
+        }
+        agregarCelda(t, "Subtotal " + pasivo.titulo(), ROW_FONT_BOLD,
+                new Color(240, 240, 240), Element.ALIGN_LEFT);
+        agregarCelda(t, formatoMonto(pasivo.total()), ROW_FONT_BOLD,
+                new Color(240, 240, 240), Element.ALIGN_RIGHT);
+
+        // PATRIMONIO
+        PdfPCell tPat = new PdfPCell(new Phrase(patrimonio.titulo(), TABLE_HEADER));
+        tPat.setColspan(2);
+        tPat.setBackgroundColor(HEADER_BG);
+        tPat.setPadding(4);
+        tPat.setHorizontalAlignment(Element.ALIGN_CENTER);
+        t.addCell(tPat);
+        for (BalanceGeneralResponse.NodoCuenta rubro : patrimonio.rubros()) {
+            agregarNodoBalance(t, rubro, 0);
+        }
+
+        // Excedente del Ejercicio (línea especial, calculado del ER del año)
+        agregarCelda(t, "  " + etiquetaExc + " del Ejercicio", ROW_FONT,
+                new Color(255, 250, 220), Element.ALIGN_LEFT);
+        agregarCelda(t, formatoMonto(excedente), ROW_FONT,
+                new Color(255, 250, 220), Element.ALIGN_RIGHT);
+
+        BigDecimal totalPasPat = pasivo.total().add(patrimonio.total())
+                .add("DÉFICIT".equals(etiquetaExc) ? excedente.negate() : excedente);
+        agregarCelda(t, "TOTAL PASIVO + PATRIMONIO", ROW_FONT_BOLD,
+                new Color(220, 230, 240), Element.ALIGN_LEFT);
+        agregarCelda(t, formatoMonto(totalPasPat), ROW_FONT_BOLD,
+                new Color(220, 230, 240), Element.ALIGN_RIGHT);
+        return t;
+    }
+
+    /**
+     * Agrega una fila al árbol del balance. Indentación visual según el nivel.
+     * Cuentas correctoras se renderizan con paréntesis negativos.
+     */
+    private void agregarNodoBalance(PdfPTable t, BalanceGeneralResponse.NodoCuenta nodo, int indent) {
+        String prefijo = "  ".repeat(indent);
+        String nombre = prefijo + nodo.codigo() + " " + nodo.nombre();
+        if (nodo.esCorrectora()) nombre = prefijo + "(−) " + nodo.codigo() + " " + nodo.nombre();
+
+        Font font = nodo.nivel() == 1 ? ROW_FONT_BOLD : ROW_FONT;
+        Color bg = nodo.nivel() == 1 ? new Color(245, 248, 252) : Color.WHITE;
+
+        String monto = formatoMonto(nodo.saldoPresentacion());
+        if (nodo.esCorrectora() && nodo.saldoNeto().signum() != 0) monto = "(" + monto + ")";
+
+        agregarCelda(t, nombre, font, bg, Element.ALIGN_LEFT);
+        agregarCelda(t, monto, font, bg, Element.ALIGN_RIGHT);
+
+        for (BalanceGeneralResponse.NodoCuenta hija : nodo.hijos()) {
+            agregarNodoBalance(t, hija, indent + 1);
+        }
+    }
+
+    private void agregarTotalesBalance(Document doc, BalanceGeneralResponse.Totales t)
+            throws DocumentException {
+        Paragraph espacio = new Paragraph(" ");
+        espacio.setSpacingBefore(8);
+        doc.add(espacio);
+
+        String resumen;
+        Font totalFont;
+        if (t.balanceado()) {
+            resumen = "✓ BALANCEADO — Total Activo = Total Pasivo + Patrimonio + Excedente";
+            totalFont = ROW_FONT_BOLD;
+        } else {
+            resumen = String.format("⚠ DESBALANCEADO — diferencia: %s", formatoMonto(t.diferencia()));
+            totalFont = new Font(Font.HELVETICA, 10, Font.BOLD, Color.RED);
+        }
+        Paragraph p = new Paragraph(resumen, totalFont);
+        p.setAlignment(Element.ALIGN_CENTER);
+        doc.add(p);
+    }
+
+    private static class FolioFooterBalance extends PdfPageEventHelper {
+        @Override
+        public void onEndPage(PdfWriter writer, Document doc) {
+            try {
+                PdfContentByte cb = writer.getDirectContent();
+                Phrase pie = new Phrase("Balance General — Fatrans", FOOTER_FONT);
+                ColumnText.showTextAligned(cb, Element.ALIGN_LEFT, pie,
+                        doc.left(), doc.bottom() - 15, 0);
+                Phrase pag = new Phrase("Página " + writer.getPageNumber(), FOOTER_FONT);
+                ColumnText.showTextAligned(cb, Element.ALIGN_RIGHT, pag,
+                        doc.right(), doc.bottom() - 15, 0);
+            } catch (Exception e) {
+                log.warn("Error footer Balance General", e);
+            }
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // ESTADO DE RESULTADOS (sub-issue #271)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Override
+    public byte[] generarEstadoResultadosPdf(EstadoResultadosResponse er) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            Document doc = new Document(PageSize.A4, 30, 30, 40, 40);
+            PdfWriter writer = PdfWriter.getInstance(doc, baos);
+            writer.setPageEvent(new FolioFooterER());
+            doc.open();
+
+            agregarEncabezadoER(doc, er.encabezado());
+
+            // Sección INGRESOS
+            PdfPTable ingresos = construirSeccionER(er.ingresos());
+            doc.add(ingresos);
+
+            // Sección EGRESOS
+            Paragraph esp = new Paragraph(" ");
+            esp.setSpacingBefore(8);
+            doc.add(esp);
+            PdfPTable egresos = construirSeccionER(er.egresos());
+            doc.add(egresos);
+
+            // Excedente / Déficit del período
+            Paragraph esp2 = new Paragraph(" ");
+            esp2.setSpacingBefore(12);
+            doc.add(esp2);
+            PdfPTable resultado = new PdfPTable(new float[]{4f, 2f});
+            resultado.setWidthPercentage(100);
+            Font font = new Font(Font.HELVETICA, 11, Font.BOLD, Color.BLACK);
+            Color bg = "DÉFICIT".equals(er.excedenteEtiqueta())
+                    ? new Color(255, 230, 230)
+                    : new Color(225, 245, 225);
+            agregarCelda(resultado, er.excedenteEtiqueta() + " DEL EJERCICIO", font, bg, Element.ALIGN_LEFT);
+            agregarCelda(resultado, formatoMonto(er.excedente()), font, bg, Element.ALIGN_RIGHT);
+            doc.add(resultado);
+
+            doc.close();
+            return baos.toByteArray();
+        } catch (Exception e) {
+            log.error("Error generando PDF Estado de Resultados", e);
+            throw new RuntimeException("No se pudo generar el Estado de Resultados: " + e.getMessage(), e);
+        }
+    }
+
+    private void agregarEncabezadoER(Document doc, EstadoResultadosResponse.Encabezado enc)
+            throws DocumentException {
+        Paragraph razon = new Paragraph(enc.razonSocial(), TITLE_FONT);
+        razon.setAlignment(Element.ALIGN_CENTER);
+        doc.add(razon);
+        Paragraph rif = new Paragraph("RIF: " + enc.rif(), SUBTITLE_FONT);
+        rif.setAlignment(Element.ALIGN_CENTER);
+        doc.add(rif);
+        Paragraph titulo = new Paragraph("ESTADO DE RESULTADOS", TITLE_FONT);
+        titulo.setAlignment(Element.ALIGN_CENTER);
+        titulo.setSpacingBefore(8);
+        doc.add(titulo);
+        Paragraph periodo = new Paragraph(
+                "Del " + enc.desde().format(FECHA_FMT) + " al " + enc.hasta().format(FECHA_FMT),
+                SUBTITLE_FONT);
+        periodo.setAlignment(Element.ALIGN_CENTER);
+        periodo.setSpacingAfter(10);
+        doc.add(periodo);
+    }
+
+    private PdfPTable construirSeccionER(EstadoResultadosResponse.Seccion seccion) {
+        PdfPTable t = new PdfPTable(new float[]{4f, 2f});
+        t.setWidthPercentage(100);
+
+        PdfPCell tit = new PdfPCell(new Phrase(seccion.titulo(), TABLE_HEADER));
+        tit.setColspan(2);
+        tit.setBackgroundColor(HEADER_BG);
+        tit.setPadding(4);
+        tit.setHorizontalAlignment(Element.ALIGN_CENTER);
+        t.addCell(tit);
+
+        for (EstadoResultadosResponse.NodoCuenta rubro : seccion.rubros()) {
+            agregarNodoER(t, rubro, 0);
+        }
+
+        agregarCelda(t, "TOTAL " + seccion.titulo(), ROW_FONT_BOLD,
+                new Color(220, 230, 240), Element.ALIGN_LEFT);
+        agregarCelda(t, formatoMonto(seccion.total()), ROW_FONT_BOLD,
+                new Color(220, 230, 240), Element.ALIGN_RIGHT);
+        return t;
+    }
+
+    private void agregarNodoER(PdfPTable t, EstadoResultadosResponse.NodoCuenta nodo, int indent) {
+        String prefijo = "  ".repeat(indent);
+        String nombre = prefijo + nodo.codigo() + " " + nodo.nombre();
+        Font font = nodo.nivel() == 1 ? ROW_FONT_BOLD : ROW_FONT;
+        Color bg = nodo.nivel() == 1 ? new Color(245, 248, 252) : Color.WHITE;
+        agregarCelda(t, nombre, font, bg, Element.ALIGN_LEFT);
+        agregarCelda(t, formatoMonto(nodo.saldoPresentacion()), font, bg, Element.ALIGN_RIGHT);
+        for (EstadoResultadosResponse.NodoCuenta hija : nodo.hijos()) {
+            agregarNodoER(t, hija, indent + 1);
+        }
+    }
+
+    private static class FolioFooterER extends PdfPageEventHelper {
+        @Override
+        public void onEndPage(PdfWriter writer, Document doc) {
+            try {
+                PdfContentByte cb = writer.getDirectContent();
+                Phrase pie = new Phrase("Estado de Resultados — Fatrans", FOOTER_FONT);
+                ColumnText.showTextAligned(cb, Element.ALIGN_LEFT, pie,
+                        doc.left(), doc.bottom() - 15, 0);
+                Phrase pag = new Phrase("Página " + writer.getPageNumber(), FOOTER_FONT);
+                ColumnText.showTextAligned(cb, Element.ALIGN_RIGHT, pag,
+                        doc.right(), doc.bottom() - 15, 0);
+            } catch (Exception e) {
+                log.warn("Error footer Estado de Resultados", e);
             }
         }
     }

--- a/backend/src/test/java/com/tufondo/contabilidad/application/dto/BalanceGeneralFilterTest.java
+++ b/backend/src/test/java/com/tufondo/contabilidad/application/dto/BalanceGeneralFilterTest.java
@@ -1,0 +1,64 @@
+package com.tufondo.contabilidad.application.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BalanceGeneralFilterTest {
+
+    @Test
+    @DisplayName("filtro válido con fecha de corte")
+    void filtro_valido() {
+        var f = BalanceGeneralFilter.al(LocalDate.of(2026, 5, 31));
+        assertThat(f.fechaCorte()).isEqualTo(LocalDate.of(2026, 5, 31));
+        assertThat(f.incluirCeros()).isFalse();
+        assertThat(f.inicioEjercicio()).isNull();
+    }
+
+    @Test
+    @DisplayName("inicioEjercicio default = 1-enero del año de fechaCorte")
+    void inicio_default_enero_mismo_anio() {
+        var f = BalanceGeneralFilter.al(LocalDate.of(2026, 5, 31));
+        assertThat(f.inicioEjercicioResuelto()).isEqualTo(LocalDate.of(2026, 1, 1));
+    }
+
+    @Test
+    @DisplayName("inicioEjercicio explícito se respeta (ejercicio fiscal no calendario)")
+    void inicio_explicito() {
+        var f = new BalanceGeneralFilter(
+                LocalDate.of(2026, 12, 31),
+                LocalDate.of(2026, 7, 1),  // ejercicio fiscal julio-junio
+                false);
+        assertThat(f.inicioEjercicioResuelto()).isEqualTo(LocalDate.of(2026, 7, 1));
+    }
+
+    @Test
+    @DisplayName("fechaCorte null → rechazado")
+    void fecha_null_rechazada() {
+        assertThatThrownBy(() -> new BalanceGeneralFilter(null, null, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("fechaCorte");
+    }
+
+    @Test
+    @DisplayName("inicioEjercicio posterior a fechaCorte → rechazado")
+    void inicio_posterior_a_corte_rechazado() {
+        assertThatThrownBy(() -> new BalanceGeneralFilter(
+                LocalDate.of(2026, 5, 1),
+                LocalDate.of(2026, 7, 1),
+                false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("posterior");
+    }
+
+    @Test
+    @DisplayName("incluirCeros se almacena")
+    void incluir_ceros_se_almacena() {
+        var f = new BalanceGeneralFilter(LocalDate.now(), null, true);
+        assertThat(f.incluirCeros()).isTrue();
+    }
+}

--- a/backend/src/test/java/com/tufondo/contabilidad/application/dto/EstadoResultadosFilterTest.java
+++ b/backend/src/test/java/com/tufondo/contabilidad/application/dto/EstadoResultadosFilterTest.java
@@ -1,0 +1,56 @@
+package com.tufondo.contabilidad.application.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EstadoResultadosFilterTest {
+
+    @Test
+    @DisplayName("filtro válido con factory de()")
+    void filtro_valido() {
+        var f = EstadoResultadosFilter.de(LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 31));
+        assertThat(f.desde()).isEqualTo(LocalDate.of(2026, 5, 1));
+        assertThat(f.hasta()).isEqualTo(LocalDate.of(2026, 5, 31));
+        assertThat(f.incluirCeros()).isFalse();
+    }
+
+    @Test
+    @DisplayName("rango > 366 días rechazado")
+    void rango_excesivo_rechazado() {
+        assertThatThrownBy(() -> EstadoResultadosFilter.de(
+                LocalDate.of(2026, 1, 1), LocalDate.of(2028, 1, 1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("excede el máximo");
+    }
+
+    @Test
+    @DisplayName("hasta < desde rechazado")
+    void rango_invertido_rechazado() {
+        assertThatThrownBy(() -> EstadoResultadosFilter.de(
+                LocalDate.of(2026, 5, 31), LocalDate.of(2026, 5, 1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("anterior");
+    }
+
+    @Test
+    @DisplayName("fechas null rechazadas")
+    void fechas_null() {
+        assertThatThrownBy(() -> new EstadoResultadosFilter(null, LocalDate.now(), false))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new EstadoResultadosFilter(LocalDate.now(), null, false))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("rango 366 días (año bisiesto) aceptado")
+    void rango_366_aceptado() {
+        var f = new EstadoResultadosFilter(
+                LocalDate.of(2026, 1, 1), LocalDate.of(2027, 1, 2), false);
+        assertThat(f).isNotNull();
+    }
+}

--- a/backend/src/test/java/com/tufondo/contabilidad/application/usecase/GenerarBalanceGeneralUseCaseTest.java
+++ b/backend/src/test/java/com/tufondo/contabilidad/application/usecase/GenerarBalanceGeneralUseCaseTest.java
@@ -1,0 +1,318 @@
+package com.tufondo.contabilidad.application.usecase;
+
+import com.tufondo.contabilidad.application.config.EntidadProperties;
+import com.tufondo.contabilidad.application.dto.BalanceGeneralFilter;
+import com.tufondo.contabilidad.application.dto.BalanceGeneralResponse;
+import com.tufondo.contabilidad.application.dto.EstadoResultadosResponse;
+import com.tufondo.contabilidad.domain.model.CuentaContable;
+import com.tufondo.contabilidad.domain.model.SaldoCuenta;
+import com.tufondo.contabilidad.domain.model.enums.NaturalezaSaldo;
+import com.tufondo.contabilidad.domain.model.enums.TipoCuentaContable;
+import com.tufondo.contabilidad.domain.repository.AsientoContableRepository;
+import com.tufondo.contabilidad.domain.repository.CuentaContableRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests del {@link GenerarBalanceGeneralUseCase} (sub-issue #271).
+ *
+ * <p>Cobertura: roll-up jerarquía A/P/Patrim, cuentas correctoras restan,
+ * excedente del ejercicio integrado, validación de cuadre, poda de ceros.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class GenerarBalanceGeneralUseCaseTest {
+
+    @Mock private AsientoContableRepository asientoRepo;
+    @Mock private CuentaContableRepository cuentaRepo;
+    @Mock private GenerarEstadoResultadosUseCase estadoResultadosUseCase;
+
+    private GenerarBalanceGeneralUseCase useCase;
+
+    // Plan: Activo (1.1.03 Bancos + 1.3.01 Cartera + 1.3.99 Provisión correctora),
+    //       Pasivo (2.1.01 Ahorros), Patrimonio (3.1.01 Aportes)
+    private CuentaContable rubroAct, grupoDisp, banco;
+    private CuentaContable grupoCart, cartera, provisionCartera;
+    private CuentaContable rubroPas, grupoDep, ahorros;
+    private CuentaContable rubroPat, grupoAp, aportes;
+
+    private final LocalDate fecha = LocalDate.of(2026, 5, 31);
+
+    @BeforeEach
+    void setUp() {
+        EntidadProperties props = new EntidadProperties();
+        props.setRazonSocial("Fatrans Test");
+        props.setRif("J-TEST-0");
+        useCase = new GenerarBalanceGeneralUseCase(asientoRepo, cuentaRepo, props, estadoResultadosUseCase);
+
+        // ACTIVO
+        rubroAct = CuentaContable.crear("1", "ACTIVO",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, null, false, null);
+        grupoDisp = CuentaContable.crear("1.1", "Disponible",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, rubroAct.getId(), false, null);
+        banco = CuentaContable.crear("1.1.03", "Bancos Bs",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, grupoDisp.getId(), true, null);
+        grupoCart = CuentaContable.crear("1.3", "Cartera Créditos",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, rubroAct.getId(), false, null);
+        cartera = CuentaContable.crear("1.3.01", "Créditos por Cobrar",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.DEUDORA, grupoCart.getId(), true, null);
+        // Correctora: ACTIVO con naturaleza ACREEDORA
+        provisionCartera = CuentaContable.crear("1.3.99", "Provisión Cartera (CR)",
+                TipoCuentaContable.ACTIVO, NaturalezaSaldo.ACREEDORA, grupoCart.getId(), true, null);
+
+        // PASIVO
+        rubroPas = CuentaContable.crear("2", "PASIVO",
+                TipoCuentaContable.PASIVO, NaturalezaSaldo.ACREEDORA, null, false, null);
+        grupoDep = CuentaContable.crear("2.1", "Depósitos Asociados",
+                TipoCuentaContable.PASIVO, NaturalezaSaldo.ACREEDORA, rubroPas.getId(), false, null);
+        ahorros = CuentaContable.crear("2.1.01", "Cuentas de Ahorro Bs",
+                TipoCuentaContable.PASIVO, NaturalezaSaldo.ACREEDORA, grupoDep.getId(), true, null);
+
+        // PATRIMONIO
+        rubroPat = CuentaContable.crear("3", "PATRIMONIO",
+                TipoCuentaContable.PATRIMONIO, NaturalezaSaldo.ACREEDORA, null, false, null);
+        grupoAp = CuentaContable.crear("3.1", "Aportes",
+                TipoCuentaContable.PATRIMONIO, NaturalezaSaldo.ACREEDORA, rubroPat.getId(), false, null);
+        aportes = CuentaContable.crear("3.1.01", "Aportes Sociales",
+                TipoCuentaContable.PATRIMONIO, NaturalezaSaldo.ACREEDORA, grupoAp.getId(), true, null);
+
+        lenient().when(cuentaRepo.listarTodas()).thenReturn(List.of(
+                rubroAct, grupoDisp, banco, grupoCart, cartera, provisionCartera,
+                rubroPas, grupoDep, ahorros,
+                rubroPat, grupoAp, aportes));
+
+        // Excedente del ER default = cero
+        lenient().when(estadoResultadosUseCase.ejecutar(any(), any()))
+                .thenReturn(estadoResultadosResponseConExcedente(BigDecimal.ZERO, "—"));
+    }
+
+    @Test
+    @DisplayName("balance vacío (sin saldos, sin excedente) → balanceado en cero")
+    void balance_vacio() {
+        when(asientoRepo.calcularSaldoCuentaHasta(any(), any())).thenReturn(SaldoCuenta.cero());
+
+        BalanceGeneralResponse resp = useCase.ejecutar(
+                BalanceGeneralFilter.al(fecha), UUID.randomUUID());
+
+        assertThat(resp.totales().totalActivo()).isEqualByComparingTo("0");
+        assertThat(resp.totales().totalPasivo()).isEqualByComparingTo("0");
+        assertThat(resp.totales().totalPatrimonio()).isEqualByComparingTo("0");
+        assertThat(resp.totales().balanceado()).isTrue();
+    }
+
+    @Test
+    @DisplayName("balance simple cuadrado: A=15000 / (P=5000 + Pat=10000)")
+    void balance_simple_cuadra() {
+        // Activo: bancos 15000 D
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(banco.getId()), eq(fecha)))
+                .thenReturn(new SaldoCuenta(new BigDecimal("15000"), BigDecimal.ZERO));
+        // Pasivo: ahorros 5000 A
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(ahorros.getId()), eq(fecha)))
+                .thenReturn(new SaldoCuenta(BigDecimal.ZERO, new BigDecimal("5000")));
+        // Patrimonio: aportes 10000 A
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(aportes.getId()), eq(fecha)))
+                .thenReturn(new SaldoCuenta(BigDecimal.ZERO, new BigDecimal("10000")));
+        // Resto de cuentas hoja: cero
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(cartera.getId()), eq(fecha)))
+                .thenReturn(SaldoCuenta.cero());
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(provisionCartera.getId()), eq(fecha)))
+                .thenReturn(SaldoCuenta.cero());
+
+        BalanceGeneralResponse resp = useCase.ejecutar(
+                BalanceGeneralFilter.al(fecha), UUID.randomUUID());
+
+        assertThat(resp.totales().totalActivo()).isEqualByComparingTo("15000");
+        assertThat(resp.totales().totalPasivo()).isEqualByComparingTo("5000");
+        assertThat(resp.totales().totalPatrimonio()).isEqualByComparingTo("10000");
+        assertThat(resp.totales().balanceado()).isTrue();
+    }
+
+    @Test
+    @DisplayName("cuenta correctora 1.3.99 con saldo resta del rubro padre")
+    void correctora_resta() {
+        // Cartera bruta: 10000
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(cartera.getId()), eq(fecha)))
+                .thenReturn(new SaldoCuenta(new BigDecimal("10000"), BigDecimal.ZERO));
+        // Provisión cartera (CR, naturaleza acreedora dentro de activo): 500
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(provisionCartera.getId()), eq(fecha)))
+                .thenReturn(new SaldoCuenta(BigDecimal.ZERO, new BigDecimal("500")));
+        // Resto cero
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(banco.getId()), eq(fecha)))
+                .thenReturn(SaldoCuenta.cero());
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(ahorros.getId()), eq(fecha)))
+                .thenReturn(SaldoCuenta.cero());
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(aportes.getId()), eq(fecha)))
+                .thenReturn(SaldoCuenta.cero());
+
+        BalanceGeneralResponse resp = useCase.ejecutar(
+                BalanceGeneralFilter.al(fecha), UUID.randomUUID());
+
+        // Activo total = 10000 (cartera) − 500 (provisión) = 9500
+        assertThat(resp.totales().totalActivo()).isEqualByComparingTo("9500");
+
+        // Verificar que la provisión aparece marcada como correctora
+        BalanceGeneralResponse.NodoCuenta rubro1 = resp.activo().rubros().get(0);
+        BalanceGeneralResponse.NodoCuenta grupo13 = rubro1.hijos().stream()
+                .filter(g -> g.codigo().equals("1.3"))
+                .findFirst().orElseThrow();
+        BalanceGeneralResponse.NodoCuenta provision = grupo13.hijos().stream()
+                .filter(c -> c.codigo().equals("1.3.99"))
+                .findFirst().orElseThrow();
+        assertThat(provision.esCorrectora()).isTrue();
+    }
+
+    @Test
+    @DisplayName("excedente del ER se suma al patrimonio para cuadrar")
+    void excedente_se_integra() {
+        // Resto cero por default
+        lenient().when(asientoRepo.calcularSaldoCuentaHasta(any(), any())).thenReturn(SaldoCuenta.cero());
+        // Activo bancos: 1000 D
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(banco.getId()), eq(fecha)))
+                .thenReturn(new SaldoCuenta(new BigDecimal("1000"), BigDecimal.ZERO));
+        // Patrimonio aportes: 700 A
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(aportes.getId()), eq(fecha)))
+                .thenReturn(new SaldoCuenta(BigDecimal.ZERO, new BigDecimal("700")));
+
+        when(estadoResultadosUseCase.ejecutar(any(), any()))
+                .thenReturn(estadoResultadosResponseConExcedente(new BigDecimal("300"), "EXCEDENTE"));
+
+        BalanceGeneralResponse resp = useCase.ejecutar(
+                BalanceGeneralFilter.al(fecha), UUID.randomUUID());
+
+        assertThat(resp.totales().totalActivo()).isEqualByComparingTo("1000");
+        assertThat(resp.totales().totalPasivo()).isEqualByComparingTo("0");
+        assertThat(resp.totales().totalPatrimonio()).isEqualByComparingTo("700");
+        assertThat(resp.totales().excedenteEjercicio()).isEqualByComparingTo("300");
+        assertThat(resp.totales().totalPasivoMasPatrimonio()).isEqualByComparingTo("1000");
+        assertThat(resp.totales().balanceado()).isTrue();
+        assertThat(resp.excedenteEtiqueta()).isEqualTo("EXCEDENTE");
+    }
+
+    @Test
+    @DisplayName("déficit del ER se resta del patrimonio")
+    void deficit_se_resta() {
+        // Activo 500, Patrimonio aportes 800, Déficit 300 → cuadrar
+        when(asientoRepo.calcularSaldoCuentaHasta(any(), any())).thenReturn(SaldoCuenta.cero());
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(banco.getId()), eq(fecha)))
+                .thenReturn(new SaldoCuenta(new BigDecimal("500"), BigDecimal.ZERO));
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(aportes.getId()), eq(fecha)))
+                .thenReturn(new SaldoCuenta(BigDecimal.ZERO, new BigDecimal("800")));
+
+        when(estadoResultadosUseCase.ejecutar(any(), any()))
+                .thenReturn(estadoResultadosResponseConExcedente(new BigDecimal("300"), "DÉFICIT"));
+
+        BalanceGeneralResponse resp = useCase.ejecutar(
+                BalanceGeneralFilter.al(fecha), UUID.randomUUID());
+
+        assertThat(resp.totales().excedenteEjercicio()).isEqualByComparingTo("-300");
+        // Activo 500 = 0 (pasivo) + 800 (patrimonio) − 300 (déficit) = 500 ✓
+        assertThat(resp.totales().balanceado()).isTrue();
+        assertThat(resp.excedenteEtiqueta()).isEqualTo("DÉFICIT");
+    }
+
+    @Test
+    @DisplayName("incluirCeros=false poda cuentas con saldo cero")
+    void poda_de_ceros_default() {
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(banco.getId()), eq(fecha)))
+                .thenReturn(new SaldoCuenta(new BigDecimal("100"), BigDecimal.ZERO));
+        // Resto cero
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(cartera.getId()), eq(fecha)))
+                .thenReturn(SaldoCuenta.cero());
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(provisionCartera.getId()), eq(fecha)))
+                .thenReturn(SaldoCuenta.cero());
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(ahorros.getId()), eq(fecha)))
+                .thenReturn(SaldoCuenta.cero());
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(aportes.getId()), eq(fecha)))
+                .thenReturn(SaldoCuenta.cero());
+
+        BalanceGeneralResponse resp = useCase.ejecutar(
+                BalanceGeneralFilter.al(fecha), UUID.randomUUID());
+
+        // Solo rubro 1 con grupo 1.1 con cuenta 1.1.03 aparece
+        BalanceGeneralResponse.NodoCuenta rubro = resp.activo().rubros().get(0);
+        // Grupo 1.3 NO aparece (cartera + provisión ambos cero)
+        boolean tieneGrupo13 = rubro.hijos().stream().anyMatch(g -> g.codigo().equals("1.3"));
+        assertThat(tieneGrupo13).isFalse();
+        // Sí tiene 1.1
+        boolean tieneGrupo11 = rubro.hijos().stream().anyMatch(g -> g.codigo().equals("1.1"));
+        assertThat(tieneGrupo11).isTrue();
+    }
+
+    @Test
+    @DisplayName("incluirCeros=true muestra árbol completo")
+    void incluir_ceros_muestra_todo() {
+        when(asientoRepo.calcularSaldoCuentaHasta(any(), any())).thenReturn(SaldoCuenta.cero());
+
+        BalanceGeneralResponse resp = useCase.ejecutar(
+                new BalanceGeneralFilter(fecha, null, true), UUID.randomUUID());
+
+        // 3 rubros visibles aunque cero (1, 2, 3)
+        assertThat(resp.activo().rubros()).hasSize(1);
+        assertThat(resp.pasivo().rubros()).hasSize(1);
+        assertThat(resp.patrimonio().rubros()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("encabezado completo con fechaCorte e inicioEjercicio resuelto")
+    void encabezado_completo() {
+        when(asientoRepo.calcularSaldoCuentaHasta(any(), any())).thenReturn(SaldoCuenta.cero());
+
+        BalanceGeneralResponse resp = useCase.ejecutar(
+                BalanceGeneralFilter.al(LocalDate.of(2026, 6, 30)), UUID.randomUUID());
+
+        assertThat(resp.encabezado().razonSocial()).isEqualTo("Fatrans Test");
+        assertThat(resp.encabezado().fechaCorte()).isEqualTo(LocalDate.of(2026, 6, 30));
+        assertThat(resp.encabezado().inicioEjercicio()).isEqualTo(LocalDate.of(2026, 1, 1));
+    }
+
+    @Test
+    @DisplayName("balance desbalanceado: diferencia visible y flag false (defensivo)")
+    void desbalance_se_reporta() {
+        // Activo: 1000, Pasivo+Patrim: 600 → diferencia 400
+        when(asientoRepo.calcularSaldoCuentaHasta(any(), any())).thenReturn(SaldoCuenta.cero());
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(banco.getId()), eq(fecha)))
+                .thenReturn(new SaldoCuenta(new BigDecimal("1000"), BigDecimal.ZERO));
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(ahorros.getId()), eq(fecha)))
+                .thenReturn(new SaldoCuenta(BigDecimal.ZERO, new BigDecimal("600")));
+
+        BalanceGeneralResponse resp = useCase.ejecutar(
+                BalanceGeneralFilter.al(fecha), UUID.randomUUID());
+
+        assertThat(resp.totales().diferencia()).isEqualByComparingTo("400");
+        assertThat(resp.totales().balanceado()).isFalse();
+    }
+
+    // ─── Helper ────────────────────────────────────────────────────────────
+
+    private EstadoResultadosResponse estadoResultadosResponseConExcedente(
+            BigDecimal excedente, String etiqueta) {
+        return EstadoResultadosResponse.builder()
+                .encabezado(EstadoResultadosResponse.Encabezado.builder()
+                        .razonSocial("Test").rif("J-T")
+                        .desde(LocalDate.now()).hasta(LocalDate.now())
+                        .build())
+                .ingresos(EstadoResultadosResponse.Seccion.builder()
+                        .tipo(TipoCuentaContable.INGRESO).titulo("INGRESOS")
+                        .rubros(List.of()).total(BigDecimal.ZERO).build())
+                .egresos(EstadoResultadosResponse.Seccion.builder()
+                        .tipo(TipoCuentaContable.EGRESO).titulo("EGRESOS")
+                        .rubros(List.of()).total(BigDecimal.ZERO).build())
+                .excedente(excedente)
+                .excedenteEtiqueta(etiqueta)
+                .build();
+    }
+}

--- a/backend/src/test/java/com/tufondo/contabilidad/application/usecase/GenerarEstadoResultadosUseCaseTest.java
+++ b/backend/src/test/java/com/tufondo/contabilidad/application/usecase/GenerarEstadoResultadosUseCaseTest.java
@@ -1,0 +1,228 @@
+package com.tufondo.contabilidad.application.usecase;
+
+import com.tufondo.contabilidad.application.config.EntidadProperties;
+import com.tufondo.contabilidad.application.dto.EstadoResultadosFilter;
+import com.tufondo.contabilidad.application.dto.EstadoResultadosResponse;
+import com.tufondo.contabilidad.domain.model.CuentaContable;
+import com.tufondo.contabilidad.domain.model.SaldoCuenta;
+import com.tufondo.contabilidad.domain.model.enums.NaturalezaSaldo;
+import com.tufondo.contabilidad.domain.model.enums.TipoCuentaContable;
+import com.tufondo.contabilidad.domain.repository.AsientoContableRepository;
+import com.tufondo.contabilidad.domain.repository.CuentaContableRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests del {@link GenerarEstadoResultadosUseCase} (sub-issue #271).
+ *
+ * <p>Cobertura: roll-up jerarquía, excedente vs déficit, poda de ceros,
+ * exclusión de tipos que no son ingresos/egresos.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class GenerarEstadoResultadosUseCaseTest {
+
+    @Mock private AsientoContableRepository asientoRepo;
+    @Mock private CuentaContableRepository cuentaRepo;
+
+    @InjectMocks private GenerarEstadoResultadosUseCase useCase;
+
+    // Plan mínimo: 4 → 4.1 → 4.1.01 (Intereses), 5 → 5.2 → 5.2.01 (Sueldos)
+    private CuentaContable rubroIngresos, grupoIngresoCart, ingresoIntereses;
+    private CuentaContable rubroEgresos, grupoEgresoOper, egresoSueldos;
+    private CuentaContable activo;  // tipo 1 — NO debe aparecer
+
+    private final LocalDate desde = LocalDate.of(2026, 5, 1);
+    private final LocalDate hasta = LocalDate.of(2026, 5, 31);
+
+    @BeforeEach
+    void setUp() {
+        EntidadProperties props = new EntidadProperties();
+        props.setRazonSocial("Fatrans Test");
+        props.setRif("J-TEST-0");
+        useCase = new GenerarEstadoResultadosUseCase(asientoRepo, cuentaRepo, props);
+
+        rubroIngresos = CuentaContable.crear(
+                "4", "INGRESOS", TipoCuentaContable.INGRESO,
+                NaturalezaSaldo.ACREEDORA, null, false, null);
+        grupoIngresoCart = CuentaContable.crear(
+                "4.1", "Ingresos Cartera", TipoCuentaContable.INGRESO,
+                NaturalezaSaldo.ACREEDORA, rubroIngresos.getId(), false, null);
+        ingresoIntereses = CuentaContable.crear(
+                "4.1.01", "Intereses sobre Créditos", TipoCuentaContable.INGRESO,
+                NaturalezaSaldo.ACREEDORA, grupoIngresoCart.getId(), true, null);
+
+        rubroEgresos = CuentaContable.crear(
+                "5", "EGRESOS", TipoCuentaContable.EGRESO,
+                NaturalezaSaldo.DEUDORA, null, false, null);
+        grupoEgresoOper = CuentaContable.crear(
+                "5.2", "Egresos Operativos", TipoCuentaContable.EGRESO,
+                NaturalezaSaldo.DEUDORA, rubroEgresos.getId(), false, null);
+        egresoSueldos = CuentaContable.crear(
+                "5.2.01", "Sueldos", TipoCuentaContable.EGRESO,
+                NaturalezaSaldo.DEUDORA, grupoEgresoOper.getId(), true, null);
+
+        // Cuenta de tipo 1 que NO debe aparecer en el ER
+        activo = CuentaContable.crear(
+                "1.1.03", "Bancos", TipoCuentaContable.ACTIVO,
+                NaturalezaSaldo.DEUDORA, UUID.randomUUID(), true, null);
+
+        lenient().when(cuentaRepo.listarTodas()).thenReturn(List.of(
+                rubroIngresos, grupoIngresoCart, ingresoIntereses,
+                rubroEgresos, grupoEgresoOper, egresoSueldos, activo));
+    }
+
+    @Test
+    @DisplayName("período sin movimientos → ingresos=0, egresos=0, excedente=0 (poda total)")
+    void periodo_vacio() {
+        when(asientoRepo.calcularSaldoCuentaHasta(any(), any())).thenReturn(SaldoCuenta.cero());
+
+        EstadoResultadosResponse resp = useCase.ejecutar(
+                EstadoResultadosFilter.de(desde, hasta), UUID.randomUUID());
+
+        assertThat(resp.ingresos().total()).isEqualByComparingTo("0");
+        assertThat(resp.egresos().total()).isEqualByComparingTo("0");
+        assertThat(resp.excedente()).isEqualByComparingTo("0");
+        assertThat(resp.excedenteEtiqueta()).isEqualTo("—");
+        // poda: rubros con saldo cero no aparecen
+        assertThat(resp.ingresos().rubros()).isEmpty();
+        assertThat(resp.egresos().rubros()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("ingresos > egresos → EXCEDENTE")
+    void excedente_positivo() {
+        // Intereses: saldo período = 1000 (acreedor)
+        // Sueldos: saldo período = 400 (deudor)
+        cuandoCalcularSaldoDevolver(ingresoIntereses.getId(), "0", "1000", "0", "0");
+        cuandoCalcularSaldoDevolver(egresoSueldos.getId(), "400", "0", "0", "0");
+
+        EstadoResultadosResponse resp = useCase.ejecutar(
+                EstadoResultadosFilter.de(desde, hasta), UUID.randomUUID());
+
+        assertThat(resp.ingresos().total()).isEqualByComparingTo("1000");
+        assertThat(resp.egresos().total()).isEqualByComparingTo("400");
+        assertThat(resp.excedente()).isEqualByComparingTo("600");
+        assertThat(resp.excedenteEtiqueta()).isEqualTo("EXCEDENTE");
+    }
+
+    @Test
+    @DisplayName("egresos > ingresos → DÉFICIT")
+    void deficit() {
+        cuandoCalcularSaldoDevolver(ingresoIntereses.getId(), "0", "100", "0", "0");
+        cuandoCalcularSaldoDevolver(egresoSueldos.getId(), "500", "0", "0", "0");
+
+        EstadoResultadosResponse resp = useCase.ejecutar(
+                EstadoResultadosFilter.de(desde, hasta), UUID.randomUUID());
+
+        assertThat(resp.excedente()).isEqualByComparingTo("400");
+        assertThat(resp.excedenteEtiqueta()).isEqualTo("DÉFICIT");
+    }
+
+    @Test
+    @DisplayName("solo cuentas de tipo INGRESO/EGRESO aparecen — activo (1.1.03) NO")
+    void excluye_otros_tipos() {
+        // El activo NO debe ser consultado por el use case (se filtra por tipo).
+        // Si fuera consultado, devolvemos saldo grande para que sea evidente
+        // si el filtro fallara (lenient porque no debería invocarse).
+        lenient().when(asientoRepo.calcularSaldoCuentaHasta(eq(activo.getId()), any()))
+                .thenReturn(new SaldoCuenta(new BigDecimal("9999"), BigDecimal.ZERO));
+        cuandoCalcularSaldoDevolver(ingresoIntereses.getId(), "0", "100", "0", "0");
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(egresoSueldos.getId()), any()))
+                .thenReturn(SaldoCuenta.cero());
+
+        EstadoResultadosResponse resp = useCase.ejecutar(
+                EstadoResultadosFilter.de(desde, hasta), UUID.randomUUID());
+
+        // El activo no debe aparecer en ninguna sección
+        boolean activoAparece = resp.ingresos().rubros().stream()
+                .anyMatch(r -> r.codigo().equals("1.1.03"))
+                || resp.egresos().rubros().stream()
+                .anyMatch(r -> r.codigo().equals("1.1.03"));
+        assertThat(activoAparece).isFalse();
+    }
+
+    @Test
+    @DisplayName("roll-up: rubro 4 = grupo 4.1 = hoja 4.1.01")
+    void rollup_funciona() {
+        cuandoCalcularSaldoDevolver(ingresoIntereses.getId(), "0", "750", "0", "0");
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(egresoSueldos.getId()), any()))
+                .thenReturn(SaldoCuenta.cero());
+
+        EstadoResultadosResponse resp = useCase.ejecutar(
+                EstadoResultadosFilter.de(desde, hasta), UUID.randomUUID());
+
+        assertThat(resp.ingresos().rubros()).hasSize(1);
+        var rubro4 = resp.ingresos().rubros().get(0);
+        assertThat(rubro4.codigo()).isEqualTo("4");
+        assertThat(rubro4.saldoNeto()).isEqualByComparingTo("750");
+        // grupo 4.1
+        assertThat(rubro4.hijos()).hasSize(1);
+        var grupo = rubro4.hijos().get(0);
+        assertThat(grupo.codigo()).isEqualTo("4.1");
+        assertThat(grupo.saldoNeto()).isEqualByComparingTo("750");
+        // hoja 4.1.01
+        assertThat(grupo.hijos()).hasSize(1);
+        assertThat(grupo.hijos().get(0).codigo()).isEqualTo("4.1.01");
+        assertThat(grupo.hijos().get(0).saldoNeto()).isEqualByComparingTo("750");
+    }
+
+    @Test
+    @DisplayName("incluirCeros=true: muestra árbol completo aunque saldos sean cero")
+    void incluir_ceros_muestra_todo() {
+        when(asientoRepo.calcularSaldoCuentaHasta(any(), any())).thenReturn(SaldoCuenta.cero());
+
+        EstadoResultadosResponse resp = useCase.ejecutar(
+                new EstadoResultadosFilter(desde, hasta, true), UUID.randomUUID());
+
+        // Con incluirCeros=true, los rubros aparecen aunque vacíos
+        assertThat(resp.ingresos().rubros()).hasSize(1);
+        assertThat(resp.egresos().rubros()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("período calculado correctamente: saldo_hasta − saldo_antesDesde")
+    void calcula_saldo_periodo_diferencial() {
+        // Saldo acumulado hasta hasta: 1500 acreedor
+        // Saldo acumulado hasta desde-1: 500 acreedor
+        // → saldo del período: 1000
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(ingresoIntereses.getId()), eq(hasta)))
+                .thenReturn(new SaldoCuenta(BigDecimal.ZERO, new BigDecimal("1500")));
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(ingresoIntereses.getId()), eq(desde.minusDays(1))))
+                .thenReturn(new SaldoCuenta(BigDecimal.ZERO, new BigDecimal("500")));
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(egresoSueldos.getId()), any()))
+                .thenReturn(SaldoCuenta.cero());
+
+        EstadoResultadosResponse resp = useCase.ejecutar(
+                EstadoResultadosFilter.de(desde, hasta), UUID.randomUUID());
+
+        assertThat(resp.ingresos().total()).isEqualByComparingTo("1000");
+    }
+
+    // ─── Helper ────────────────────────────────────────────────────────────
+
+    /** Mock cómodo: setea saldo hasta(hasta) y hasta(desde-1) con valores. */
+    private void cuandoCalcularSaldoDevolver(UUID cuentaId,
+                                              String debeHasta, String haberHasta,
+                                              String debeAntes, String haberAntes) {
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(cuentaId), eq(hasta)))
+                .thenReturn(new SaldoCuenta(new BigDecimal(debeHasta), new BigDecimal(haberHasta)));
+        when(asientoRepo.calcularSaldoCuentaHasta(eq(cuentaId), eq(desde.minusDays(1))))
+                .thenReturn(new SaldoCuenta(new BigDecimal(debeAntes), new BigDecimal(haberAntes)));
+    }
+}

--- a/backend/src/test/java/com/tufondo/contabilidad/infrastructure/pdf/BalanceYEstadoResultadosPdfAdapterTest.java
+++ b/backend/src/test/java/com/tufondo/contabilidad/infrastructure/pdf/BalanceYEstadoResultadosPdfAdapterTest.java
@@ -1,0 +1,247 @@
+package com.tufondo.contabilidad.infrastructure.pdf;
+
+import com.tufondo.contabilidad.application.dto.BalanceGeneralResponse;
+import com.tufondo.contabilidad.application.dto.EstadoResultadosResponse;
+import com.tufondo.contabilidad.domain.model.enums.NaturalezaSaldo;
+import com.tufondo.contabilidad.domain.model.enums.TipoCuentaContable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests del método {@code generarBalanceGeneralPdf} y
+ * {@code generarEstadoResultadosPdf} del adapter unificado (sub-issue #271).
+ *
+ * <p>Verifica generación de bytes válidos para diversos casos: vacío, con
+ * datos, con cuentas correctoras, con déficit, balanceado y desbalanceado.</p>
+ */
+class BalanceYEstadoResultadosPdfAdapterTest {
+
+    private final LibroDiarioPdfAdapter adapter = new LibroDiarioPdfAdapter();
+
+    // ═══ Balance General ═══════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Balance General PDF")
+    class Balance {
+
+        @Test
+        @DisplayName("balance vacío genera PDF con cabecera y totales en cero")
+        void balance_vacio() {
+            BalanceGeneralResponse b = BalanceGeneralResponse.builder()
+                    .encabezado(encabezadoBalance())
+                    .activo(seccionVacia(TipoCuentaContable.ACTIVO, "ACTIVO"))
+                    .pasivo(seccionVacia(TipoCuentaContable.PASIVO, "PASIVO"))
+                    .patrimonio(seccionVacia(TipoCuentaContable.PATRIMONIO, "PATRIMONIO"))
+                    .excedenteEjercicio(BigDecimal.ZERO)
+                    .excedenteEtiqueta("—")
+                    .totales(BalanceGeneralResponse.Totales.builder()
+                            .totalActivo(BigDecimal.ZERO).totalPasivo(BigDecimal.ZERO)
+                            .totalPatrimonio(BigDecimal.ZERO).excedenteEjercicio(BigDecimal.ZERO)
+                            .totalPasivoMasPatrimonio(BigDecimal.ZERO)
+                            .diferencia(BigDecimal.ZERO).balanceado(true)
+                            .build())
+                    .build();
+
+            byte[] pdf = adapter.generarBalanceGeneralPdf(b);
+            assertThat(esPdfValido(pdf)).isTrue();
+        }
+
+        @Test
+        @DisplayName("balance con cuentas y correctora genera PDF (signo negativo en correctora)")
+        void balance_con_correctora() {
+            BalanceGeneralResponse.NodoCuenta cartera = nodoBalance(
+                    "1.3.01", "Créditos por Cobrar", 3, false, "10000");
+            BalanceGeneralResponse.NodoCuenta provision = BalanceGeneralResponse.NodoCuenta.builder()
+                    .codigo("1.3.99").nombre("Provisión Cartera (CR)")
+                    .nivel(3).naturaleza(NaturalezaSaldo.ACREEDORA)
+                    .esCorrectora(true)
+                    .saldoNeto(new BigDecimal("-500"))   // saldo negativo dentro de rubro deudor
+                    .saldoPresentacion(new BigDecimal("500"))
+                    .hijos(List.of())
+                    .build();
+            BalanceGeneralResponse.NodoCuenta grupo = BalanceGeneralResponse.NodoCuenta.builder()
+                    .codigo("1.3").nombre("Cartera").nivel(2)
+                    .naturaleza(NaturalezaSaldo.DEUDORA).esCorrectora(false)
+                    .saldoNeto(new BigDecimal("9500")).saldoPresentacion(new BigDecimal("9500"))
+                    .hijos(List.of(cartera, provision))
+                    .build();
+            BalanceGeneralResponse.NodoCuenta rubro = BalanceGeneralResponse.NodoCuenta.builder()
+                    .codigo("1").nombre("ACTIVO").nivel(1)
+                    .naturaleza(NaturalezaSaldo.DEUDORA).esCorrectora(false)
+                    .saldoNeto(new BigDecimal("9500")).saldoPresentacion(new BigDecimal("9500"))
+                    .hijos(List.of(grupo))
+                    .build();
+            BalanceGeneralResponse b = BalanceGeneralResponse.builder()
+                    .encabezado(encabezadoBalance())
+                    .activo(BalanceGeneralResponse.Seccion.builder()
+                            .tipo(TipoCuentaContable.ACTIVO).titulo("ACTIVO")
+                            .rubros(List.of(rubro)).total(new BigDecimal("9500"))
+                            .build())
+                    .pasivo(seccionVacia(TipoCuentaContable.PASIVO, "PASIVO"))
+                    .patrimonio(seccionVacia(TipoCuentaContable.PATRIMONIO, "PATRIMONIO"))
+                    .excedenteEjercicio(BigDecimal.ZERO).excedenteEtiqueta("—")
+                    .totales(BalanceGeneralResponse.Totales.builder()
+                            .totalActivo(new BigDecimal("9500")).totalPasivo(BigDecimal.ZERO)
+                            .totalPatrimonio(BigDecimal.ZERO).excedenteEjercicio(BigDecimal.ZERO)
+                            .totalPasivoMasPatrimonio(BigDecimal.ZERO)
+                            .diferencia(new BigDecimal("9500")).balanceado(false)
+                            .build())
+                    .build();
+
+            byte[] pdf = adapter.generarBalanceGeneralPdf(b);
+            assertThat(esPdfValido(pdf)).isTrue();
+            assertThat(pdf.length).isGreaterThan(1500);
+        }
+
+        @Test
+        @DisplayName("balance con déficit del ejercicio se renderiza con fondo distintivo")
+        void balance_con_deficit() {
+            BalanceGeneralResponse b = BalanceGeneralResponse.builder()
+                    .encabezado(encabezadoBalance())
+                    .activo(seccionVacia(TipoCuentaContable.ACTIVO, "ACTIVO"))
+                    .pasivo(seccionVacia(TipoCuentaContable.PASIVO, "PASIVO"))
+                    .patrimonio(seccionVacia(TipoCuentaContable.PATRIMONIO, "PATRIMONIO"))
+                    .excedenteEjercicio(new BigDecimal("200"))
+                    .excedenteEtiqueta("DÉFICIT")
+                    .totales(BalanceGeneralResponse.Totales.builder()
+                            .totalActivo(BigDecimal.ZERO).totalPasivo(BigDecimal.ZERO)
+                            .totalPatrimonio(BigDecimal.ZERO)
+                            .excedenteEjercicio(new BigDecimal("-200"))
+                            .totalPasivoMasPatrimonio(new BigDecimal("-200"))
+                            .diferencia(new BigDecimal("200")).balanceado(false)
+                            .build())
+                    .build();
+            byte[] pdf = adapter.generarBalanceGeneralPdf(b);
+            assertThat(esPdfValido(pdf)).isTrue();
+        }
+    }
+
+    // ═══ Estado de Resultados ══════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("Estado de Resultados PDF")
+    class EstadoResultados {
+
+        @Test
+        @DisplayName("ER vacío genera PDF con secciones vacías y excedente cero")
+        void er_vacio() {
+            EstadoResultadosResponse er = EstadoResultadosResponse.builder()
+                    .encabezado(encabezadoER())
+                    .ingresos(seccionERVacia(TipoCuentaContable.INGRESO, "INGRESOS"))
+                    .egresos(seccionERVacia(TipoCuentaContable.EGRESO, "EGRESOS"))
+                    .excedente(BigDecimal.ZERO).excedenteEtiqueta("—")
+                    .build();
+            byte[] pdf = adapter.generarEstadoResultadosPdf(er);
+            assertThat(esPdfValido(pdf)).isTrue();
+        }
+
+        @Test
+        @DisplayName("ER con excedente positivo se renderiza con fondo verde")
+        void er_con_excedente() {
+            EstadoResultadosResponse.NodoCuenta intereses = nodoER(
+                    "4.1.01", "Intereses sobre Créditos", 3, "1000");
+            EstadoResultadosResponse.NodoCuenta grupo = EstadoResultadosResponse.NodoCuenta.builder()
+                    .codigo("4.1").nombre("Ingresos Cartera").nivel(2)
+                    .naturaleza(NaturalezaSaldo.ACREEDORA)
+                    .saldoNeto(new BigDecimal("1000")).saldoPresentacion(new BigDecimal("1000"))
+                    .hijos(List.of(intereses)).build();
+            EstadoResultadosResponse.NodoCuenta rubro = EstadoResultadosResponse.NodoCuenta.builder()
+                    .codigo("4").nombre("INGRESOS").nivel(1)
+                    .naturaleza(NaturalezaSaldo.ACREEDORA)
+                    .saldoNeto(new BigDecimal("1000")).saldoPresentacion(new BigDecimal("1000"))
+                    .hijos(List.of(grupo)).build();
+            EstadoResultadosResponse er = EstadoResultadosResponse.builder()
+                    .encabezado(encabezadoER())
+                    .ingresos(EstadoResultadosResponse.Seccion.builder()
+                            .tipo(TipoCuentaContable.INGRESO).titulo("INGRESOS")
+                            .rubros(List.of(rubro)).total(new BigDecimal("1000"))
+                            .build())
+                    .egresos(seccionERVacia(TipoCuentaContable.EGRESO, "EGRESOS"))
+                    .excedente(new BigDecimal("1000"))
+                    .excedenteEtiqueta("EXCEDENTE")
+                    .build();
+            byte[] pdf = adapter.generarEstadoResultadosPdf(er);
+            assertThat(esPdfValido(pdf)).isTrue();
+            assertThat(pdf.length).isGreaterThan(1500);
+        }
+
+        @Test
+        @DisplayName("ER con déficit se renderiza con fondo rojo")
+        void er_con_deficit() {
+            EstadoResultadosResponse er = EstadoResultadosResponse.builder()
+                    .encabezado(encabezadoER())
+                    .ingresos(seccionERVacia(TipoCuentaContable.INGRESO, "INGRESOS"))
+                    .egresos(seccionERVacia(TipoCuentaContable.EGRESO, "EGRESOS"))
+                    .excedente(new BigDecimal("500"))
+                    .excedenteEtiqueta("DÉFICIT")
+                    .build();
+            byte[] pdf = adapter.generarEstadoResultadosPdf(er);
+            assertThat(esPdfValido(pdf)).isTrue();
+        }
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────
+
+    private boolean esPdfValido(byte[] pdf) {
+        if (pdf == null || pdf.length < 4) return false;
+        return pdf[0] == '%' && pdf[1] == 'P' && pdf[2] == 'D' && pdf[3] == 'F';
+    }
+
+    private BalanceGeneralResponse.Encabezado encabezadoBalance() {
+        return BalanceGeneralResponse.Encabezado.builder()
+                .razonSocial("Fatrans Test").rif("J-12345678-9")
+                .fechaCorte(LocalDate.of(2026, 5, 31))
+                .inicioEjercicio(LocalDate.of(2026, 1, 1))
+                .generadoEn(Instant.now()).generadoPorUsuarioId(UUID.randomUUID())
+                .incluyeCeros(false).build();
+    }
+
+    private EstadoResultadosResponse.Encabezado encabezadoER() {
+        return EstadoResultadosResponse.Encabezado.builder()
+                .razonSocial("Fatrans Test").rif("J-12345678-9")
+                .desde(LocalDate.of(2026, 5, 1)).hasta(LocalDate.of(2026, 5, 31))
+                .generadoEn(Instant.now()).generadoPorUsuarioId(UUID.randomUUID())
+                .incluyeCeros(false).build();
+    }
+
+    private BalanceGeneralResponse.Seccion seccionVacia(TipoCuentaContable tipo, String titulo) {
+        return BalanceGeneralResponse.Seccion.builder()
+                .tipo(tipo).titulo(titulo).rubros(List.of()).total(BigDecimal.ZERO)
+                .build();
+    }
+
+    private EstadoResultadosResponse.Seccion seccionERVacia(TipoCuentaContable tipo, String titulo) {
+        return EstadoResultadosResponse.Seccion.builder()
+                .tipo(tipo).titulo(titulo).rubros(List.of()).total(BigDecimal.ZERO)
+                .build();
+    }
+
+    private BalanceGeneralResponse.NodoCuenta nodoBalance(
+            String codigo, String nombre, int nivel, boolean correctora, String saldo) {
+        return BalanceGeneralResponse.NodoCuenta.builder()
+                .codigo(codigo).nombre(nombre).nivel(nivel)
+                .naturaleza(NaturalezaSaldo.DEUDORA).esCorrectora(correctora)
+                .saldoNeto(new BigDecimal(saldo))
+                .saldoPresentacion(new BigDecimal(saldo).abs())
+                .hijos(List.of()).build();
+    }
+
+    private EstadoResultadosResponse.NodoCuenta nodoER(
+            String codigo, String nombre, int nivel, String saldo) {
+        return EstadoResultadosResponse.NodoCuenta.builder()
+                .codigo(codigo).nombre(nombre).nivel(nivel)
+                .naturaleza(NaturalezaSaldo.ACREEDORA)
+                .saldoNeto(new BigDecimal(saldo))
+                .saldoPresentacion(new BigDecimal(saldo).abs())
+                .hijos(List.of()).build();
+    }
+}

--- a/docs/modulos/contabilidad/00-overview.md
+++ b/docs/modulos/contabilidad/00-overview.md
@@ -28,11 +28,11 @@ contable de partida doble. Eso significa:
 El EPIC #263 cierra esa brecha desde la base (plan de cuentas) hasta los
 reportes finales.
 
-## Estado actual (2026-05-20, post #270)
+## Estado actual (2026-05-21, post #271)
 
 ```
-Plan de cuentas (#264) ──► Asientos (#265+#266) ──► Hooks Ahorros (#267) ──► Hooks Créditos (#268) ──► Libro Diario (#269) ──► Libro Mayor (#270) ──► Balance General (#271) ──► Cierre (#272+#273)
-       ✅                       ✅                        ✅                        ✅                     🚧 PR #317              🚧 PR #318              ⏳                          ⏳
+Plan de cuentas (#264) ──► Asientos (#265+#266) ──► Hooks Ahorros (#267) ──► Hooks Créditos (#268) ──► Libro Diario (#269) ──► Libro Mayor (#270) ──► Balance + ER (#271) ──► Cierre (#272+#273)
+       ✅                       ✅                        ✅                        ✅                        ✅                       ✅                     🚧 En PR                ⏳
 ```
 
 ## Timeline cronológico de decisiones y entregas
@@ -184,12 +184,41 @@ resuelta por movimiento, saldo acumulado por línea, y saldo final.
 **Pendientes nuevos**:
 - Cachear saldos cerrados al cierre mensual (parte de #272) para performance.
 
-## Lo que viene después de #270
+### 2026-05-21 — #271 Balance General + Estado de Resultados (PR — reportes VEN-NIF finales)
+
+**[[07-balance-general|#271 Balance]]** y **[[08-estado-resultados|#271 ER]]** (PR en revisión)
+
+Los **dos reportes regulatorios obligatorios VEN-NIF** del bloque inicial.
+
+**Decisiones D-008** ([[_decisiones-contables#D-008|completas acá]]):
+- Roll-up jerárquico Rubro → Grupo → Cuenta hoja.
+- 🐛 **Bug detectado y fix crítico**: cuentas correctoras (`1.3.99` Provisión Cartera, `1.5.99` Depreciación) ahora restan correctamente del rubro padre. El bug usaba `c.getNaturaleza()` cuando debe ser `c.getTipo().naturalezaNatural()`. Test `correctora_resta` lo detectó (esperaba 9500, obtuvo 10500).
+- Excedente del Ejercicio integrado on-the-fly desde el ER (hasta #272 implemente persistencia en `3.3.02`).
+- Asientos ANULADOS excluidos (consistente con #270).
+- Saldos en formato absoluto + etiqueta D/A/—.
+- Validación de cuadre defensiva con marca visual.
+
+**Endpoints**:
+- `GET /api/v1/contabilidad/balance-general` (+ `/pdf`) — fecha de corte
+- `GET /api/v1/contabilidad/estado-resultados` (+ `/pdf`) — rango
+
+**33 tests nuevos, todos verde** (205 totales en el módulo contabilidad):
+- `BalanceGeneralFilterTest` (6) + `EstadoResultadosFilterTest` (5) — validaciones rango
+- `GenerarBalanceGeneralUseCaseTest` (10) — Mockito: cuadrado, correctora, excedente, déficit, poda
+- `GenerarEstadoResultadosUseCaseTest` (7) — Mockito: excedente/déficit, exclusión otros tipos, cálculo diferencial
+- `BalanceYEstadoResultadosPdfAdapterTest` (5) — generación bytes válidos
+
+**Pendientes nuevos**:
+- Asiento de cierre del Excedente (parte de #272 — para persistir en `3.3.02`).
+- Estados comparativos (período actual vs anterior).
+- Notas a los Estados Financieros (NIC-1).
+- Estado de Cambios en el Patrimonio (3er reporte VEN-NIF).
+
+## Lo que viene después de #271
 
 | # | Tema | Comentario |
 |---|---|---|
-| #271 | Balance General + Estado de Resultados | Reportes finales VEN-NIF |
-| #272 | Cierre mensual/anual | Bloqueo de período + asientos de cierre |
+| #272 | Cierre mensual/anual | Bloqueo de período + asientos de cierre (persiste Excedente en `3.3.02`) |
 | #273 | Reversión de asientos | Generación automática de asiento inverso para anulación |
 
 ## Red flags identificados durante el EPIC (no resueltos aún)

--- a/docs/modulos/contabilidad/07-balance-general.md
+++ b/docs/modulos/contabilidad/07-balance-general.md
@@ -1,0 +1,152 @@
+---
+tags: [contabilidad, reporte, balance-general, sudeca, ven-nif]
+sub-issue: "#271"
+pr: en-curso
+estado: implementado
+created: 2026-05-20
+---
+
+# 🏛️ Balance General — situación patrimonial a una fecha
+
+> [!summary] Sub-issue [[Home|#271]] (parte 1/2) — IMPLEMENTADO
+> Foto del fondo a una fecha de corte: qué tiene (Activo) vs qué debe
+> (Pasivo) y qué le pertenece (Patrimonio). **Reporte regulatorio
+> obligatorio VEN-NIF** para auditoría externa y SUDECA.
+
+## Endpoint
+
+```http
+GET /api/v1/contabilidad/balance-general
+GET /api/v1/contabilidad/balance-general/pdf
+```
+
+**Permisos**: `ROLE_ADMIN`, `ROLE_SUPER_ADMIN`, `ROLE_SISTEMA`.
+
+### Query parameters
+
+| Parámetro | Tipo | Default | Descripción |
+|---|---|---|---|
+| `fechaCorte` | `LocalDate` | **obligatorio** | Fecha a la que se evalúa (inclusive) |
+| `inicioEjercicio` | `LocalDate` | `1-enero del año de fechaCorte` | Inicio del ejercicio fiscal para calcular Excedente |
+| `incluirCeros` | `boolean` | `false` | Si `true`, muestra todas las cuentas aunque tengan saldo cero |
+
+## Estructura visual
+
+```
+═══════════════════════════════════════════════════════════════════
+       BALANCE GENERAL AL 31/05/2026
+       Asociación Fatrans — RIF J-XXX
+═══════════════════════════════════════════════════════════════════
+ACTIVO                                  PASIVO
+  1.1 Disponible          6,500.00       2.1 Depósitos       4,500.00
+    1.1.03 Bancos Bs        6,500.00       2.1.01 Ahorros Bs   4,500.00
+  1.3 Cartera              9,500.00     Subtotal PASIVO      4,500.00
+    1.3.01 Créditos        10,000.00     PATRIMONIO
+    (−) 1.3.99 Provisión     (500.00)     3.1 Aportes         10,000.00
+                                            3.1.01 Sociales    10,000.00
+                                          EXCEDENTE Ejercicio   2,400.00
+                                        TOTAL P+P+E           16,900.00
+TOTAL ACTIVO              16,000.00     ......................
+
+[Si los totales cuadran: ✓ BALANCEADO]
+[Si no:                   ⚠ DESBALANCEADO — diferencia: X]
+```
+
+## Fórmula contable
+
+```
+Total Activo  =  Total Pasivo  +  Total Patrimonio  +  Excedente del Ejercicio
+```
+
+> [!important] El Excedente del Ejercicio
+> A diferencia de las cuentas del balance que se leen directamente de los
+> saldos del plan, el **Excedente del Ejercicio** se calcula on-the-fly:
+> el use case del Balance invoca internamente al
+> [[08-estado-resultados|Estado de Resultados]] del rango
+> `inicioEjercicio → fechaCorte` y extrae el resultado.
+>
+> Esto es porque la cuenta `3.3.02 Excedente del Ejercicio` solo se persiste
+> con el saldo real cuando corre el **asiento de cierre** (#272). Mientras
+> #272 no esté implementado, el Balance lo calcula on-the-fly. Cuando
+> #272 mergee, este cálculo se reemplaza por lectura directa de `3.3.02`.
+
+## Decisiones de diseño (D-008)
+
+### D-008.1 — Roll-up por jerarquía
+Cada cuenta hoja aporta su saldo al grupo padre; cada grupo aporta a su
+rubro padre. El use case construye el árbol en memoria recorriendo el plan
+una sola vez.
+
+### D-008.2 — Cuentas correctoras restan del padre (corrección crítica del bug inicial)
+Cuentas como `1.3.99` Provisión Cartera (tipo ACTIVO con naturaleza
+ACREEDORA) tienen saldo en HABER. Para integrarlas correctamente al rubro
+padre, el use case usa la **naturaleza del TIPO** (`ACTIVO → DEUDORA`) al
+firmar el saldo, no la naturaleza de la cuenta individual. Resultado:
+`(0 debe - 500 haber)` con fórmula DEUDORA = **−500** (negativo). Suma así
+al padre correctamente restando.
+
+🐛 **Bug detectado durante implementación**: la versión inicial usaba
+`c.getNaturaleza()` en lugar de `c.getTipo().naturalezaNatural()`. Tests
+detectaron `10000 + 500 = 10500` cuando se esperaba `9500`. Fix documentado
+explícitamente en el código y en este doc para evitar regresión.
+
+### D-008.3 — Excluir asientos ANULADOS
+Mismo criterio que Libro Mayor (D-007): el Balance refleja saldos
+vigentes, no historial. Exclusión por el repo (`calcularSaldoCuentaHasta`
+ya filtra REGISTRADOS).
+
+### D-008.4 — Excedente integrado automáticamente
+Si el ER da EXCEDENTE, suma al patrimonio. Si da DÉFICIT, resta. Si es
+cero, no afecta. Etiqueta visual `EXCEDENTE / DÉFICIT / —` clara.
+
+### D-008.5 — Ejercicio fiscal calendario por default
+Si `inicioEjercicio` no se provee, default = **1-enero del año de
+fechaCorte**. Para ejercicios no calendarios (ej. julio-junio) el contador
+debe pasarlo explícito.
+
+### D-008.6 — Poda de ceros por default
+Cuentas con saldo cero NO se muestran salvo `incluirCeros=true`. Reporte
+limpio para el contador típico; vista completa disponible si auditoría lo
+exige.
+
+### D-008.7 — Validación de cuadre defensiva
+Si `Σ Activo ≠ Σ Pasivo + Σ Patrimonio + Excedente`, el sistema tiene un
+bug. El reporte muestra `⚠ DESBALANCEADO` con la diferencia exacta y
+loguea ERROR. Esto NO debería ocurrir si cada asiento individual cuadra
+(invariante del dominio), pero defensa en profundidad.
+
+## Tests (16 nuevos, todos verdes)
+
+| Test | Casos |
+|---|---|
+| `BalanceGeneralFilterTest` | 6 (validaciones fechaCorte, inicioEjercicio, incluirCeros) |
+| `GenerarBalanceGeneralUseCaseTest` | 10 (Mockito: vacío, simple cuadrado, correctora, excedente integrado, déficit, poda, encabezado, desbalance) |
+
+### Garantías verificadas
+
+- ✅ Balance vacío → totales cero, `balanceado=true`
+- ✅ Balance simple cuadrado (Activo = Pasivo + Patrimonio)
+- ✅ Cuenta correctora `1.3.99` resta del rubro padre correctamente (fix bug)
+- ✅ Cuenta correctora marcada `esCorrectora=true` en el response
+- ✅ Excedente del ER se suma al patrimonio para cuadrar
+- ✅ Déficit se resta del patrimonio
+- ✅ `incluirCeros=false` poda cuentas vacías
+- ✅ `incluirCeros=true` muestra árbol completo
+- ✅ Encabezado completo con `inicioEjercicio` resuelto
+- ✅ Desbalance se reporta con `diferencia` y `balanceado=false`
+
+## Pendientes
+
+- ⏳ **Asiento de cierre del Excedente** (parte de #272) → permitirá leer
+  saldo persistido de `3.3.02` en lugar de calcular on-the-fly.
+- ⏳ **Estados comparativos** (período actual vs anterior) — exigencia
+  VEN-NIF para reportes anuales. Sub-issue futuro.
+- ⏳ **Notas a los Estados Financieros** (NIC-1) — sub-issue dedicado.
+- ⏳ **Estado de Cambios en el Patrimonio** — tercer reporte VEN-NIF. Sub-issue dedicado.
+
+## Referencias
+
+- Issue: [[Home|#271]]
+- Decisión: [[_decisiones-contables#D-008|D-008]]
+- Dependencias: [[01-plan-cuentas|#264]], [[02-asientos-contables|#265+#266]], [[06-libro-mayor|#270]] (reutiliza `calcularSaldoCuentaHasta`)
+- Complementa: [[08-estado-resultados|Estado de Resultados]]

--- a/docs/modulos/contabilidad/08-estado-resultados.md
+++ b/docs/modulos/contabilidad/08-estado-resultados.md
@@ -1,0 +1,149 @@
+---
+tags: [contabilidad, reporte, estado-resultados, sudeca, ven-nif]
+sub-issue: "#271"
+pr: en-curso
+estado: implementado
+created: 2026-05-20
+---
+
+# 💰 Estado de Resultados — excedente del período
+
+> [!summary] Sub-issue [[Home|#271]] (parte 2/2) — IMPLEMENTADO
+> Reporte VEN-NIF del **excedente** (o déficit) del período: cuánto entró
+> de ingresos vs cuánto se gastó. El resultado es el "Excedente del
+> Ejercicio" que también aparece en el [[07-balance-general|Balance General]].
+
+## Endpoint
+
+```http
+GET /api/v1/contabilidad/estado-resultados
+GET /api/v1/contabilidad/estado-resultados/pdf
+```
+
+**Permisos**: `ROLE_ADMIN`, `ROLE_SUPER_ADMIN`, `ROLE_SISTEMA`.
+
+### Query parameters
+
+| Parámetro | Tipo | Default | Descripción |
+|---|---|---|---|
+| `desde` | `LocalDate` | **obligatorio** | Inicio del período (inclusive) |
+| `hasta` | `LocalDate` | **obligatorio** | Fin del período (inclusive) |
+| `incluirCeros` | `boolean` | `false` | Muestra todas las cuentas aunque sean cero |
+
+### Validaciones
+
+- `hasta >= desde`
+- `(hasta - desde) ≤ 366 días`
+
+## Estructura visual
+
+```
+═══════════════════════════════════════════════════════════════════
+       ESTADO DE RESULTADOS
+       Del 01/05/2026 al 31/05/2026
+       Asociación Fatrans — RIF J-XXX
+═══════════════════════════════════════════════════════════════════
+INGRESOS
+  4.1 Ingresos por Cartera                              3,800.00
+    4.1.01 Intereses sobre Créditos       3,500.00
+    4.1.02 Comisiones                       200.00
+    4.1.03 Mora                             100.00
+  4.3 Otros Ingresos                                        0.00
+TOTAL INGRESOS                                          3,800.00
+
+EGRESOS
+  5.1 Egresos por Captaciones                             400.00
+    5.1.01 Intereses sobre Ahorros          400.00
+  5.2 Egresos Operativos                                1,000.00
+    5.2.01 Sueldos                          800.00
+    5.2.04 Servicios Básicos                200.00
+TOTAL EGRESOS                                           1,400.00
+
+═══════════════════════════════════════════════════════════════════
+       EXCEDENTE DEL EJERCICIO                          2,400.00
+       (fondo verde si excedente, rojo si déficit)
+═══════════════════════════════════════════════════════════════════
+```
+
+## Cálculo del saldo del período
+
+Para cada cuenta hoja de tipo INGRESO o EGRESO:
+
+```
+saldo_periodo = saldo_acumulado(hasta) - saldo_acumulado(desde - 1)
+```
+
+Esta fórmula **diferencial** garantiza que solo se cuente lo que ocurrió
+EN el período, sin importar saldos previos (ej. ingresos de meses
+anteriores). El cálculo se hace con `calcularSaldoCuentaHasta()` del
+repositorio (#270), que ya excluye ANULADOS.
+
+## Decisiones (D-008 compartido con Balance General)
+
+### Roll-up jerárquico
+Igual que el Balance: hojas → grupos → rubros. El total de la sección es
+la suma de los rubros.
+
+### Solo cuentas de tipo INGRESO (4) y EGRESO (5)
+El use case filtra explícitamente. Cuentas de tipos 1/2/3 no aparecen
+aunque tengan movimientos en el período (esas son del Balance General).
+
+### Excedente firmado
+- `INGRESOS − EGRESOS > 0` → "EXCEDENTE"
+- `INGRESOS − EGRESOS < 0` → "DÉFICIT"
+- `INGRESOS − EGRESOS = 0` → "—"
+
+El campo `excedente` del DTO siempre es valor absoluto; la `excedenteEtiqueta`
+indica el signo conceptual.
+
+### Asientos ANULADOS excluidos
+Mismo criterio que Mayor y Balance.
+
+### Poda de ceros
+Default: cuentas con saldo cero en el período NO se muestran. Toggle
+`incluirCeros=true`.
+
+## Tests (12 nuevos, todos verdes)
+
+| Test | Casos |
+|---|---|
+| `EstadoResultadosFilterTest` | 5 (rango ≤ 1 año, hasta >= desde, factories) |
+| `GenerarEstadoResultadosUseCaseTest` | 7 (vacío, excedente positivo/déficit, exclusión otros tipos, roll-up, incluirCeros, cálculo diferencial) |
+
+### Garantías verificadas
+
+- ✅ Período vacío → ingresos=0, egresos=0, excedente=0, etiqueta `—`
+- ✅ Ingresos > Egresos → etiqueta `EXCEDENTE` y valor correcto
+- ✅ Egresos > Ingresos → etiqueta `DÉFICIT` y valor correcto
+- ✅ Cuentas de Activo (1.x) NO aparecen aunque tengan saldo grande
+- ✅ Roll-up: rubro = grupo = hoja en jerarquía 4 → 4.1 → 4.1.01
+- ✅ `incluirCeros=true` muestra árbol completo aunque cero
+- ✅ Cálculo diferencial: `saldo_hasta(hasta) − saldo_hasta(desde-1)`
+
+## Relación con el Balance General
+
+El Balance General invoca este use case internamente para calcular el
+"Excedente del Ejercicio" que aparece en Patrimonio. Cuando se invoca por
+el Balance, se usa rango = `inicioEjercicio → fechaCorte` (típicamente
+1-enero del año hasta la fecha de corte).
+
+```
+Balance General  →  invoca  →  Estado de Resultados (año fiscal)
+                                          ↓
+                              Excedente → Patrimonio del Balance
+```
+
+## Pendientes
+
+- ⏳ **Asiento de cierre** (#272): cuando esté, el excedente se persiste en
+  `3.3.02` y este reporte sigue funcionando normal; el Balance ya no
+  necesita invocarlo on-the-fly.
+- ⏳ **Estados comparativos** (período actual vs anterior).
+- ⏳ **Notas a los Estados Financieros** (NIC-1).
+
+## Referencias
+
+- Issue: [[Home|#271]]
+- Decisión: [[_decisiones-contables#D-008|D-008]]
+- Dependencias: [[01-plan-cuentas|#264]], [[02-asientos-contables|#265+#266]], [[06-libro-mayor|#270]]
+- Complementa: [[07-balance-general|Balance General]]

--- a/docs/modulos/contabilidad/Home.md
+++ b/docs/modulos/contabilidad/Home.md
@@ -31,6 +31,8 @@ estado: en-construccion
 - 🔌 [[04-hooks-creditos]] — #268 — Hooks Créditos: desembolso/cobro → asiento auto
 - 📖 [[05-libro-diario]] — #269 — Reporte Libro Diario JSON + PDF SUDECA
 - 📚 [[06-libro-mayor]] — #270 — Reporte Libro Mayor (saldos y movimientos por cuenta)
+- 🏛️ [[07-balance-general]] — #271 — Balance General (situación patrimonial)
+- 💰 [[08-estado-resultados]] — #271 — Estado de Resultados (excedente del período)
 
 ## Mapa del módulo (código)
 
@@ -71,8 +73,9 @@ backend/src/main/java/com/tufondo/ahorros/
 | [[03-hooks-ahorros\|#267]] | ✅ Merged (PR #315) | Hooks de Ahorros: depósito/retiro → asiento auto | [[_decisiones-contables#D-002\|D-002]] usar `1.1.03` no `1.1.01` |
 | [[04-hooks-creditos\|#268]] | ✅ Merged (PR #316) | Hooks de Créditos: desembolso/cobro → asiento auto | [[_decisiones-contables#D-003\|D-003]] [[_decisiones-contables#D-004\|D-004]] |
 | [[05-libro-diario\|#269]] | 🚧 PR #317 abierto | Libro Diario JSON + PDF SUDECA | [[_decisiones-contables#D-006\|D-006]] incluir anulados |
-| [[06-libro-mayor\|#270]] | 🚧 PR #318 abierto | Libro Mayor JSON + PDF (saldos por cuenta) | [[_decisiones-contables#D-007\|D-007]] saldo real, solo hojas |
-| #271 | ⏳ Pending | Balance General + Estado de Resultados | |
+| [[06-libro-mayor\|#270]] | ✅ Merged (PR #318) | Libro Mayor JSON + PDF (saldos por cuenta) | [[_decisiones-contables#D-007\|D-007]] saldo real, solo hojas |
+| [[07-balance-general\|#271 (1/2)]] | 🚧 En PR | Balance General JSON + PDF | [[_decisiones-contables#D-008\|D-008]] roll-up, correctoras, Excedente |
+| [[08-estado-resultados\|#271 (2/2)]] | 🚧 En PR | Estado de Resultados JSON + PDF | [[_decisiones-contables#D-008\|D-008]] cálculo diferencial |
 | #272 | ⏳ Pending | Cierre mensual / anual con bloqueo de período | |
 | #273 | ⏳ Pending | Reversión de asientos (asiento inverso, sin DELETE) | |
 | #274 | ⚠️ **BLOCKER LEGAL** | Confirmar naturaleza jurídica Fatrans (caja ahorro / cooperativa / fideicomiso) | Ver [[_pendientes-criticos#Confirmar-naturaleza-jurídica-Fatrans\|aquí]] |

--- a/docs/modulos/contabilidad/_decisiones-contables.md
+++ b/docs/modulos/contabilidad/_decisiones-contables.md
@@ -347,6 +347,83 @@ se toma la de mayor monto + tag `(múltiple)`. Mejora UX masivamente.
 
 ---
 
+## D-008 — Balance General y Estado de Resultados: roll-up, correctoras, Excedente integrado
+
+**Fecha:** 2026-05-21
+**Sub-issue:** [[07-balance-general|#271]] (parte 1) y [[08-estado-resultados|#271]] (parte 2)
+**Estado:** ✅ Aprobada e implementada
+**Revisor:** [[_contador-fatrans|contador-fatrans]] (rol asumido en sesión)
+
+### Contexto
+Los dos reportes finales del bloque inicial del EPIC. Balance General es
+foto a una fecha (Activo = Pasivo + Patrimonio); Estado de Resultados es
+ingresos vs egresos del período. Ambos requieren roll-up jerárquico del
+plan de cuentas y manejo cuidadoso de cuentas correctoras.
+
+### Decisiones tomadas
+
+**D-008.1 — Roll-up por jerarquía**
+Cada cuenta hoja aporta su saldo al grupo padre; cada grupo al rubro. Use
+case construye árbol en memoria recorriendo el plan + un saldo por hoja
+vía `calcularSaldoCuentaHasta`. Costo: ~2N queries (N = cuentas hoja).
+Aceptable; optimización futura con saldos cacheados en #272.
+
+**D-008.2 — Cuentas correctoras restan del padre (¡bug crítico inicial!)**
+Implementación inicial usaba `c.getNaturaleza()` para firmar el saldo.
+Para `1.3.99` Provisión Cartera (ACTIVO + naturaleza ACREEDORA): saldo
+HABER 500 → firmado por ACREEDORA = +500 → sumaba al padre ACTIVO en
+lugar de restar.
+
+**Fix**: usar `c.getTipo().naturalezaNatural()` al firmar el saldo. Para
+1.3.99 (tipo ACTIVO): firmado por DEUDORA = `debe - haber = 0 - 500 = -500`.
+Negativo → resta correctamente del padre.
+
+Test que detectó el bug: `correctora_resta` esperaba 9500 y obtuvo 10500.
+Sin este test el bug habría llegado a producción y los Balances reales
+estarían incorrectos por 2× la provisión.
+
+**D-008.3 — Asientos ANULADOS excluidos**
+Consistente con D-007 (Mayor): saldos vigentes, no historial. Exclusión a
+nivel repository por `calcularSaldoCuentaHasta`.
+
+**D-008.4 — Excedente del Ejercicio integrado on-the-fly**
+El Balance invoca al use case del Estado de Resultados para calcular
+excedente y agregarlo virtualmente al patrimonio. Cuando #272 (cierre)
+persista el excedente en `3.3.02`, este cálculo se reemplaza por lectura
+directa.
+
+**D-008.5 — Ejercicio fiscal calendario por default**
+`inicioEjercicio` default = 1-enero del año de `fechaCorte`. Si Fatrans
+operara con ejercicio fiscal no calendario, contador pasa explícito.
+
+**D-008.6 — Poda de cuentas en cero por default**
+`incluirCeros=false`: reporte limpio. `=true`: vista completa para auditoría.
+
+**D-008.7 — Validación de cuadre defensiva**
+Si `Σ Activo ≠ Σ Pasivo + Σ Patrimonio + Excedente`, log ERROR + marca
+visual `⚠ DESBALANCEADO`. NO debería ocurrir si cada asiento individual
+cuadra (invariante dominio).
+
+### Consecuencias
+
+- 2 use cases nuevos en application: `GenerarBalanceGeneralUseCase` y
+  `GenerarEstadoResultadosUseCase`.
+- 4 DTOs (filter + response × 2 reportes).
+- Extensión del port `ContabilidadPdfPort` con 2 métodos.
+- Adapter PDF unificado en `LibroDiarioPdfAdapter` (ya hace 4 reportes).
+- 2 controllers nuevos.
+- 33 tests nuevos cubriendo casos críticos.
+
+### Pendientes que abre
+
+- **#272 Cierre del Excedente**: persistir el excedente en `3.3.02` para
+  que el Balance lea saldo real en lugar de cálculo on-the-fly.
+- **Estados comparativos** (período actual vs anterior).
+- **Notas a los Estados Financieros** (VEN-NIF NIC-1).
+- **Estado de Cambios en el Patrimonio** (3er reporte VEN-NIF).
+
+---
+
 ## D-005 — (PENDIENTE) Criterio de caja vs devengo para intereses de cartera
 
 **Fecha:** 2026-05-20


### PR DESCRIPTION
## Resumen

Sub-issue **#271** del EPIC Contabilidad **#263**. Los **dos reportes regulatorios obligatorios VEN-NIF**: Balance General (foto patrimonial a una fecha) y Estado de Resultados (excedente del período). Cierran el bloque inicial de reportes contables.

## Endpoints

```http
GET /api/v1/contabilidad/balance-general            (JSON)
GET /api/v1/contabilidad/balance-general/pdf        (descarga A4 vertical)
GET /api/v1/contabilidad/estado-resultados          (JSON)
GET /api/v1/contabilidad/estado-resultados/pdf      (descarga A4 vertical)
```

**Permisos**: `ROLE_ADMIN`, `ROLE_SUPER_ADMIN`, `ROLE_SISTEMA`.

| Reporte | Parámetros | Descripción |
|---|---|---|
| Balance General | `fechaCorte` (obligatorio), `inicioEjercicio` (opt), `incluirCeros` | Snapshot patrimonial a una fecha |
| Estado de Resultados | `desde`, `hasta` (≤ 1 año), `incluirCeros` | Ingresos vs egresos del período |

## Decisiones tomadas (D-008)

| # | Decisión | Razón |
|---|---|---|
| 1 | Roll-up por jerarquía (hojas → grupos → rubros) | Construye árbol VEN-NIF en memoria con ~2N queries (N = cuentas hoja) |
| 2 | 🐛 **Bug crítico detectado + fix** | Cuentas correctoras (`1.3.99` Provisión, `1.5.99` Depreciación) usaban `c.getNaturaleza()` y sumaban en lugar de restar. Fix: `c.getTipo().naturalezaNatural()`. Test `correctora_resta` lo detectó (esperaba 9500, obtuvo 10500). |
| 3 | Asientos ANULADOS excluidos | Consistente con D-007 Libro Mayor |
| 4 | Excedente del Ejercicio integrado on-the-fly | Balance invoca al ER internamente. Cuando #272 (cierre) persista en `3.3.02`, se reemplaza por lectura directa |
| 5 | Ejercicio fiscal calendario por default | `inicioEjercicio` = 1-enero del año de `fechaCorte`. Override si ejercicio no calendario |
| 6 | Poda de cuentas en cero por default | Reporte limpio; toggle `incluirCeros=true` para vista completa |
| 7 | Validación de cuadre defensiva | Marca `⚠ DESBALANCEADO` + log ERROR si `Σ Activo ≠ Σ P+P+E` |

## Arquitectura

```
BalanceGeneralController            EstadoResultadosController
            │                                    │
            ▼                                    ▼
GenerarBalanceGeneralUseCase  ─invoca─►  GenerarEstadoResultadosUseCase
            │                                    │
            └──────────► AsientoContableRepository.calcularSaldoCuentaHasta()
                                                 │
                                                 ▼
                              SaldoCuenta + cuentaRepo.listarTodas()
                                                 │
                                                 ▼
                                 BalanceGeneralResponse / ERResponse
                                                 │
            ┌────────────────────────────────────┘
            ▼
ContabilidadPdfPort.generarBalanceGeneralPdf() / generarEstadoResultadosPdf()
            │
            ▼
LibroDiarioPdfAdapter (unificado — ya hace 4 reportes: Diario + Mayor + Balance + ER)
```

## Tests reales — 33 nuevos, todos verde

| Test class | Casos | Tipo |
|---|---|---|
| `BalanceGeneralFilterTest` | 6 | Unit — validaciones |
| `EstadoResultadosFilterTest` | 5 | Unit — validaciones rango ≤ 1 año |
| `GenerarBalanceGeneralUseCaseTest` | 10 | Mockito — vacío, cuadrado, correctora, excedente, déficit, poda, desbalance |
| `GenerarEstadoResultadosUseCaseTest` | 7 | Mockito — excedente/déficit, exclusión otros tipos, roll-up, cálculo diferencial |
| `BalanceYEstadoResultadosPdfAdapterTest` | 5 | Verificación bytes PDF (`%PDF`), correctoras, déficit |

**Suite completa backend: 672 tests / 0 failures / 0 errors** ✅

### Garantías verificadas

**Balance General:**
- ✅ Balance vacío → totales cero, `balanceado=true`
- ✅ Balance simple cuadrado (A = P + Pat)
- ✅ Cuenta correctora `1.3.99` resta del rubro padre (fix bug crítico)
- ✅ Cuenta correctora marcada `esCorrectora=true` en response
- ✅ Excedente del ER se suma al patrimonio
- ✅ Déficit se resta del patrimonio
- ✅ Poda `incluirCeros=false` esconde grupos con todo cero
- ✅ `incluirCeros=true` muestra árbol completo
- ✅ Desbalance se reporta con `diferencia` y `balanceado=false`

**Estado de Resultados:**
- ✅ Período vacío → ceros + etiqueta "—"
- ✅ Ingresos > Egresos → "EXCEDENTE"
- ✅ Egresos > Ingresos → "DÉFICIT"
- ✅ Cuentas de tipo 1/2/3 NO aparecen (filtro correcto)
- ✅ Roll-up funciona en jerarquía 4 → 4.1 → 4.1.01
- ✅ Cálculo diferencial `saldo_hasta(hasta) − saldo_hasta(desde-1)` correcto

## Documentación (vault Obsidian)

- [`07-balance-general.md`](https://github.com/gamijoam/fatrans/blob/feat/contab-balance-resultados-271/docs/modulos/contabilidad/07-balance-general.md) (nuevo)
- [`08-estado-resultados.md`](https://github.com/gamijoam/fatrans/blob/feat/contab-balance-resultados-271/docs/modulos/contabilidad/08-estado-resultados.md) (nuevo)
- `Home.md` + `00-overview.md` — estado actualizado
- `_decisiones-contables.md` — D-008 con 7 sub-decisiones formales

## Pendientes documentados

- **Asiento de cierre del Excedente** (parte de #272 — para persistir en `3.3.02` y que el Balance lea saldo real en lugar de cálculo on-the-fly).
- **Estados comparativos** (período actual vs anterior) — exigencia VEN-NIF anual.
- **Notas a los Estados Financieros** (NIC-1) — sub-issue dedicado.
- **Estado de Cambios en el Patrimonio** — 3er reporte VEN-NIF.
- **Refactor LibroDiarioPdfAdapter → ContabilidadPdfAdapter** (renombre cosmético — ya implementa 4 reportes).

## Test plan (post-merge en QA)

- [ ] Generar Balance General al cierre del mes actual → verificar que `Σ Activo = Σ Pasivo + Patrimonio + Excedente`.
- [ ] Comparar Balance con Libro Mayor (deben tener saldos consistentes por cuenta).
- [ ] Generar PDF del Balance → abrir → verificar formato 2 columnas, correctora `1.3.99` aparece con `(−)` y signo negativo.
- [ ] Generar Estado de Resultados del mes → verificar excedente coincide con el del Balance.
- [ ] Probar con período sin movimientos → ceros sin crashear.
- [ ] Probar con socio (rol SOCIO) → debe rechazar 403.

## Próximo paso del EPIC

Cuando #271 mergee a develop, sigue:
- **#272 Cierre mensual/anual** (con bloqueo de período y asiento de cierre que persiste excedente en `3.3.02`)
- **#273 Reversión de asientos** (asiento inverso automático)