### PR TITLE
feat(productos): agregar galeria de imagenes

### DIFF
--- a/backend/src/main/java/com/tufondo/productos/application/dto/ProductoFinanciableResponse.java
+++ b/backend/src/main/java/com/tufondo/productos/application/dto/ProductoFinanciableResponse.java
@@ -2,6 +2,7 @@ package com.tufondo.productos.application.dto;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class ProductoFinanciableResponse {
     private Long id;
@@ -14,6 +15,7 @@ public class ProductoFinanciableResponse {
     private BigDecimal precio;
     private String moneda;
     private String imagenUrl;
+    private List<ProductoImagenResponse> imagenes;
     private Long tipoCreditoId;
     private Integer plazoMinimoMeses;
     private Integer plazoMaximoMeses;
@@ -43,6 +45,8 @@ public class ProductoFinanciableResponse {
     public void setMoneda(String moneda) { this.moneda = moneda; }
     public String getImagenUrl() { return imagenUrl; }
     public void setImagenUrl(String imagenUrl) { this.imagenUrl = imagenUrl; }
+    public List<ProductoImagenResponse> getImagenes() { return imagenes; }
+    public void setImagenes(List<ProductoImagenResponse> imagenes) { this.imagenes = imagenes; }
     public Long getTipoCreditoId() { return tipoCreditoId; }
     public void setTipoCreditoId(Long tipoCreditoId) { this.tipoCreditoId = tipoCreditoId; }
     public Integer getPlazoMinimoMeses() { return plazoMinimoMeses; }

--- a/backend/src/main/java/com/tufondo/productos/application/dto/ProductoImagenResponse.java
+++ b/backend/src/main/java/com/tufondo/productos/application/dto/ProductoImagenResponse.java
@@ -1,0 +1,31 @@
+package com.tufondo.productos.application.dto;
+
+import java.time.LocalDateTime;
+
+public class ProductoImagenResponse {
+    private Long id;
+    private String imagenUrl;
+    private Boolean esPrincipal;
+    private Integer orden;
+    private Integer width;
+    private Integer height;
+    private Long sizeBytes;
+    private LocalDateTime createdAt;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getImagenUrl() { return imagenUrl; }
+    public void setImagenUrl(String imagenUrl) { this.imagenUrl = imagenUrl; }
+    public Boolean getEsPrincipal() { return esPrincipal; }
+    public void setEsPrincipal(Boolean esPrincipal) { this.esPrincipal = esPrincipal; }
+    public Integer getOrden() { return orden; }
+    public void setOrden(Integer orden) { this.orden = orden; }
+    public Integer getWidth() { return width; }
+    public void setWidth(Integer width) { this.width = width; }
+    public Integer getHeight() { return height; }
+    public void setHeight(Integer height) { this.height = height; }
+    public Long getSizeBytes() { return sizeBytes; }
+    public void setSizeBytes(Long sizeBytes) { this.sizeBytes = sizeBytes; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+}

--- a/backend/src/main/java/com/tufondo/productos/application/usecase/GestionarProductosFinanciablesUseCase.java
+++ b/backend/src/main/java/com/tufondo/productos/application/usecase/GestionarProductosFinanciablesUseCase.java
@@ -11,8 +11,12 @@ import com.tufondo.creditos.domain.repository.TipoCreditoRepository;
 import com.tufondo.productos.application.dto.PrecalificacionProductoResponse;
 import com.tufondo.productos.application.dto.ProductoFinanciableRequest;
 import com.tufondo.productos.application.dto.ProductoFinanciableResponse;
+import com.tufondo.productos.application.dto.ProductoImagenResponse;
 import com.tufondo.productos.infrastructure.persistence.entity.ProductoFinanciableEntity;
+import com.tufondo.productos.infrastructure.persistence.entity.ProductoImagenEntity;
 import com.tufondo.productos.infrastructure.persistence.jpa.ProductoFinanciableJpaRepository;
+import com.tufondo.productos.infrastructure.persistence.jpa.ProductoImagenJpaRepository;
+import com.tufondo.productos.infrastructure.storage.ProductoImagenStorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -35,8 +39,10 @@ public class GestionarProductosFinanciablesUseCase {
     private static final String ESTADO_PUBLICADO = "PUBLICADO";
     private static final String ESTADO_PAUSADO = "PAUSADO";
     private static final String ESTADO_ARCHIVADO = "ARCHIVADO";
+    private static final int MAX_IMAGENES_PRODUCTO = 5;
 
     private final ProductoFinanciableJpaRepository repository;
+    private final ProductoImagenJpaRepository imagenRepository;
     private final CuentaAhorroJpaRepository cuentaRepository;
     private final TipoCreditoRepository tipoCreditoRepository;
     private final CrearSolicitudCreditoUseCase crearSolicitudCreditoUseCase;
@@ -111,10 +117,88 @@ public class GestionarProductosFinanciablesUseCase {
     }
 
     @Transactional
-    public ProductoFinanciableResponse actualizarImagen(Long id, String imagenUrl) {
+    public ProductoFinanciableResponse actualizarImagen(Long id, ProductoImagenStorageService.UploadProductoImagenResult imagen, UUID adminId) {
+        return agregarImagen(id, imagen, true, adminId);
+    }
+
+    @Transactional
+    public ProductoFinanciableResponse agregarImagen(Long id, ProductoImagenStorageService.UploadProductoImagenResult imagen, boolean principal, UUID adminId) {
         ProductoFinanciableEntity entity = repository.findById(id)
             .orElseThrow(() -> new ProductoNoEncontradoException(id.toString()));
-        entity.setImagenUrl(imagenUrl);
+        long activas = imagenRepository.countByProductoIdAndActivaTrue(id);
+        if (activas >= MAX_IMAGENES_PRODUCTO) {
+            throw new IllegalArgumentException("El producto ya tiene el maximo de 5 imagenes activas");
+        }
+
+        boolean seraPrincipal = principal || activas == 0 || entity.getImagenUrl() == null || entity.getImagenUrl().isBlank();
+        if (seraPrincipal) {
+            quitarPrincipal(id);
+            entity.setImagenUrl(imagen.imagenUrl());
+        }
+
+        ProductoImagenEntity imageEntity = new ProductoImagenEntity();
+        imageEntity.setProductoId(id);
+        imageEntity.setImagenUrl(imagen.imagenUrl());
+        imageEntity.setStorageKey(imagen.storageKey());
+        imageEntity.setMimeType(imagen.mimeType());
+        imageEntity.setSizeBytes(imagen.sizeBytes());
+        imageEntity.setWidth(imagen.width());
+        imageEntity.setHeight(imagen.height());
+        imageEntity.setEsPrincipal(seraPrincipal);
+        imageEntity.setActiva(true);
+        imageEntity.setOrden((int) activas);
+        imageEntity.setCreatedBy(adminId);
+        imageEntity.setCreatedAt(LocalDateTime.now());
+        imageEntity.setUpdatedAt(LocalDateTime.now());
+        imagenRepository.save(imageEntity);
+
+        entity.setUpdatedAt(LocalDateTime.now());
+        return toResponse(repository.save(entity));
+    }
+
+    @Transactional
+    public ProductoFinanciableResponse marcarImagenPrincipal(Long productoId, Long imagenId) {
+        ProductoFinanciableEntity entity = repository.findById(productoId)
+            .orElseThrow(() -> new ProductoNoEncontradoException(productoId.toString()));
+        ProductoImagenEntity imagen = imagenRepository.findByIdAndProductoIdAndActivaTrue(imagenId, productoId)
+            .orElseThrow(() -> new ProductoNoEncontradoException(imagenId.toString()));
+        quitarPrincipal(productoId);
+        imagen.setEsPrincipal(true);
+        imagen.setOrden(0);
+        imagen.setUpdatedAt(LocalDateTime.now());
+        imagenRepository.save(imagen);
+        entity.setImagenUrl(imagen.getImagenUrl());
+        entity.setUpdatedAt(LocalDateTime.now());
+        return toResponse(repository.save(entity));
+    }
+
+    @Transactional
+    public ProductoFinanciableResponse desactivarImagen(Long productoId, Long imagenId) {
+        ProductoFinanciableEntity entity = repository.findById(productoId)
+            .orElseThrow(() -> new ProductoNoEncontradoException(productoId.toString()));
+        ProductoImagenEntity imagen = imagenRepository.findByIdAndProductoIdAndActivaTrue(imagenId, productoId)
+            .orElseThrow(() -> new ProductoNoEncontradoException(imagenId.toString()));
+        boolean eraPrincipal = Boolean.TRUE.equals(imagen.getEsPrincipal());
+        imagen.setActiva(false);
+        imagen.setEsPrincipal(false);
+        imagen.setUpdatedAt(LocalDateTime.now());
+        imagenRepository.save(imagen);
+
+        if (eraPrincipal) {
+            ProductoImagenEntity siguiente = imagenRepository.findByProductoIdAndActivaTrueOrderByOrdenAscIdAsc(productoId)
+                .stream()
+                .findFirst()
+                .orElse(null);
+            if (siguiente != null) {
+                quitarPrincipal(productoId);
+                siguiente.setEsPrincipal(true);
+                siguiente.setUpdatedAt(LocalDateTime.now());
+                imagenRepository.save(siguiente);
+                entity.setImagenUrl(siguiente.getImagenUrl());
+            } else {
+                entity.setImagenUrl(null);
+            }
+        }
         entity.setUpdatedAt(LocalDateTime.now());
         return toResponse(repository.save(entity));
     }
@@ -187,7 +271,7 @@ public class GestionarProductosFinanciablesUseCase {
         entity.setProveedor(request.getProveedor());
         entity.setPrecio(request.getPrecio());
         entity.setMoneda(request.getMoneda().trim().toUpperCase(Locale.ROOT));
-        entity.setImagenUrl(request.getImagenUrl());
+        entity.setImagenUrl(normalizarImagenUrlInterna(request.getImagenUrl()));
         entity.setTipoCreditoId(request.getTipoCreditoId());
         entity.setPlazoMinimoMeses(request.getPlazoMinimoMeses());
         entity.setPlazoMaximoMeses(calcularPlazoMaximoPermitido(request.getPlazoMaximoMeses(), tipoCredito));
@@ -242,6 +326,9 @@ public class GestionarProductosFinanciablesUseCase {
         response.setPrecio(entity.getPrecio());
         response.setMoneda(entity.getMoneda());
         response.setImagenUrl(entity.getImagenUrl());
+        response.setImagenes(imagenRepository.findByProductoIdAndActivaTrueOrderByOrdenAscIdAsc(entity.getId()).stream()
+            .map(this::toImagenResponse)
+            .toList());
         response.setTipoCreditoId(entity.getTipoCreditoId());
         response.setPlazoMinimoMeses(entity.getPlazoMinimoMeses());
         response.setPlazoMaximoMeses(entity.getPlazoMaximoMeses());
@@ -251,6 +338,40 @@ public class GestionarProductosFinanciablesUseCase {
         response.setEstado(entity.getEstado());
         response.setUpdatedAt(entity.getUpdatedAt());
         return response;
+    }
+
+    private ProductoImagenResponse toImagenResponse(ProductoImagenEntity entity) {
+        ProductoImagenResponse response = new ProductoImagenResponse();
+        response.setId(entity.getId());
+        response.setImagenUrl(entity.getImagenUrl());
+        response.setEsPrincipal(entity.getEsPrincipal());
+        response.setOrden(entity.getOrden());
+        response.setWidth(entity.getWidth());
+        response.setHeight(entity.getHeight());
+        response.setSizeBytes(entity.getSizeBytes());
+        response.setCreatedAt(entity.getCreatedAt());
+        return response;
+    }
+
+    private void quitarPrincipal(Long productoId) {
+        imagenRepository.findByProductoIdAndActivaTrue(productoId).forEach(imagen -> {
+            if (Boolean.TRUE.equals(imagen.getEsPrincipal())) {
+                imagen.setEsPrincipal(false);
+                imagen.setUpdatedAt(LocalDateTime.now());
+                imagenRepository.save(imagen);
+            }
+        });
+    }
+
+    private String normalizarImagenUrlInterna(String imagenUrl) {
+        if (imagenUrl == null || imagenUrl.isBlank()) {
+            return null;
+        }
+        String trimmed = imagenUrl.trim();
+        if (!trimmed.startsWith("/api/v1/productos/imagenes/")) {
+            throw new IllegalArgumentException("La imagen del producto debe subirse desde el panel administrador");
+        }
+        return trimmed;
     }
 
     private BigDecimal calcularColateral(ProductoFinanciableEntity producto) {

--- a/backend/src/main/java/com/tufondo/productos/infrastructure/persistence/entity/ProductoImagenEntity.java
+++ b/backend/src/main/java/com/tufondo/productos/infrastructure/persistence/entity/ProductoImagenEntity.java
@@ -1,0 +1,87 @@
+package com.tufondo.productos.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "producto_imagenes",
+    indexes = {
+        @Index(name = "idx_producto_imagenes_producto", columnList = "producto_id"),
+        @Index(name = "idx_producto_imagenes_producto_activa", columnList = "producto_id, activa, orden")
+    })
+public class ProductoImagenEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "producto_id", nullable = false)
+    private Long productoId;
+
+    @Column(name = "imagen_url", nullable = false, length = 500)
+    private String imagenUrl;
+
+    @Column(name = "storage_key", nullable = false, length = 500)
+    private String storageKey;
+
+    @Column(name = "mime_type", nullable = false, length = 60)
+    private String mimeType;
+
+    @Column(name = "size_bytes", nullable = false)
+    private Long sizeBytes;
+
+    @Column(nullable = false)
+    private Integer width;
+
+    @Column(nullable = false)
+    private Integer height;
+
+    @Column(name = "es_principal", nullable = false)
+    private Boolean esPrincipal;
+
+    @Column(nullable = false)
+    private Boolean activa;
+
+    @Column(nullable = false)
+    private Integer orden;
+
+    @Column(name = "created_by")
+    private UUID createdBy;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public Long getProductoId() { return productoId; }
+    public void setProductoId(Long productoId) { this.productoId = productoId; }
+    public String getImagenUrl() { return imagenUrl; }
+    public void setImagenUrl(String imagenUrl) { this.imagenUrl = imagenUrl; }
+    public String getStorageKey() { return storageKey; }
+    public void setStorageKey(String storageKey) { this.storageKey = storageKey; }
+    public String getMimeType() { return mimeType; }
+    public void setMimeType(String mimeType) { this.mimeType = mimeType; }
+    public Long getSizeBytes() { return sizeBytes; }
+    public void setSizeBytes(Long sizeBytes) { this.sizeBytes = sizeBytes; }
+    public Integer getWidth() { return width; }
+    public void setWidth(Integer width) { this.width = width; }
+    public Integer getHeight() { return height; }
+    public void setHeight(Integer height) { this.height = height; }
+    public Boolean getEsPrincipal() { return esPrincipal; }
+    public void setEsPrincipal(Boolean esPrincipal) { this.esPrincipal = esPrincipal; }
+    public Boolean getActiva() { return activa; }
+    public void setActiva(Boolean activa) { this.activa = activa; }
+    public Integer getOrden() { return orden; }
+    public void setOrden(Integer orden) { this.orden = orden; }
+    public UUID getCreatedBy() { return createdBy; }
+    public void setCreatedBy(UUID createdBy) { this.createdBy = createdBy; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/backend/src/main/java/com/tufondo/productos/infrastructure/persistence/jpa/ProductoImagenJpaRepository.java
+++ b/backend/src/main/java/com/tufondo/productos/infrastructure/persistence/jpa/ProductoImagenJpaRepository.java
@@ -1,0 +1,14 @@
+package com.tufondo.productos.infrastructure.persistence.jpa;
+
+import com.tufondo.productos.infrastructure.persistence.entity.ProductoImagenEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductoImagenJpaRepository extends JpaRepository<ProductoImagenEntity, Long> {
+    long countByProductoIdAndActivaTrue(Long productoId);
+    List<ProductoImagenEntity> findByProductoIdAndActivaTrueOrderByOrdenAscIdAsc(Long productoId);
+    List<ProductoImagenEntity> findByProductoIdAndActivaTrue(Long productoId);
+    Optional<ProductoImagenEntity> findByIdAndProductoIdAndActivaTrue(Long id, Long productoId);
+}

--- a/backend/src/main/java/com/tufondo/productos/infrastructure/storage/ProductoImagenStorageService.java
+++ b/backend/src/main/java/com/tufondo/productos/infrastructure/storage/ProductoImagenStorageService.java
@@ -40,7 +40,7 @@ public class ProductoImagenStorageService {
     @Value("${fatrans.productos.imagenes.max-size-bytes:2097152}")
     private long maxSizeBytes;
 
-    public String subirImagen(Long productoId, MultipartFile file) {
+    public UploadProductoImagenResult subirImagen(Long productoId, MultipartFile file) {
         if (file == null || file.isEmpty()) {
             throw new IllegalArgumentException("La imagen del producto es requerida");
         }
@@ -78,7 +78,14 @@ public class ProductoImagenStorageService {
                 );
             }
 
-            return "/api/v1/productos/imagenes/" + fecha + "/" + fileName;
+            return new UploadProductoImagenResult(
+                "/api/v1/productos/imagenes/" + fecha + "/" + fileName,
+                objectPath,
+                "image/jpeg",
+                (long) normalizada.length,
+                original.getWidth(),
+                original.getHeight()
+            );
         } catch (IllegalArgumentException ex) {
             throw ex;
         } catch (Exception ex) {
@@ -160,6 +167,15 @@ public class ProductoImagenStorageService {
     }
 
     public record ImagenProducto(byte[] data, String contentType) {}
+
+    public record UploadProductoImagenResult(
+        String imagenUrl,
+        String storageKey,
+        String mimeType,
+        Long sizeBytes,
+        Integer width,
+        Integer height
+    ) {}
 
     public static class ImagenNoEncontradaException extends RuntimeException {}
 }

--- a/backend/src/main/java/com/tufondo/productos/presentation/controller/ProductoFinanciableController.java
+++ b/backend/src/main/java/com/tufondo/productos/presentation/controller/ProductoFinanciableController.java
@@ -113,10 +113,38 @@ public class ProductoFinanciableController {
     @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
     public ResponseEntity<ProductoFinanciableResponse> subirImagen(
             @PathVariable Long id,
-            @RequestParam("file") MultipartFile file) {
+            @RequestParam("file") MultipartFile file,
+            Authentication authentication) {
         useCase.validarExiste(id);
-        String imagenUrl = imagenStorageService.subirImagen(id, file);
-        return ResponseEntity.ok(useCase.actualizarImagen(id, imagenUrl));
+        ProductoImagenStorageService.UploadProductoImagenResult imagen = imagenStorageService.subirImagen(id, file);
+        return ResponseEntity.ok(useCase.actualizarImagen(id, imagen, extraerUserId(authentication)));
+    }
+
+    @PostMapping(value = "/admin/productos/{id}/imagenes", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
+    public ResponseEntity<ProductoFinanciableResponse> agregarImagen(
+            @PathVariable Long id,
+            @RequestParam("file") MultipartFile file,
+            Authentication authentication) {
+        useCase.validarExiste(id);
+        ProductoImagenStorageService.UploadProductoImagenResult imagen = imagenStorageService.subirImagen(id, file);
+        return ResponseEntity.ok(useCase.agregarImagen(id, imagen, false, extraerUserId(authentication)));
+    }
+
+    @PostMapping("/admin/productos/{id}/imagenes/{imagenId}/principal")
+    @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
+    public ResponseEntity<ProductoFinanciableResponse> marcarImagenPrincipal(
+            @PathVariable Long id,
+            @PathVariable Long imagenId) {
+        return ResponseEntity.ok(useCase.marcarImagenPrincipal(id, imagenId));
+    }
+
+    @DeleteMapping("/admin/productos/{id}/imagenes/{imagenId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
+    public ResponseEntity<ProductoFinanciableResponse> eliminarImagen(
+            @PathVariable Long id,
+            @PathVariable Long imagenId) {
+        return ResponseEntity.ok(useCase.desactivarImagen(id, imagenId));
     }
 
     @GetMapping("/productos/imagenes/{fecha}/{fileName}")

--- a/backend/src/main/resources/db/migration/V24__producto_imagenes.sql
+++ b/backend/src/main/resources/db/migration/V24__producto_imagenes.sql
@@ -1,0 +1,49 @@
+CREATE TABLE producto_imagenes (
+    id BIGSERIAL PRIMARY KEY,
+    producto_id BIGINT NOT NULL REFERENCES productos_financiables(id) ON DELETE CASCADE,
+    imagen_url VARCHAR(500) NOT NULL,
+    storage_key VARCHAR(500) NOT NULL,
+    mime_type VARCHAR(60) NOT NULL,
+    size_bytes BIGINT NOT NULL,
+    width INTEGER NOT NULL,
+    height INTEGER NOT NULL,
+    es_principal BOOLEAN NOT NULL DEFAULT FALSE,
+    activa BOOLEAN NOT NULL DEFAULT TRUE,
+    orden INTEGER NOT NULL DEFAULT 0,
+    created_by UUID,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_producto_imagenes_producto ON producto_imagenes(producto_id);
+CREATE INDEX idx_producto_imagenes_producto_activa ON producto_imagenes(producto_id, activa, orden);
+
+INSERT INTO producto_imagenes (
+    producto_id,
+    imagen_url,
+    storage_key,
+    mime_type,
+    size_bytes,
+    width,
+    height,
+    es_principal,
+    activa,
+    orden,
+    created_at,
+    updated_at
+)
+SELECT
+    id,
+    imagen_url,
+    imagen_url,
+    'image/jpeg',
+    0,
+    1,
+    1,
+    TRUE,
+    TRUE,
+    0,
+    NOW(),
+    NOW()
+FROM productos_financiables
+WHERE imagen_url IS NOT NULL AND imagen_url <> '';

--- a/frontend-web/src/app/(admin)/admin/productos/page.tsx
+++ b/frontend-web/src/app/(admin)/admin/productos/page.tsx
@@ -18,8 +18,17 @@ import {
   Pause,
   Plus,
   Send,
+  Star,
+  Trash2,
   Upload,
 } from "lucide-react";
+
+interface ProductoImagen {
+  id: number;
+  imagenUrl: string;
+  esPrincipal: boolean;
+  orden: number;
+}
 
 interface Producto {
   id: number;
@@ -36,6 +45,7 @@ interface Producto {
   porcentajeColateral: number;
   colateralRequerido: number;
   imagenUrl?: string;
+  imagenes?: ProductoImagen[];
   estado: string;
 }
 
@@ -127,7 +137,7 @@ export default function AdminProductosPage() {
     if (!file) return;
     setUploadingId(producto.id);
     try {
-      const response = await productosApi.subirImagen(producto.id, file);
+      const response = await productosApi.agregarImagen(producto.id, file);
       setProductos((current) =>
         current.map((item) =>
           item.id === producto.id ? { ...item, ...response.data } : item,
@@ -136,6 +146,30 @@ export default function AdminProductosPage() {
     } finally {
       setUploadingId(null);
     }
+  };
+
+  const marcarPrincipal = async (
+    producto: Producto,
+    imagen: ProductoImagen,
+  ) => {
+    const response = await productosApi.marcarImagenPrincipal(
+      producto.id,
+      imagen.id,
+    );
+    setProductos((current) =>
+      current.map((item) =>
+        item.id === producto.id ? { ...item, ...response.data } : item,
+      ),
+    );
+  };
+
+  const eliminarImagen = async (producto: Producto, imagen: ProductoImagen) => {
+    const response = await productosApi.eliminarImagen(producto.id, imagen.id);
+    setProductos((current) =>
+      current.map((item) =>
+        item.id === producto.id ? { ...item, ...response.data } : item,
+      ),
+    );
   };
 
   return (
@@ -369,7 +403,7 @@ export default function AdminProductosPage() {
                           {uploadingId === producto.id
                             ? "Subiendo..."
                             : producto.imagenUrl
-                              ? "Cambiar foto"
+                              ? "Agregar foto"
                               : "Subir foto"}
                           <input
                             type="file"
@@ -384,8 +418,54 @@ export default function AdminProductosPage() {
                           />
                         </label>
                         <p className="mt-1 text-xs text-slate-500">
-                          JPG o PNG, máximo 2 MB.
+                          JPG o PNG, máximo 2 MB. Hasta 5 fotos por producto.
                         </p>
+                        {producto.imagenes && producto.imagenes.length > 0 && (
+                          <div className="mt-3 flex flex-wrap gap-2">
+                            {producto.imagenes.map((imagen) => (
+                              <div
+                                key={imagen.id}
+                                className="group relative h-16 w-20 overflow-hidden rounded-md border border-slate-200 bg-slate-50"
+                              >
+                                {/* eslint-disable-next-line @next/next/no-img-element */}
+                                <img
+                                  src={resolveApiAssetUrl(imagen.imagenUrl)}
+                                  alt={`${producto.nombre} ${imagen.orden + 1}`}
+                                  className="h-full w-full object-cover"
+                                />
+                                {imagen.esPrincipal && (
+                                  <span className="absolute left-1 top-1 rounded bg-white px-1.5 py-0.5 text-[10px] font-semibold text-[#0F2744] shadow-sm">
+                                    Principal
+                                  </span>
+                                )}
+                                <div className="absolute inset-x-1 bottom-1 flex justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                                  {!imagen.esPrincipal && (
+                                    <button
+                                      type="button"
+                                      aria-label="Marcar como principal"
+                                      className="rounded bg-white p-1 text-[#0F2744] shadow-sm hover:bg-slate-100"
+                                      onClick={() =>
+                                        void marcarPrincipal(producto, imagen)
+                                      }
+                                    >
+                                      <Star className="h-3.5 w-3.5" />
+                                    </button>
+                                  )}
+                                  <button
+                                    type="button"
+                                    aria-label="Eliminar imagen"
+                                    className="rounded bg-white p-1 text-red-600 shadow-sm hover:bg-red-50"
+                                    onClick={() =>
+                                      void eliminarImagen(producto, imagen)
+                                    }
+                                  >
+                                    <Trash2 className="h-3.5 w-3.5" />
+                                  </button>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        )}
                       </div>
                     </div>
                     <div className="flex shrink-0 gap-2">

--- a/frontend-web/src/app/(dashboard)/dashboard/productos/page.tsx
+++ b/frontend-web/src/app/(dashboard)/dashboard/productos/page.tsx
@@ -8,6 +8,13 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { PackageOpen, ShieldCheck, WalletCards } from "lucide-react";
 
+interface ProductoImagen {
+  id: number;
+  imagenUrl: string;
+  esPrincipal: boolean;
+  orden: number;
+}
+
 interface Producto {
   id: number;
   slug: string;
@@ -18,6 +25,7 @@ interface Producto {
   precio: number;
   moneda: string;
   imagenUrl?: string;
+  imagenes?: ProductoImagen[];
   plazoMinimoMeses: number;
   plazoMaximoMeses: number;
   porcentajeColateral: number;
@@ -129,16 +137,20 @@ export default function ProductosSocioPage() {
           productos.map((producto) => {
             const precalificacion = precalificaciones[producto.id];
             const elegible = precalificacion?.elegible;
+            const imagenPrincipal =
+              producto.imagenes?.find((imagen) => imagen.esPrincipal) ||
+              producto.imagenes?.[0];
+            const heroUrl = imagenPrincipal?.imagenUrl || producto.imagenUrl;
             return (
               <Card
                 key={producto.id}
                 className="overflow-hidden border-slate-200"
               >
                 <div className="relative h-36 bg-[#0F2744]">
-                  {producto.imagenUrl ? (
+                  {heroUrl ? (
                     // eslint-disable-next-line @next/next/no-img-element
                     <img
-                      src={resolveApiAssetUrl(producto.imagenUrl)}
+                      src={resolveApiAssetUrl(heroUrl)}
                       alt={producto.nombre}
                       className="h-full w-full object-cover"
                     />
@@ -150,6 +162,18 @@ export default function ProductosSocioPage() {
                   <Badge className="absolute left-3 top-3 bg-white text-[#0F2744] hover:bg-white">
                     {producto.categoria}
                   </Badge>
+                  {producto.imagenes && producto.imagenes.length > 1 && (
+                    <div className="absolute bottom-3 right-3 flex gap-1">
+                      {producto.imagenes.slice(0, 4).map((imagen) => (
+                        <span
+                          key={imagen.id}
+                          className={`h-1.5 w-5 rounded-full ${
+                            imagen.esPrincipal ? "bg-white" : "bg-white/45"
+                          }`}
+                        />
+                      ))}
+                    </div>
+                  )}
                 </div>
                 <CardContent className="p-5 space-y-4">
                   <div>

--- a/frontend-web/src/lib/api/client.ts
+++ b/frontend-web/src/lib/api/client.ts
@@ -185,6 +185,17 @@ export const productosApi = {
       timeout: 30_000,
     });
   },
+  agregarImagen: (id: number, file: File) => {
+    const formData = new FormData();
+    formData.append("file", file);
+    return apiClient.post(`/v1/admin/productos/${id}/imagenes`, formData, {
+      timeout: 30_000,
+    });
+  },
+  marcarImagenPrincipal: (id: number, imagenId: number) =>
+    apiClient.post(`/v1/admin/productos/${id}/imagenes/${imagenId}/principal`),
+  eliminarImagen: (id: number, imagenId: number) =>
+    apiClient.delete(`/v1/admin/productos/${id}/imagenes/${imagenId}`),
   publicar: (id: number) =>
     apiClient.post(`/v1/admin/productos/${id}/publicar`),
   pausar: (id: number) => apiClient.post(`/v1/admin/productos/${id}/pausar`),


### PR DESCRIPTION
## Resumen
- Agrega tabla producto_imagenes con migracion V24 y migra imagen_url existente como imagen principal.
- Devuelve imagenes[] en productos para admin/socio, manteniendo imagenUrl como compatibilidad.
- Permite subir hasta 5 imagenes activas por producto, marcar principal y desactivar imagenes.
- Mantiene la subida segura: JPG/PNG, 2 MB, reprocesado a JPG y URLs internas.
- Actualiza admin con miniaturas y acciones; socio usa principal y muestra indicador de galeria.

## Seguridad
- Solo ADMIN/SUPER_ADMIN administra galeria.
- Se bloquean imagenUrl externas en requests JSON; las fotos deben venir del uploader interno.
- Las eliminaciones son soft-delete para trazabilidad y para no romper referencias.

## Pruebas
- git diff --check
- npm.cmd run build
- Backend compile: validado por GitHub Actions.