### PR TITLE
fix(creditos): conservar version de solicitud al guardar

### DIFF
--- a/backend/src/main/java/com/tufondo/creditos/infrastructure/persistence/adapter/SolicitudCreditoRepositoryImpl.java
+++ b/backend/src/main/java/com/tufondo/creditos/infrastructure/persistence/adapter/SolicitudCreditoRepositoryImpl.java
@@ -152,6 +152,8 @@ public class SolicitudCreditoRepositoryImpl implements SolicitudCreditoRepositor
             builder.id(domain.getId());
         }
 
-        return builder.build();
+        return builder
+            .version(domain.getId() != null && domain.getVersion() == null ? 0L : domain.getVersion())
+            .build();
     }
 }


### PR DESCRIPTION
## Resumen
- copia el campo version del dominio SolicitudCredito al entity antes de guardar
- normaliza a 0 solo para solicitudes existentes que pudieran llegar sin version

## Causa raiz
Durante la evaluacion de una solicitud, el repositorio reconstruia SolicitudCreditoEntity con id pero sin @Version. Hibernate lo interpretaba como entidad detached con version nula y abortaba la actualizacion.

## Validacion
- docker build --progress=plain -t fatrans-backend-verify:solicitud-version backend