### PR TITLE
fix(creditos): evitar unboxing en version de solicitud

### DIFF
--- a/backend/src/main/java/com/tufondo/creditos/infrastructure/persistence/adapter/SolicitudCreditoRepositoryImpl.java
+++ b/backend/src/main/java/com/tufondo/creditos/infrastructure/persistence/adapter/SolicitudCreditoRepositoryImpl.java
@@ -152,8 +152,13 @@ public class SolicitudCreditoRepositoryImpl implements SolicitudCreditoRepositor
             builder.id(domain.getId());
         }
 
+        Long version = domain.getVersion();
+        if (domain.getId() != null && version == null) {
+            version = 0L;
+        }
+
         return builder
-            .version(domain.getId() != null && domain.getVersion() == null ? 0L : domain.getVersion())
+            .version(version)
             .build();
     }
 }


### PR DESCRIPTION
## Resumen
- calcula la version de SolicitudCredito en una variable Long antes de construir el entity
- evita el unboxing accidental cuando se guarda una solicitud nueva con version null

## Causa raiz
El ternario anterior mezclaba 0L con domain.getVersion(), lo que forzaba unboxing. En solicitudes nuevas, version es null y eso provocaba NPE al crear financiamiento desde productos.

## Validacion
- git diff --check
- docker build --progress=plain -t fatrans-backend-verify:solicitud-version-unboxing backend