### PR TITLE
fix(creditos): persistir evaluacion crediticia nueva

### DIFF
--- a/backend/src/main/java/com/tufondo/creditos/application/usecase/EvaluarSolicitudUseCase.java
+++ b/backend/src/main/java/com/tufondo/creditos/application/usecase/EvaluarSolicitudUseCase.java
@@ -21,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 /**
  * Caso de uso para evaluar una solicitud de crédito.
@@ -76,7 +75,6 @@ public class EvaluarSolicitudUseCase {
 
         // Crear evaluación (tasaInteresFinal se calcula después)
         EvaluacionCrediticia evaluacion = EvaluacionCrediticia.builder()
-            .id(UUID.randomUUID())
             .solicitudId(solicitud.getId())
             .socioId(solicitud.getSocioId())
             .puntajeAntiguedad(puntajeAntiguedad)

--- a/backend/src/main/java/com/tufondo/creditos/infrastructure/persistence/adapter/EvaluacionCrediticiaRepositoryImpl.java
+++ b/backend/src/main/java/com/tufondo/creditos/infrastructure/persistence/adapter/EvaluacionCrediticiaRepositoryImpl.java
@@ -71,7 +71,7 @@ public class EvaluacionCrediticiaRepositoryImpl implements EvaluacionCrediticiaR
 
     private EvaluacionCrediticiaEntity toEntity(EvaluacionCrediticia domain) {
         return EvaluacionCrediticiaEntity.builder()
-            .id(domain.getId())
+            .id(domain.getVersion() == null ? null : domain.getId())
             .solicitudId(domain.getSolicitudId())
             .socioId(domain.getSocioId())
             .puntajeAntiguedad(domain.getPuntajeAntiguedad())


### PR DESCRIPTION
## Resumen
- Evita preasignar UUID en evaluaciones crediticias nuevas con @GeneratedValue.
- El mapper JPA solo conserva id cuando la entidad ya trae version, evitando que Hibernate trate la evaluación nueva como detached.

## Pruebas
- git diff --check
- docker build -t fatrans-backend-verify:evaluacion-version backend

## Contexto QA
Durante la prueba real del marketplace, el flujo llegó a evaluación y falló con: Detached entity with generated id ... version null. Este fix desbloquea la evaluación admin.