### PR TITLE
fix(creditos): permitir SUPER_ADMIN en evaluacion

### DIFF
--- a/backend/src/main/java/com/tufondo/creditos/api/controller/CreditoController.java
+++ b/backend/src/main/java/com/tufondo/creditos/api/controller/CreditoController.java
@@ -195,7 +195,7 @@ public class CreditoController {
      * Roles: ADMIN, SISTEMA
      */
     @PostMapping("/creditos/solicitudes/{numeroSolicitud}/evaluar")
-    @PreAuthorize("hasAnyRole('ADMIN', 'SISTEMA')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN', 'SISTEMA')")
     @Operation(summary = "Evaluar solicitud de crédito")
     public ResponseEntity<EvaluacionResponse> evaluarSolicitud(
             @PathVariable String numeroSolicitud,
@@ -262,7 +262,7 @@ public class CreditoController {
      * Roles: ADMIN, SISTEMA
      */
     @PostMapping("/creditos/solicitudes/{numeroSolicitud}/desembolso")
-    @PreAuthorize("hasAnyRole('ADMIN', 'SISTEMA')")
+    @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN', 'SISTEMA')")
     @Operation(summary = "Desembolsar crédito")
     public ResponseEntity<Map<String, Object>> desembolsarCredito(
             @PathVariable String numeroSolicitud,
@@ -373,6 +373,7 @@ public class CreditoController {
     private boolean esAdmin(Authentication authentication) {
         return authentication.getAuthorities().stream()
                 .anyMatch(a -> a.equals(new SimpleGrantedAuthority("ROLE_ADMIN")) ||
+                              a.equals(new SimpleGrantedAuthority("ROLE_SUPER_ADMIN")) ||
                               a.equals(new SimpleGrantedAuthority("ROLE_SISTEMA")));
     }
 


### PR DESCRIPTION
## Resumen
- Permite que SUPER_ADMIN evalúe y desembolse solicitudes de crédito.
- Corrige el helper esAdmin para tratar ROLE_SUPER_ADMIN como admin en endpoints con validación IDOR.

## Pruebas
- git diff --check
- docker build -t fatrans-backend-verify:super-admin-creditos backend

## Contexto QA
Durante la prueba real del marketplace, el usuario admin (rol SUPER_ADMIN) podía listar solicitudes, pero recibía 403/Access Denied al abrir detalle/evaluar. Este fix desbloquea el flujo admin real.