### PR TITLE
fix(ui): simplificar menu de usuario y saludo socio

### DIFF
--- a/frontend-web/src/app/(dashboard)/dashboard/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import Link from 'next/link';
 import { useAuthStore } from '@/stores/auth-store';
+import { sociosApi } from '@/lib/api/client';
 import {
   Loader2, Wallet, CreditCard, Plus, ArrowUpRight, ArrowDownRight,
   Shield, FileText, Users, Calculator, Eye, EyeOff,
@@ -37,6 +38,17 @@ interface CuentaAhorro {
   moneda: string;
   saldoActual: number;
   estado: string;
+}
+
+interface PerfilSocioBasico {
+  primerNombre?: string;
+}
+
+function obtenerNombreSaludo(userName?: string | null, primerNombrePerfil?: string | null) {
+  const primerNombre = primerNombrePerfil?.trim() || userName?.trim().split(/\s+/)[0] || '';
+  return primerNombre && !['socio', 'usuario'].includes(primerNombre.toLowerCase())
+    ? primerNombre
+    : null;
 }
 
 function formatCurrency(amount: number, currency: string = 'VES') {
@@ -294,6 +306,7 @@ function ProgressBar({ percentage, color }: { percentage: number; color: string 
 export default function SocioDashboardPage() {
   const user = useAuthStore((state) => state.user);
   const isLoading = useAuthStore((state) => state.isLoading);
+  const [primerNombrePerfil, setPrimerNombrePerfil] = useState<string | null>(null);
 
   const [cuentas, setCuentas] = useState<CuentaAhorro[]>([]);
   const [loadingCuentas, setLoadingCuentas] = useState(true);
@@ -358,6 +371,24 @@ export default function SocioDashboardPage() {
       cargarCuentas();
     }
   }, [isLoading, user?.socioId, cargarCuentas]);
+
+  const cargarPerfilSocio = useCallback(async () => {
+    if (!user?.socioId) return;
+    try {
+      const response = await sociosApi.getById(user.socioId);
+      const data = response.data as PerfilSocioBasico;
+      setPrimerNombrePerfil(data.primerNombre?.trim() || null);
+    } catch (err) {
+      console.error('Error cargando perfil del socio:', err);
+      setPrimerNombrePerfil(null);
+    }
+  }, [user?.socioId]);
+
+  useEffect(() => {
+    if (!isLoading && user?.socioId) {
+      cargarPerfilSocio();
+    }
+  }, [isLoading, user?.socioId, cargarPerfilSocio]);
 
   // Issue #212: cargar beneficiarios REALES del socio
   const cargarBeneficiarios = useCallback(async () => {
@@ -476,6 +507,7 @@ export default function SocioDashboardPage() {
   // Derivados de los beneficiarios reales para la UI
   const beneficiariosOrdenados = beneficiariosActivosOrdenados(beneficiarios);
   const totalPorcentajeAsignado = sumaPorcentajes(beneficiarios);
+  const nombreSaludo = obtenerNombreSaludo(user?.nombreCompleto, primerNombrePerfil);
 
   if (isLoading) {
     return (
@@ -491,7 +523,7 @@ export default function SocioDashboardPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-[#0F2744]">
-            Hola, {user?.nombreCompleto?.split(' ')[0] || ' Socio'}
+            {nombreSaludo ? `Hola, ${nombreSaludo}` : 'Hola'}
           </h1>
           <p className="text-sm text-slate-500 mt-0.5">Aquí está el resumen de tu cuenta</p>
         </div>

--- a/frontend-web/src/components/layouts/admin/admin-layout.tsx
+++ b/frontend-web/src/components/layouts/admin/admin-layout.tsx
@@ -317,16 +317,6 @@ export default function AdminLayout({
                         </div>
                       )}
                       <div className="py-1">
-                        <Link href="/admin/perfil" className="flex items-center gap-3 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50">
-                          <User className="w-4 h-4" />
-                          Mi Perfil
-                        </Link>
-                        <Link href="/admin/configuracion" className="flex items-center gap-3 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50">
-                          <Settings className="w-4 h-4" />
-                          Configuración
-                        </Link>
-                      </div>
-                      <div className="py-1 border-t border-slate-100">
                         <LogoutButton variant="ghost" className="w-full justify-start text-red-600 hover:bg-red-50 px-4" />
                       </div>
                     </div>

--- a/frontend-web/src/components/layouts/admin/admin-shell.tsx
+++ b/frontend-web/src/components/layouts/admin/admin-shell.tsx
@@ -323,16 +323,6 @@ export function AdminShell({ children }: { children: React.ReactNode }) {
                         </div>
                       )}
                       <div className="py-1">
-                        <Link href="/admin/perfil" className="flex items-center gap-3 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50">
-                          <User className="w-4 h-4" />
-                          Mi Perfil
-                        </Link>
-                        <Link href="/admin/configuracion" className="flex items-center gap-3 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50">
-                          <Settings className="w-4 h-4" />
-                          Configuración
-                        </Link>
-                      </div>
-                      <div className="py-1 border-t border-slate-100">
                         <LogoutButton />
                       </div>
                     </div>

--- a/frontend-web/src/components/layouts/socio/socio-shell.tsx
+++ b/frontend-web/src/components/layouts/socio/socio-shell.tsx
@@ -276,16 +276,6 @@ export function SocioShell({ children }: { children: React.ReactNode }) {
                       </div>
                     )}
                     <div className="py-2">
-                      <Link href="/perfil" className="flex items-center gap-3 px-4 py-3 text-sm text-slate-700 hover:bg-slate-50">
-                        <User className="w-4 h-4" />
-                        Mi Perfil
-                      </Link>
-                      <Link href="/dashboard/documentos" className="flex items-center gap-3 px-4 py-3 text-sm text-slate-700 hover:bg-slate-50">
-                        <FileText className="w-4 h-4" />
-                        Documentos
-                      </Link>
-                    </div>
-                    <div className="py-2 border-t border-slate-100">
                       <LogoutButton />
                     </div>
                   </div>


### PR DESCRIPTION
## Resumen
- Elimina los accesos a Perfil, Documentos y Configuracion del menu superior del usuario en socio/admin.
- Mantiene el menu lateral sin cambios para que esas secciones sigan accesibles donde corresponda.
- Refuerza el saludo del dashboard del socio usando el primer nombre real del perfil cuando esta disponible.

## Validacion
- npm.cmd run build
- npm.cmd run typecheck (falla por errores preexistentes en archivos de test: afterEach/mocks tipados; el cambio productivo compila en build)
- Revision local en navegador: la app responde en localhost y redirige a login sin sesion.
- Grep literal confirma que los links removidos ya no estan en los dropdowns de layouts.