### PR TITLE
feat(productos): permitir imagen principal segura

### DIFF
--- a/backend/src/main/java/com/tufondo/productos/application/usecase/GestionarProductosFinanciablesUseCase.java
+++ b/backend/src/main/java/com/tufondo/productos/application/usecase/GestionarProductosFinanciablesUseCase.java
@@ -56,6 +56,13 @@ public class GestionarProductosFinanciablesUseCase {
     }
 
     @Transactional(readOnly = true)
+    public void validarExiste(Long id) {
+        if (!repository.existsById(id)) {
+            throw new ProductoNoEncontradoException(id.toString());
+        }
+    }
+
+    @Transactional(readOnly = true)
     public ProductoFinanciableResponse obtenerPublicado(String slug) {
         return repository.findBySlugAndEstado(slug, ESTADO_PUBLICADO)
             .map(this::toResponse)
@@ -99,6 +106,15 @@ public class GestionarProductosFinanciablesUseCase {
         ProductoFinanciableEntity entity = repository.findById(id)
             .orElseThrow(() -> new ProductoNoEncontradoException(id.toString()));
         entity.setEstado(estado);
+        entity.setUpdatedAt(LocalDateTime.now());
+        return toResponse(repository.save(entity));
+    }
+
+    @Transactional
+    public ProductoFinanciableResponse actualizarImagen(Long id, String imagenUrl) {
+        ProductoFinanciableEntity entity = repository.findById(id)
+            .orElseThrow(() -> new ProductoNoEncontradoException(id.toString()));
+        entity.setImagenUrl(imagenUrl);
         entity.setUpdatedAt(LocalDateTime.now());
         return toResponse(repository.save(entity));
     }

--- a/backend/src/main/java/com/tufondo/productos/infrastructure/storage/ProductoImagenStorageService.java
+++ b/backend/src/main/java/com/tufondo/productos/infrastructure/storage/ProductoImagenStorageService.java
@@ -1,0 +1,165 @@
+package com.tufondo.productos.infrastructure.storage;
+
+import io.minio.BucketExistsArgs;
+import io.minio.errors.ErrorResponseException;
+import io.minio.GetObjectArgs;
+import io.minio.MakeBucketArgs;
+import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.security.SecureRandom;
+import java.time.LocalDate;
+import java.util.HexFormat;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class ProductoImagenStorageService {
+
+    private static final Set<String> MIME_PERMITIDOS = Set.of("image/jpeg", "image/png");
+    private static final int MAX_DIMENSION = 2400;
+
+    private final MinioClient minioClient;
+
+    @Value("${minio.buckets.productos:bucket-productos}")
+    private String bucket;
+
+    @Value("${fatrans.productos.imagenes.max-size-bytes:2097152}")
+    private long maxSizeBytes;
+
+    public String subirImagen(Long productoId, MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("La imagen del producto es requerida");
+        }
+        if (file.getSize() > maxSizeBytes) {
+            throw new IllegalArgumentException("La imagen no puede superar 2 MB");
+        }
+        String contentType = file.getContentType();
+        if (contentType == null || !MIME_PERMITIDOS.contains(contentType.toLowerCase())) {
+            throw new IllegalArgumentException("Formato no permitido. Usa JPG o PNG");
+        }
+
+        try {
+            BufferedImage original = ImageIO.read(new ByteArrayInputStream(file.getBytes()));
+            if (original == null || original.getWidth() < 1 || original.getHeight() < 1) {
+                throw new IllegalArgumentException("El archivo no es una imagen valida");
+            }
+
+            byte[] normalizada = normalizarJpeg(original);
+            if (normalizada.length > maxSizeBytes) {
+                throw new IllegalArgumentException("La imagen normalizada no puede superar 2 MB");
+            }
+            ensureBucketExists();
+
+            String fecha = LocalDate.now().toString();
+            String fileName = generarNombre(productoId);
+            String objectPath = "productos/" + fecha + "/" + fileName;
+            try (InputStream input = new ByteArrayInputStream(normalizada)) {
+                minioClient.putObject(
+                    PutObjectArgs.builder()
+                        .bucket(bucket)
+                        .object(objectPath)
+                        .stream(input, normalizada.length, -1)
+                        .contentType("image/jpeg")
+                        .build()
+                );
+            }
+
+            return "/api/v1/productos/imagenes/" + fecha + "/" + fileName;
+        } catch (IllegalArgumentException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new RuntimeException("No se pudo guardar la imagen del producto", ex);
+        }
+    }
+
+    public ImagenProducto descargar(String fecha, String fileName) {
+        String safeFecha = sanitizarFecha(fecha);
+        String safeName = sanitizarFileName(fileName);
+        String objectPath = "productos/" + safeFecha + "/" + safeName;
+        try {
+            ensureBucketExists();
+            try (InputStream input = minioClient.getObject(
+                    GetObjectArgs.builder()
+                        .bucket(bucket)
+                        .object(objectPath)
+                        .build())) {
+                return new ImagenProducto(input.readAllBytes(), "image/jpeg");
+            }
+        } catch (ImagenNoEncontradaException ex) {
+            throw ex;
+        } catch (ErrorResponseException ex) {
+            if ("NoSuchKey".equals(ex.errorResponse().code())) {
+                throw new ImagenNoEncontradaException();
+            }
+            throw new RuntimeException("No se pudo leer la imagen del producto", ex);
+        } catch (Exception ex) {
+            throw new RuntimeException("No se pudo leer la imagen del producto", ex);
+        }
+    }
+
+    private byte[] normalizarJpeg(BufferedImage original) throws Exception {
+        int width = original.getWidth();
+        int height = original.getHeight();
+        double scale = Math.min(1.0, (double) MAX_DIMENSION / Math.max(width, height));
+        int targetWidth = Math.max(1, (int) Math.round(width * scale));
+        int targetHeight = Math.max(1, (int) Math.round(height * scale));
+
+        Image scaled = original.getScaledInstance(targetWidth, targetHeight, Image.SCALE_SMOOTH);
+        BufferedImage output = new BufferedImage(targetWidth, targetHeight, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = output.createGraphics();
+        graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+        graphics.setColor(Color.WHITE);
+        graphics.fillRect(0, 0, targetWidth, targetHeight);
+        graphics.drawImage(scaled, 0, 0, null);
+        graphics.dispose();
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(output, "jpg", baos);
+        return baos.toByteArray();
+    }
+
+    private void ensureBucketExists() throws Exception {
+        boolean exists = minioClient.bucketExists(BucketExistsArgs.builder().bucket(bucket).build());
+        if (!exists) {
+            minioClient.makeBucket(MakeBucketArgs.builder().bucket(bucket).build());
+        }
+    }
+
+    private String generarNombre(Long productoId) {
+        byte[] random = new byte[12];
+        new SecureRandom().nextBytes(random);
+        return "producto-" + productoId + "-" + HexFormat.of().formatHex(random) + ".jpg";
+    }
+
+    private String sanitizarFileName(String fileName) {
+        if (fileName == null || !fileName.matches("producto-[0-9]+-[a-f0-9]{24}\\.jpg")) {
+            throw new IllegalArgumentException("Nombre de imagen invalido");
+        }
+        return fileName;
+    }
+
+    private String sanitizarFecha(String fecha) {
+        if (fecha == null || !fecha.matches("[0-9]{4}-[0-9]{2}-[0-9]{2}")) {
+            throw new IllegalArgumentException("Ruta de imagen invalida");
+        }
+        return fecha;
+    }
+
+    public record ImagenProducto(byte[] data, String contentType) {}
+
+    public static class ImagenNoEncontradaException extends RuntimeException {}
+}

--- a/backend/src/main/java/com/tufondo/productos/presentation/controller/ProductoFinanciableController.java
+++ b/backend/src/main/java/com/tufondo/productos/presentation/controller/ProductoFinanciableController.java
@@ -6,15 +6,20 @@ import com.tufondo.productos.application.dto.PrecalificacionProductoResponse;
 import com.tufondo.productos.application.dto.ProductoFinanciableRequest;
 import com.tufondo.productos.application.dto.ProductoFinanciableResponse;
 import com.tufondo.productos.application.usecase.GestionarProductosFinanciablesUseCase;
+import com.tufondo.productos.infrastructure.storage.ProductoImagenStorageService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.concurrent.TimeUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -25,6 +30,7 @@ import java.util.UUID;
 public class ProductoFinanciableController {
 
     private final GestionarProductosFinanciablesUseCase useCase;
+    private final ProductoImagenStorageService imagenStorageService;
 
     @GetMapping("/productos")
     @PreAuthorize("hasAnyRole('SOCIO', 'ADMIN', 'SUPER_ADMIN')")
@@ -103,9 +109,34 @@ public class ProductoFinanciableController {
         return ResponseEntity.ok(useCase.cambiarEstado(id, "ARCHIVADO"));
     }
 
+    @PostMapping(value = "/admin/productos/{id}/imagen", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
+    public ResponseEntity<ProductoFinanciableResponse> subirImagen(
+            @PathVariable Long id,
+            @RequestParam("file") MultipartFile file) {
+        useCase.validarExiste(id);
+        String imagenUrl = imagenStorageService.subirImagen(id, file);
+        return ResponseEntity.ok(useCase.actualizarImagen(id, imagenUrl));
+    }
+
+    @GetMapping("/productos/imagenes/{fecha}/{fileName}")
+    @PreAuthorize("hasAnyRole('SOCIO', 'ADMIN', 'SUPER_ADMIN')")
+    public ResponseEntity<byte[]> obtenerImagen(@PathVariable String fecha, @PathVariable String fileName) {
+        ProductoImagenStorageService.ImagenProducto imagen = imagenStorageService.descargar(fecha, fileName);
+        return ResponseEntity.ok()
+            .contentType(MediaType.parseMediaType(imagen.contentType()))
+            .cacheControl(CacheControl.maxAge(1, TimeUnit.HOURS).cachePrivate())
+            .body(imagen.data());
+    }
+
     @ExceptionHandler(GestionarProductosFinanciablesUseCase.ProductoNoEncontradoException.class)
     public ResponseEntity<Map<String, String>> noEncontrado(RuntimeException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("message", ex.getMessage()));
+    }
+
+    @ExceptionHandler(ProductoImagenStorageService.ImagenNoEncontradaException.class)
+    public ResponseEntity<Map<String, String>> imagenNoEncontrada() {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("message", "Imagen de producto no encontrada"));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -47,6 +47,11 @@ spring:
             enable: false
         debug: ${MAIL_DEBUG:false}
 
+  servlet:
+    multipart:
+      max-file-size: ${PRODUCT_IMAGE_MAX_FILE_SIZE:2MB}
+      max-request-size: ${PRODUCT_IMAGE_MAX_REQUEST_SIZE:3MB}
+
 springdoc:
   api-docs:
     path: /v3/api-docs

--- a/frontend-web/src/app/(admin)/admin/productos/page.tsx
+++ b/frontend-web/src/app/(admin)/admin/productos/page.tsx
@@ -1,14 +1,25 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import { productosApi, creditosApi } from '@/lib/api/client';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { PackageOpen, Pause, Plus, Send } from 'lucide-react';
+import { useEffect, useState } from "react";
+import {
+  productosApi,
+  creditosApi,
+  resolveApiAssetUrl,
+} from "@/lib/api/client";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  ImageIcon,
+  PackageOpen,
+  Pause,
+  Plus,
+  Send,
+  Upload,
+} from "lucide-react";
 
 interface Producto {
   id: number;
@@ -24,6 +35,7 @@ interface Producto {
   plazoMaximoMeses: number;
   porcentajeColateral: number;
   colateralRequerido: number;
+  imagenUrl?: string;
   estado: string;
 }
 
@@ -33,24 +45,24 @@ interface TipoCredito {
 }
 
 const initialForm = {
-  codigo: '',
-  nombre: '',
-  descripcion: '',
-  categoria: 'REPUESTOS',
-  proveedor: '',
-  precio: '',
-  moneda: 'VES',
-  tipoCreditoId: '',
-  plazoMinimoMeses: '1',
-  plazoMaximoMeses: '12',
-  porcentajeColateral: '30',
-  imagenUrl: '',
+  codigo: "",
+  nombre: "",
+  descripcion: "",
+  categoria: "REPUESTOS",
+  proveedor: "",
+  precio: "",
+  moneda: "VES",
+  tipoCreditoId: "",
+  plazoMinimoMeses: "1",
+  plazoMaximoMeses: "12",
+  porcentajeColateral: "30",
+  imagenUrl: "",
   requiereAprobacionManual: true,
 };
 
 function formatMoney(value: number, currency: string) {
-  const prefix = currency === 'USD' ? 'USD' : 'Bs.';
-  return `${prefix} ${Number(value || 0).toLocaleString('es-VE', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  const prefix = currency === "USD" ? "USD" : "Bs.";
+  return `${prefix} ${Number(value || 0).toLocaleString("es-VE", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 }
 
 export default function AdminProductosPage() {
@@ -59,6 +71,7 @@ export default function AdminProductosPage() {
   const [form, setForm] = useState(initialForm);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [uploadingId, setUploadingId] = useState<number | null>(null);
 
   useEffect(() => {
     cargarDatos();
@@ -74,7 +87,10 @@ export default function AdminProductosPage() {
       setProductos(productosRes.data.productos || []);
       setTiposCredito(tiposRes.data.tiposCredito || []);
       if (!form.tipoCreditoId && tiposRes.data.tiposCredito?.[0]?.id) {
-        setForm((current) => ({ ...current, tipoCreditoId: String(tiposRes.data.tiposCredito[0].id) }));
+        setForm((current) => ({
+          ...current,
+          tipoCreditoId: String(tiposRes.data.tiposCredito[0].id),
+        }));
       }
     } finally {
       setLoading(false);
@@ -99,18 +115,41 @@ export default function AdminProductosPage() {
     }
   };
 
-  const cambiarEstado = async (producto: Producto, action: 'publicar' | 'pausar' | 'archivar') => {
+  const cambiarEstado = async (
+    producto: Producto,
+    action: "publicar" | "pausar" | "archivar",
+  ) => {
     await productosApi[action](producto.id);
     await cargarDatos();
+  };
+
+  const subirImagen = async (producto: Producto, file?: File) => {
+    if (!file) return;
+    setUploadingId(producto.id);
+    try {
+      const response = await productosApi.subirImagen(producto.id, file);
+      setProductos((current) =>
+        current.map((item) =>
+          item.id === producto.id ? { ...item, ...response.data } : item,
+        ),
+      );
+    } finally {
+      setUploadingId(null);
+    }
   };
 
   return (
     <div className="max-w-7xl mx-auto space-y-6">
       <div>
-        <p className="text-sm font-medium text-[#16A34A]">Catálogo financiero</p>
-        <h1 className="text-2xl font-bold text-[#0F2744]">Productos financiables</h1>
+        <p className="text-sm font-medium text-[#16A34A]">
+          Catálogo financiero
+        </p>
+        <h1 className="text-2xl font-bold text-[#0F2744]">
+          Productos financiables
+        </h1>
         <p className="mt-1 text-sm text-slate-600">
-          Publica beneficios para socios con precio, plazo, tipo de crédito y colateral requerido.
+          Publica beneficios para socios con precio, plazo, tipo de crédito y
+          colateral requerido.
         </p>
       </div>
 
@@ -125,32 +164,59 @@ export default function AdminProductosPage() {
             <div className="grid gap-3 sm:grid-cols-2">
               <div>
                 <Label>Código</Label>
-                <Input value={form.codigo} onChange={(e) => setForm({ ...form, codigo: e.target.value })} placeholder="CAUCHO-001" />
+                <Input
+                  value={form.codigo}
+                  onChange={(e) => setForm({ ...form, codigo: e.target.value })}
+                  placeholder="CAUCHO-001"
+                />
               </div>
               <div>
                 <Label>Categoría</Label>
-                <Input value={form.categoria} onChange={(e) => setForm({ ...form, categoria: e.target.value })} />
+                <Input
+                  value={form.categoria}
+                  onChange={(e) =>
+                    setForm({ ...form, categoria: e.target.value })
+                  }
+                />
               </div>
             </div>
 
             <div>
               <Label>Nombre</Label>
-              <Input value={form.nombre} onChange={(e) => setForm({ ...form, nombre: e.target.value })} placeholder="Kit de cauchos" />
+              <Input
+                value={form.nombre}
+                onChange={(e) => setForm({ ...form, nombre: e.target.value })}
+                placeholder="Kit de cauchos"
+              />
             </div>
 
             <div>
               <Label>Descripción</Label>
-              <Textarea value={form.descripcion} onChange={(e) => setForm({ ...form, descripcion: e.target.value })} rows={3} />
+              <Textarea
+                value={form.descripcion}
+                onChange={(e) =>
+                  setForm({ ...form, descripcion: e.target.value })
+                }
+                rows={3}
+              />
             </div>
 
             <div className="grid gap-3 sm:grid-cols-2">
               <div>
                 <Label>Precio</Label>
-                <Input type="number" value={form.precio} onChange={(e) => setForm({ ...form, precio: e.target.value })} />
+                <Input
+                  type="number"
+                  value={form.precio}
+                  onChange={(e) => setForm({ ...form, precio: e.target.value })}
+                />
               </div>
               <div>
                 <Label>Moneda</Label>
-                <select className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm" value={form.moneda} onChange={(e) => setForm({ ...form, moneda: e.target.value })}>
+                <select
+                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                  value={form.moneda}
+                  onChange={(e) => setForm({ ...form, moneda: e.target.value })}
+                >
                   <option value="VES">VES</option>
                   <option value="USD">USD</option>
                 </select>
@@ -159,9 +225,17 @@ export default function AdminProductosPage() {
 
             <div>
               <Label>Tipo de crédito</Label>
-              <select className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm" value={form.tipoCreditoId} onChange={(e) => setForm({ ...form, tipoCreditoId: e.target.value })}>
+              <select
+                className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                value={form.tipoCreditoId}
+                onChange={(e) =>
+                  setForm({ ...form, tipoCreditoId: e.target.value })
+                }
+              >
                 {tiposCredito.map((tipo) => (
-                  <option key={tipo.id} value={tipo.id}>{tipo.nombre}</option>
+                  <option key={tipo.id} value={tipo.id}>
+                    {tipo.nombre}
+                  </option>
                 ))}
               </select>
             </div>
@@ -169,58 +243,167 @@ export default function AdminProductosPage() {
             <div className="grid gap-3 sm:grid-cols-3">
               <div>
                 <Label>Plazo mín.</Label>
-                <Input type="number" value={form.plazoMinimoMeses} onChange={(e) => setForm({ ...form, plazoMinimoMeses: e.target.value })} />
+                <Input
+                  type="number"
+                  value={form.plazoMinimoMeses}
+                  onChange={(e) =>
+                    setForm({ ...form, plazoMinimoMeses: e.target.value })
+                  }
+                />
               </div>
               <div>
                 <Label>Plazo máx.</Label>
-                <Input type="number" value={form.plazoMaximoMeses} onChange={(e) => setForm({ ...form, plazoMaximoMeses: e.target.value })} />
+                <Input
+                  type="number"
+                  value={form.plazoMaximoMeses}
+                  onChange={(e) =>
+                    setForm({ ...form, plazoMaximoMeses: e.target.value })
+                  }
+                />
               </div>
               <div>
                 <Label>Colateral %</Label>
-                <Input type="number" value={form.porcentajeColateral} onChange={(e) => setForm({ ...form, porcentajeColateral: e.target.value })} />
+                <Input
+                  type="number"
+                  value={form.porcentajeColateral}
+                  onChange={(e) =>
+                    setForm({ ...form, porcentajeColateral: e.target.value })
+                  }
+                />
               </div>
             </div>
 
-            <Button className="w-full bg-[#16A34A] hover:bg-[#15803D]" onClick={submit} disabled={saving || !form.codigo || !form.nombre || !form.precio || !form.tipoCreditoId}>
-              {saving ? 'Guardando...' : 'Crear como borrador'}
+            <Button
+              className="w-full bg-[#16A34A] hover:bg-[#15803D]"
+              onClick={submit}
+              disabled={
+                saving ||
+                !form.codigo ||
+                !form.nombre ||
+                !form.precio ||
+                !form.tipoCreditoId
+              }
+            >
+              {saving ? "Guardando..." : "Crear como borrador"}
             </Button>
           </CardContent>
         </Card>
 
         <div className="space-y-3">
           {loading ? (
-            <div className="rounded-lg border border-slate-200 bg-white p-8 text-sm text-slate-500">Cargando productos...</div>
+            <div className="rounded-lg border border-slate-200 bg-white p-8 text-sm text-slate-500">
+              Cargando productos...
+            </div>
           ) : productos.length === 0 ? (
             <div className="rounded-lg border border-dashed border-slate-300 bg-white p-10 text-center">
               <PackageOpen className="mx-auto h-10 w-10 text-slate-400" />
-              <h2 className="mt-3 font-semibold text-slate-950">Aún no hay productos</h2>
+              <h2 className="mt-3 font-semibold text-slate-950">
+                Aún no hay productos
+              </h2>
             </div>
           ) : (
             productos.map((producto) => (
-              <Card key={producto.id} className="border-slate-200">
+              <Card
+                key={producto.id}
+                className="overflow-hidden border-slate-200"
+              >
                 <CardContent className="p-5">
                   <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-                    <div className="min-w-0">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <h2 className="font-semibold text-slate-950">{producto.nombre}</h2>
-                        <Badge variant={producto.estado === 'PUBLICADO' ? 'default' : 'secondary'}>{producto.estado}</Badge>
-                        <Badge variant="outline">{producto.categoria}</Badge>
+                    <div className="flex min-w-0 flex-1 gap-4">
+                      <div className="relative h-24 w-32 shrink-0 overflow-hidden rounded-lg border border-slate-200 bg-slate-50">
+                        {producto.imagenUrl ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={resolveApiAssetUrl(producto.imagenUrl)}
+                            alt={producto.nombre}
+                            className="h-full w-full object-cover"
+                          />
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center bg-slate-100">
+                            <ImageIcon className="h-8 w-8 text-slate-400" />
+                          </div>
+                        )}
                       </div>
-                      <p className="mt-1 line-clamp-2 text-sm text-slate-600">{producto.descripcion || 'Sin descripción'}</p>
-                      <div className="mt-3 flex flex-wrap gap-4 text-sm text-slate-600">
-                        <span>Precio: <strong className="text-[#0F2744]">{formatMoney(producto.precio, producto.moneda)}</strong></span>
-                        <span>Colateral: <strong className="text-[#0F2744]">{producto.porcentajeColateral}%</strong></span>
-                        <span>Plazo: <strong className="text-[#0F2744]">{producto.plazoMinimoMeses}-{producto.plazoMaximoMeses} meses</strong></span>
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h2 className="font-semibold text-slate-950">
+                            {producto.nombre}
+                          </h2>
+                          <Badge
+                            variant={
+                              producto.estado === "PUBLICADO"
+                                ? "default"
+                                : "secondary"
+                            }
+                          >
+                            {producto.estado}
+                          </Badge>
+                          <Badge variant="outline">{producto.categoria}</Badge>
+                        </div>
+                        <p className="mt-1 line-clamp-2 text-sm text-slate-600">
+                          {producto.descripcion || "Sin descripción"}
+                        </p>
+                        <div className="mt-3 flex flex-wrap gap-4 text-sm text-slate-600">
+                          <span>
+                            Precio:{" "}
+                            <strong className="text-[#0F2744]">
+                              {formatMoney(producto.precio, producto.moneda)}
+                            </strong>
+                          </span>
+                          <span>
+                            Colateral:{" "}
+                            <strong className="text-[#0F2744]">
+                              {producto.porcentajeColateral}%
+                            </strong>
+                          </span>
+                          <span>
+                            Plazo:{" "}
+                            <strong className="text-[#0F2744]">
+                              {producto.plazoMinimoMeses}-
+                              {producto.plazoMaximoMeses} meses
+                            </strong>
+                          </span>
+                        </div>
+                        <label className="mt-3 inline-flex h-9 cursor-pointer items-center gap-2 rounded-md border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50">
+                          <Upload className="h-4 w-4" />
+                          {uploadingId === producto.id
+                            ? "Subiendo..."
+                            : producto.imagenUrl
+                              ? "Cambiar foto"
+                              : "Subir foto"}
+                          <input
+                            type="file"
+                            accept="image/jpeg,image/png"
+                            className="sr-only"
+                            disabled={uploadingId === producto.id}
+                            onChange={(event) => {
+                              const file = event.target.files?.[0];
+                              void subirImagen(producto, file);
+                              event.target.value = "";
+                            }}
+                          />
+                        </label>
+                        <p className="mt-1 text-xs text-slate-500">
+                          JPG o PNG, máximo 2 MB.
+                        </p>
                       </div>
                     </div>
                     <div className="flex shrink-0 gap-2">
-                      {producto.estado !== 'PUBLICADO' ? (
-                        <Button size="sm" className="bg-[#16A34A] hover:bg-[#15803D]" onClick={() => cambiarEstado(producto, 'publicar')}>
+                      {producto.estado !== "PUBLICADO" ? (
+                        <Button
+                          size="sm"
+                          className="bg-[#16A34A] hover:bg-[#15803D]"
+                          onClick={() => cambiarEstado(producto, "publicar")}
+                        >
                           <Send className="mr-2 h-4 w-4" />
                           Publicar
                         </Button>
                       ) : (
-                        <Button size="sm" variant="outline" onClick={() => cambiarEstado(producto, 'pausar')}>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => cambiarEstado(producto, "pausar")}
+                        >
                           <Pause className="mr-2 h-4 w-4" />
                           Pausar
                         </Button>

--- a/frontend-web/src/app/(dashboard)/dashboard/productos/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/productos/page.tsx
@@ -1,12 +1,12 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { productosApi } from '@/lib/api/client';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
-import { PackageOpen, ShieldCheck, WalletCards } from 'lucide-react';
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { productosApi, resolveApiAssetUrl } from "@/lib/api/client";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { PackageOpen, ShieldCheck, WalletCards } from "lucide-react";
 
 interface Producto {
   id: number;
@@ -34,14 +34,16 @@ interface Precalificacion {
 }
 
 function formatMoney(value: number, currency: string) {
-  const prefix = currency === 'USD' ? 'USD' : 'Bs.';
-  return `${prefix} ${Number(value || 0).toLocaleString('es-VE', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  const prefix = currency === "USD" ? "USD" : "Bs.";
+  return `${prefix} ${Number(value || 0).toLocaleString("es-VE", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 }
 
 export default function ProductosSocioPage() {
   const router = useRouter();
   const [productos, setProductos] = useState<Producto[]>([]);
-  const [precalificaciones, setPrecalificaciones] = useState<Record<number, Precalificacion>>({});
+  const [precalificaciones, setPrecalificaciones] = useState<
+    Record<number, Precalificacion>
+  >({});
   const [loading, setLoading] = useState(true);
   const [solicitandoId, setSolicitandoId] = useState<number | null>(null);
 
@@ -56,11 +58,13 @@ export default function ProductosSocioPage() {
       const items = res.data.productos || [];
       setProductos(items);
       const resultados = await Promise.allSettled(
-        items.map((producto: Producto) => productosApi.precalificar(producto.id))
+        items.map((producto: Producto) =>
+          productosApi.precalificar(producto.id),
+        ),
       );
       const mapa: Record<number, Precalificacion> = {};
       resultados.forEach((resultado, index) => {
-        if (resultado.status === 'fulfilled') {
+        if (resultado.status === "fulfilled") {
           mapa[items[index].id] = resultado.value.data;
         }
       });
@@ -84,10 +88,15 @@ export default function ProductosSocioPage() {
     <div className="max-w-7xl mx-auto space-y-6">
       <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
         <div>
-          <p className="text-sm font-medium text-[#16A34A]">Beneficios financiables</p>
-          <h1 className="text-2xl font-bold text-[#0F2744]">Productos para socios</h1>
+          <p className="text-sm font-medium text-[#16A34A]">
+            Beneficios financiables
+          </p>
+          <h1 className="text-2xl font-bold text-[#0F2744]">
+            Productos para socios
+          </h1>
           <p className="text-sm text-slate-600 mt-1">
-            Consulta productos disponibles y solicita financiamiento sujeto a colateral y aprobación.
+            Consulta productos disponibles y solicita financiamiento sujeto a
+            colateral y aprobación.
           </p>
         </div>
         <Button variant="outline" onClick={cargarProductos} disabled={loading}>
@@ -109,19 +118,30 @@ export default function ProductosSocioPage() {
         ) : productos.length === 0 ? (
           <div className="md:col-span-2 xl:col-span-3 rounded-lg border border-dashed border-slate-300 bg-white p-10 text-center">
             <PackageOpen className="mx-auto h-10 w-10 text-slate-400" />
-            <h2 className="mt-3 text-lg font-semibold text-slate-900">No hay productos publicados</h2>
-            <p className="mt-1 text-sm text-slate-500">Cuando la asociación publique beneficios aparecerán aquí.</p>
+            <h2 className="mt-3 text-lg font-semibold text-slate-900">
+              No hay productos publicados
+            </h2>
+            <p className="mt-1 text-sm text-slate-500">
+              Cuando la asociación publique beneficios aparecerán aquí.
+            </p>
           </div>
         ) : (
           productos.map((producto) => {
             const precalificacion = precalificaciones[producto.id];
             const elegible = precalificacion?.elegible;
             return (
-              <Card key={producto.id} className="overflow-hidden border-slate-200">
+              <Card
+                key={producto.id}
+                className="overflow-hidden border-slate-200"
+              >
                 <div className="relative h-36 bg-[#0F2744]">
                   {producto.imagenUrl ? (
                     // eslint-disable-next-line @next/next/no-img-element
-                    <img src={producto.imagenUrl} alt={producto.nombre} className="h-full w-full object-cover" />
+                    <img
+                      src={resolveApiAssetUrl(producto.imagenUrl)}
+                      alt={producto.nombre}
+                      className="h-full w-full object-cover"
+                    />
                   ) : (
                     <div className="flex h-full items-center justify-center bg-[linear-gradient(135deg,#0F2744,#1D4B77)]">
                       <PackageOpen className="h-12 w-12 text-white/80" />
@@ -133,29 +153,50 @@ export default function ProductosSocioPage() {
                 </div>
                 <CardContent className="p-5 space-y-4">
                   <div>
-                    <h2 className="text-lg font-semibold text-slate-950">{producto.nombre}</h2>
-                    <p className="mt-1 line-clamp-2 text-sm text-slate-600">{producto.descripcion || 'Producto financiable para socios.'}</p>
+                    <h2 className="text-lg font-semibold text-slate-950">
+                      {producto.nombre}
+                    </h2>
+                    <p className="mt-1 line-clamp-2 text-sm text-slate-600">
+                      {producto.descripcion ||
+                        "Producto financiable para socios."}
+                    </p>
                   </div>
 
                   <div className="grid grid-cols-2 gap-3 text-sm">
                     <div className="rounded-md bg-slate-50 p-3">
                       <p className="text-slate-500">Precio</p>
-                      <p className="font-semibold text-[#0F2744]">{formatMoney(producto.precio, producto.moneda)}</p>
+                      <p className="font-semibold text-[#0F2744]">
+                        {formatMoney(producto.precio, producto.moneda)}
+                      </p>
                     </div>
                     <div className="rounded-md bg-slate-50 p-3">
                       <p className="text-slate-500">Cuotas</p>
-                      <p className="font-semibold text-[#0F2744]">{producto.plazoMinimoMeses}-{producto.plazoMaximoMeses} meses</p>
+                      <p className="font-semibold text-[#0F2744]">
+                        {producto.plazoMinimoMeses}-{producto.plazoMaximoMeses}{" "}
+                        meses
+                      </p>
                     </div>
                   </div>
 
                   <div className="flex items-start gap-3 rounded-md border border-slate-200 p-3">
-                    {elegible ? <ShieldCheck className="mt-0.5 h-5 w-5 text-[#16A34A]" /> : <WalletCards className="mt-0.5 h-5 w-5 text-amber-600" />}
+                    {elegible ? (
+                      <ShieldCheck className="mt-0.5 h-5 w-5 text-[#16A34A]" />
+                    ) : (
+                      <WalletCards className="mt-0.5 h-5 w-5 text-amber-600" />
+                    )}
                     <div className="min-w-0">
                       <p className="text-sm font-medium text-slate-900">
-                        Colateral requerido: {formatMoney(precalificacion?.colateralRequerido ?? producto.colateralRequerido, producto.moneda)}
+                        Colateral requerido:{" "}
+                        {formatMoney(
+                          precalificacion?.colateralRequerido ??
+                            producto.colateralRequerido,
+                          producto.moneda,
+                        )}
                       </p>
                       <p className="text-xs text-slate-500">
-                        {precalificacion ? precalificacion.mensaje : 'Validando saldo disponible.'}
+                        {precalificacion
+                          ? precalificacion.mensaje
+                          : "Validando saldo disponible."}
                       </p>
                     </div>
                   </div>
@@ -165,7 +206,9 @@ export default function ProductosSocioPage() {
                     disabled={!elegible || solicitandoId === producto.id}
                     onClick={() => solicitar(producto.id)}
                   >
-                    {solicitandoId === producto.id ? 'Enviando solicitud...' : 'Solicitar financiamiento'}
+                    {solicitandoId === producto.id
+                      ? "Enviando solicitud..."
+                      : "Solicitar financiamiento"}
                   </Button>
                 </CardContent>
               </Card>

--- a/frontend-web/src/lib/api/client.ts
+++ b/frontend-web/src/lib/api/client.ts
@@ -1,7 +1,23 @@
-import axios from 'axios';
-import { toast } from 'sonner';
+import axios from "axios";
+import { toast } from "sonner";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:18080/api';
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:18080/api";
+
+export function resolveApiAssetUrl(url?: string | null) {
+  if (!url) return "";
+  if (/^https?:\/\//i.test(url)) return url;
+  if (url.startsWith("/api/")) {
+    try {
+      return `${new URL(API_URL).origin}${url}`;
+    } catch {
+      return url;
+    }
+  }
+  if (url.startsWith("/v1/")) {
+    return `${API_URL}${url}`;
+  }
+  return url;
+}
 
 export const apiClient = axios.create({
   baseURL: API_URL,
@@ -11,14 +27,17 @@ export const apiClient = axios.create({
 
 apiClient.interceptors.request.use((config) => {
   const method = config.method?.toLowerCase();
-  if (['post', 'put', 'delete', 'patch'].includes(method || '')) {
-    const csrfToken = typeof document !== 'undefined' ? document.cookie
-      .split('; ')
-      .find((row) => row.startsWith('csrf_token='))
-      ?.split('=')[1] : null;
-    
+  if (["post", "put", "delete", "patch"].includes(method || "")) {
+    const csrfToken =
+      typeof document !== "undefined"
+        ? document.cookie
+            .split("; ")
+            .find((row) => row.startsWith("csrf_token="))
+            ?.split("=")[1]
+        : null;
+
     if (csrfToken) {
-      config.headers['X-CSRF-Token'] = csrfToken;
+      config.headers["X-CSRF-Token"] = csrfToken;
     }
   }
   return config;
@@ -32,47 +51,62 @@ apiClient.interceptors.response.use(
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;
       try {
-        await apiClient.post('/v1/auth/refresh-web');
+        await apiClient.post("/v1/auth/refresh-web");
         return apiClient(originalRequest);
       } catch {
-        toast.error('Sesión expirada. Por favor inicie sesión nuevamente.');
-        if (typeof window !== 'undefined') {
-          window.location.href = '/login';
+        toast.error("Sesión expirada. Por favor inicie sesión nuevamente.");
+        if (typeof window !== "undefined") {
+          window.location.href = "/login";
         }
       }
     }
 
-    const message = error.response?.data?.message || error.message || 'Error desconocido';
+    const message =
+      error.response?.data?.message || error.message || "Error desconocido";
     // No mostrar toast para errores 404 de recursos no encontrados en dashboard (silencioso)
     if (error.response?.status !== 404) {
       toast.error(message);
     }
-    
+
     return Promise.reject(error);
-  }
+  },
 );
 
 export const authApi = {
   login: (identificador: string, password: string) =>
-    apiClient.post('/v1/auth/login-web', { identificador, password }),
-  logout: () => apiClient.post('/v1/auth/logout-web'),
-  refresh: () => apiClient.post('/v1/auth/refresh-web'),
-  me: () => apiClient.get('/v1/auth/me'),
+    apiClient.post("/v1/auth/login-web", { identificador, password }),
+  logout: () => apiClient.post("/v1/auth/logout-web"),
+  refresh: () => apiClient.post("/v1/auth/refresh-web"),
+  me: () => apiClient.get("/v1/auth/me"),
   changePassword: (passwordActual: string, nuevoPassword: string) =>
-    apiClient.post('/v1/auth/cambiar-password', { passwordActual, nuevoPassword }),
+    apiClient.post("/v1/auth/cambiar-password", {
+      passwordActual,
+      nuevoPassword,
+    }),
 };
 
 export const sociosApi = {
-  getAll: () => apiClient.get('/v1/socios'),
+  getAll: () => apiClient.get("/v1/socios"),
   getById: (id: string) => apiClient.get(`/v1/socios/${id}`),
-  updateProfile: (id: string, data: unknown) => apiClient.put(`/v1/socios/${id}/perfil`, data),
+  updateProfile: (id: string, data: unknown) =>
+    apiClient.put(`/v1/socios/${id}/perfil`, data),
 };
 
 export const cuentasApi = {
-  getCuentas: (socioId: string) => apiClient.get(`/v1/cuentas/socio/${socioId}`),
-  getCuenta: (numeroCuenta: string) => apiClient.get(`/v1/cuentas/${numeroCuenta}`),
-  getSaldo: (numeroCuenta: string) => apiClient.get(`/v1/cuentas/${numeroCuenta}/saldo`),
-  getMovimientos: (numeroCuenta: string, page = 0, size = 10, fechaInicio?: string, fechaFin?: string, tipoFiltro?: string) => {
+  getCuentas: (socioId: string) =>
+    apiClient.get(`/v1/cuentas/socio/${socioId}`),
+  getCuenta: (numeroCuenta: string) =>
+    apiClient.get(`/v1/cuentas/${numeroCuenta}`),
+  getSaldo: (numeroCuenta: string) =>
+    apiClient.get(`/v1/cuentas/${numeroCuenta}/saldo`),
+  getMovimientos: (
+    numeroCuenta: string,
+    page = 0,
+    size = 10,
+    fechaInicio?: string,
+    fechaFin?: string,
+    tipoFiltro?: string,
+  ) => {
     let url = `/v1/cuentas/${numeroCuenta}/movimientos?page=${page}&size=${size}`;
     if (fechaInicio) url += `&fechaInicio=${fechaInicio}`;
     if (fechaFin) url += `&fechaFin=${fechaFin}`;
@@ -82,58 +116,90 @@ export const cuentasApi = {
   // Issue #218 PR-C — `extras` permite enviar la declaración LOCDOFT
   // cuando el backend responde 422 LOCDOFT_CONSENT_REQUIRED y el usuario
   // confirma en el modal. Para operaciones normales, no se pasa.
-  deposito: (numeroCuenta: string, monto: number, extras?: { confirmaOrigenLicito?: boolean; origenFondos?: string }) =>
+  deposito: (
+    numeroCuenta: string,
+    monto: number,
+    extras?: { confirmaOrigenLicito?: boolean; origenFondos?: string },
+  ) =>
     apiClient.post(`/v1/cuentas/${numeroCuenta}/depositos`, {
       monto,
-      canalOrigen: 'WEB',
-      descripcion: 'Depósito en línea',
-      ...(extras?.confirmaOrigenLicito ? {
-        confirmaOrigenLicito: true,
-        origenFondos: extras.origenFondos || null,
-      } : {}),
+      canalOrigen: "WEB",
+      descripcion: "Depósito en línea",
+      ...(extras?.confirmaOrigenLicito
+        ? {
+            confirmaOrigenLicito: true,
+            origenFondos: extras.origenFondos || null,
+          }
+        : {}),
     }),
-  retiro: (numeroCuenta: string, monto: number, extras?: { confirmaOrigenLicito?: boolean; origenFondos?: string }) =>
+  retiro: (
+    numeroCuenta: string,
+    monto: number,
+    extras?: { confirmaOrigenLicito?: boolean; origenFondos?: string },
+  ) =>
     apiClient.post(`/v1/cuentas/${numeroCuenta}/retiros`, {
       monto,
-      canalOrigen: 'WEB',
-      descripcion: 'Retiro en línea',
-      ...(extras?.confirmaOrigenLicito ? {
-        confirmaOrigenLicito: true,
-        origenFondos: extras.origenFondos || null,
-      } : {}),
+      canalOrigen: "WEB",
+      descripcion: "Retiro en línea",
+      ...(extras?.confirmaOrigenLicito
+        ? {
+            confirmaOrigenLicito: true,
+            origenFondos: extras.origenFondos || null,
+          }
+        : {}),
     }),
 };
 
 export const creditosApi = {
-  getTiposCredito: () => apiClient.get('/v1/creditos/tipos-credito'),
+  getTiposCredito: () => apiClient.get("/v1/creditos/tipos-credito"),
   getSolicitudesAdmin: (params?: Record<string, string>) => {
-    const query = params ? new URLSearchParams(params).toString() : '';
-    return apiClient.get(`/v1/admin/creditos/solicitudes${query ? `?${query}` : ''}`);
+    const query = params ? new URLSearchParams(params).toString() : "";
+    return apiClient.get(
+      `/v1/admin/creditos/solicitudes${query ? `?${query}` : ""}`,
+    );
   },
-  getSolicitudesPorSocio: (socioId: string) => apiClient.get(`/v1/creditos/solicitudes/socio/${socioId}`),
-  getSolicitud: (numero: string) => apiClient.get(`/v1/creditos/solicitudes/${numero}`),
-  crearSolicitud: (data: unknown) => apiClient.post('/v1/creditos/solicitudes', data),
-  simular: (data: unknown) => apiClient.post('/v1/simulador', data),
+  getSolicitudesPorSocio: (socioId: string) =>
+    apiClient.get(`/v1/creditos/solicitudes/socio/${socioId}`),
+  getSolicitud: (numero: string) =>
+    apiClient.get(`/v1/creditos/solicitudes/${numero}`),
+  crearSolicitud: (data: unknown) =>
+    apiClient.post("/v1/creditos/solicitudes", data),
+  simular: (data: unknown) => apiClient.post("/v1/simulador", data),
 };
 
 export const productosApi = {
-  getPublicados: () => apiClient.get('/v1/productos'),
+  getPublicados: () => apiClient.get("/v1/productos"),
   getProducto: (slug: string) => apiClient.get(`/v1/productos/${slug}`),
-  precalificar: (id: number) => apiClient.post(`/v1/productos/${id}/precalificar`),
-  solicitarFinanciamiento: (id: number) => apiClient.post(`/v1/productos/${id}/solicitar-financiamiento`),
-  getAdmin: () => apiClient.get('/v1/admin/productos'),
-  crear: (data: unknown) => apiClient.post('/v1/admin/productos', data),
-  actualizar: (id: number, data: unknown) => apiClient.put(`/v1/admin/productos/${id}`, data),
-  publicar: (id: number) => apiClient.post(`/v1/admin/productos/${id}/publicar`),
+  precalificar: (id: number) =>
+    apiClient.post(`/v1/productos/${id}/precalificar`),
+  solicitarFinanciamiento: (id: number) =>
+    apiClient.post(`/v1/productos/${id}/solicitar-financiamiento`),
+  getAdmin: () => apiClient.get("/v1/admin/productos"),
+  crear: (data: unknown) => apiClient.post("/v1/admin/productos", data),
+  actualizar: (id: number, data: unknown) =>
+    apiClient.put(`/v1/admin/productos/${id}`, data),
+  subirImagen: (id: number, file: File) => {
+    const formData = new FormData();
+    formData.append("file", file);
+    return apiClient.post(`/v1/admin/productos/${id}/imagen`, formData, {
+      timeout: 30_000,
+    });
+  },
+  publicar: (id: number) =>
+    apiClient.post(`/v1/admin/productos/${id}/publicar`),
   pausar: (id: number) => apiClient.post(`/v1/admin/productos/${id}/pausar`),
-  archivar: (id: number) => apiClient.post(`/v1/admin/productos/${id}/archivar`),
+  archivar: (id: number) =>
+    apiClient.post(`/v1/admin/productos/${id}/archivar`),
 };
 
 export const adminApi = {
-  getStats: () => apiClient.get('/v1/admin/dashboard/estadisticas'),
-  getActividad: (limit: number = 15) => apiClient.get(`/v1/admin/actividad?limit=${limit}`),
+  getStats: () => apiClient.get("/v1/admin/dashboard/estadisticas"),
+  getActividad: (limit: number = 15) =>
+    apiClient.get(`/v1/admin/actividad?limit=${limit}`),
   getSolicitudes: (params?: Record<string, string>) => {
-    const query = params ? new URLSearchParams(params).toString() : '';
-    return apiClient.get(`/v1/admin/creditos/solicitudes${query ? `?${query}` : ''}`);
+    const query = params ? new URLSearchParams(params).toString() : "";
+    return apiClient.get(
+      `/v1/admin/creditos/solicitudes${query ? `?${query}` : ""}`,
+    );
   },
 };


### PR DESCRIPTION
## Resumen
- Agrega subida segura de imagen principal para productos financiables desde admin.
- Valida JPG/PNG, limite de 2 MB, re-procesa a JPG para eliminar metadatos y guarda en bucket MinIO de productos.
- Sirve imagenes por endpoint autenticado para socios/admin y resuelve URLs en frontend.
- Muestra preview y control de subir/cambiar foto en admin; socios ven la imagen en el catalogo.

## Seguridad
- Solo ADMIN/SUPER_ADMIN puede subir imagenes.
- SOCIO/ADMIN/SUPER_ADMIN puede consultar imagenes.
- No acepta SVG ni archivos por extension solamente; valida MIME y lectura real como imagen.
- Nombres internos aleatorios, sin usar nombre original.

## Pruebas
- git diff --check
- npm.cmd run build
- Backend compile: pendiente de GitHub Actions porque no hay Java/Maven ni Docker disponible en el entorno local.