### PR TITLE
feat(productos): auditar historial del catalogo

### DIFF
--- a/backend/src/main/java/com/tufondo/productos/application/dto/ProductoHistorialCambioResponse.java
+++ b/backend/src/main/java/com/tufondo/productos/application/dto/ProductoHistorialCambioResponse.java
@@ -1,0 +1,22 @@
+package com.tufondo.productos.application.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+public class ProductoHistorialCambioResponse {
+
+    private Long id;
+    private Long productoId;
+    private String tipoEvento;
+    private String campo;
+    private String valorAnterior;
+    private String valorNuevo;
+    private String estadoProducto;
+    private UUID actorId;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/tufondo/productos/application/usecase/GestionarProductosFinanciablesUseCase.java
+++ b/backend/src/main/java/com/tufondo/productos/application/usecase/GestionarProductosFinanciablesUseCase.java
@@ -11,10 +11,13 @@ import com.tufondo.creditos.domain.repository.TipoCreditoRepository;
 import com.tufondo.productos.application.dto.PrecalificacionProductoResponse;
 import com.tufondo.productos.application.dto.ProductoFinanciableRequest;
 import com.tufondo.productos.application.dto.ProductoFinanciableResponse;
+import com.tufondo.productos.application.dto.ProductoHistorialCambioResponse;
 import com.tufondo.productos.application.dto.ProductoImagenResponse;
 import com.tufondo.productos.infrastructure.persistence.entity.ProductoFinanciableEntity;
+import com.tufondo.productos.infrastructure.persistence.entity.ProductoHistorialCambioEntity;
 import com.tufondo.productos.infrastructure.persistence.entity.ProductoImagenEntity;
 import com.tufondo.productos.infrastructure.persistence.jpa.ProductoFinanciableJpaRepository;
+import com.tufondo.productos.infrastructure.persistence.jpa.ProductoHistorialCambioJpaRepository;
 import com.tufondo.productos.infrastructure.persistence.jpa.ProductoImagenJpaRepository;
 import com.tufondo.productos.infrastructure.storage.ProductoImagenStorageService;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +32,7 @@ import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.UUID;
 
 @Service
@@ -43,6 +47,7 @@ public class GestionarProductosFinanciablesUseCase {
 
     private final ProductoFinanciableJpaRepository repository;
     private final ProductoImagenJpaRepository imagenRepository;
+    private final ProductoHistorialCambioJpaRepository historialRepository;
     private final CuentaAhorroJpaRepository cuentaRepository;
     private final TipoCreditoRepository tipoCreditoRepository;
     private final CrearSolicitudCreditoUseCase crearSolicitudCreditoUseCase;
@@ -69,6 +74,14 @@ public class GestionarProductosFinanciablesUseCase {
     }
 
     @Transactional(readOnly = true)
+    public List<ProductoHistorialCambioResponse> listarHistorial(Long productoId) {
+        validarExiste(productoId);
+        return historialRepository.findByProductoIdOrderByCreatedAtDesc(productoId).stream()
+            .map(this::toHistorialResponse)
+            .toList();
+    }
+
+    @Transactional(readOnly = true)
     public ProductoFinanciableResponse obtenerPublicado(String slug) {
         return repository.findBySlugAndEstado(slug, ESTADO_PUBLICADO)
             .map(this::toResponse)
@@ -91,29 +104,37 @@ public class GestionarProductosFinanciablesUseCase {
         entity.setCreatedBy(adminId);
         entity.setCreatedAt(LocalDateTime.now());
         entity.setUpdatedAt(LocalDateTime.now());
-        return toResponse(repository.save(entity));
+        ProductoFinanciableEntity saved = repository.save(entity);
+        registrarCambio(saved.getId(), "CREACION", null, null, "Producto creado", saved.getEstado(), adminId);
+        return toResponse(saved);
     }
 
     @Transactional
-    public ProductoFinanciableResponse actualizar(Long id, ProductoFinanciableRequest request) {
+    public ProductoFinanciableResponse actualizar(Long id, ProductoFinanciableRequest request, UUID adminId) {
         TipoCredito tipoCredito = validarRequest(request);
         ProductoFinanciableEntity entity = repository.findById(id)
             .orElseThrow(() -> new ProductoNoEncontradoException(id.toString()));
+        ProductoSnapshot anterior = ProductoSnapshot.from(entity);
         aplicarRequest(entity, request, tipoCredito);
         entity.setUpdatedAt(LocalDateTime.now());
-        return toResponse(repository.save(entity));
+        ProductoFinanciableEntity saved = repository.save(entity);
+        registrarCambiosActualizacion(id, anterior, saved, adminId);
+        return toResponse(saved);
     }
 
     @Transactional
-    public ProductoFinanciableResponse cambiarEstado(Long id, String estado) {
+    public ProductoFinanciableResponse cambiarEstado(Long id, String estado, UUID adminId) {
         if (!List.of(ESTADO_BORRADOR, ESTADO_PUBLICADO, ESTADO_PAUSADO, ESTADO_ARCHIVADO).contains(estado)) {
             throw new IllegalArgumentException("Estado no permitido");
         }
         ProductoFinanciableEntity entity = repository.findById(id)
             .orElseThrow(() -> new ProductoNoEncontradoException(id.toString()));
+        String estadoAnterior = entity.getEstado();
         entity.setEstado(estado);
         entity.setUpdatedAt(LocalDateTime.now());
-        return toResponse(repository.save(entity));
+        ProductoFinanciableEntity saved = repository.save(entity);
+        registrarCambioSiCambio(id, "CAMBIO_ESTADO", "estado", estadoAnterior, estado, saved.getEstado(), adminId);
+        return toResponse(saved);
     }
 
     @Transactional
@@ -131,6 +152,7 @@ public class GestionarProductosFinanciablesUseCase {
         }
 
         boolean seraPrincipal = principal || activas == 0 || entity.getImagenUrl() == null || entity.getImagenUrl().isBlank();
+        String imagenPrincipalAnterior = entity.getImagenUrl();
         if (seraPrincipal) {
             quitarPrincipal(id);
             entity.setImagenUrl(imagen.imagenUrl());
@@ -153,15 +175,19 @@ public class GestionarProductosFinanciablesUseCase {
         imagenRepository.save(imageEntity);
 
         entity.setUpdatedAt(LocalDateTime.now());
-        return toResponse(repository.save(entity));
+        ProductoFinanciableEntity saved = repository.save(entity);
+        registrarCambio(id, "IMAGEN_AGREGADA", "imagen", null, imagen.imagenUrl(), saved.getEstado(), adminId);
+        registrarCambioSiCambio(id, "IMAGEN_PRINCIPAL", "imagenUrl", imagenPrincipalAnterior, saved.getImagenUrl(), saved.getEstado(), adminId);
+        return toResponse(saved);
     }
 
     @Transactional
-    public ProductoFinanciableResponse marcarImagenPrincipal(Long productoId, Long imagenId) {
+    public ProductoFinanciableResponse marcarImagenPrincipal(Long productoId, Long imagenId, UUID adminId) {
         ProductoFinanciableEntity entity = repository.findById(productoId)
             .orElseThrow(() -> new ProductoNoEncontradoException(productoId.toString()));
         ProductoImagenEntity imagen = imagenRepository.findByIdAndProductoIdAndActivaTrue(imagenId, productoId)
             .orElseThrow(() -> new ProductoNoEncontradoException(imagenId.toString()));
+        String imagenPrincipalAnterior = entity.getImagenUrl();
         quitarPrincipal(productoId);
         imagen.setEsPrincipal(true);
         imagen.setOrden(0);
@@ -169,16 +195,20 @@ public class GestionarProductosFinanciablesUseCase {
         imagenRepository.save(imagen);
         entity.setImagenUrl(imagen.getImagenUrl());
         entity.setUpdatedAt(LocalDateTime.now());
-        return toResponse(repository.save(entity));
+        ProductoFinanciableEntity saved = repository.save(entity);
+        registrarCambioSiCambio(productoId, "IMAGEN_PRINCIPAL", "imagenUrl", imagenPrincipalAnterior, saved.getImagenUrl(), saved.getEstado(), adminId);
+        return toResponse(saved);
     }
 
     @Transactional
-    public ProductoFinanciableResponse desactivarImagen(Long productoId, Long imagenId) {
+    public ProductoFinanciableResponse desactivarImagen(Long productoId, Long imagenId, UUID adminId) {
         ProductoFinanciableEntity entity = repository.findById(productoId)
             .orElseThrow(() -> new ProductoNoEncontradoException(productoId.toString()));
         ProductoImagenEntity imagen = imagenRepository.findByIdAndProductoIdAndActivaTrue(imagenId, productoId)
             .orElseThrow(() -> new ProductoNoEncontradoException(imagenId.toString()));
         boolean eraPrincipal = Boolean.TRUE.equals(imagen.getEsPrincipal());
+        String imagenUrlEliminada = imagen.getImagenUrl();
+        String imagenPrincipalAnterior = entity.getImagenUrl();
         imagen.setActiva(false);
         imagen.setEsPrincipal(false);
         imagen.setUpdatedAt(LocalDateTime.now());
@@ -200,7 +230,10 @@ public class GestionarProductosFinanciablesUseCase {
             }
         }
         entity.setUpdatedAt(LocalDateTime.now());
-        return toResponse(repository.save(entity));
+        ProductoFinanciableEntity saved = repository.save(entity);
+        registrarCambio(productoId, "IMAGEN_ELIMINADA", "imagen", imagenUrlEliminada, null, saved.getEstado(), adminId);
+        registrarCambioSiCambio(productoId, "IMAGEN_PRINCIPAL", "imagenUrl", imagenPrincipalAnterior, saved.getImagenUrl(), saved.getEstado(), adminId);
+        return toResponse(saved);
     }
 
     @Transactional(readOnly = true)
@@ -353,6 +386,85 @@ public class GestionarProductosFinanciablesUseCase {
         return response;
     }
 
+    private ProductoHistorialCambioResponse toHistorialResponse(ProductoHistorialCambioEntity entity) {
+        ProductoHistorialCambioResponse response = new ProductoHistorialCambioResponse();
+        response.setId(entity.getId());
+        response.setProductoId(entity.getProductoId());
+        response.setTipoEvento(entity.getTipoEvento());
+        response.setCampo(entity.getCampo());
+        response.setValorAnterior(entity.getValorAnterior());
+        response.setValorNuevo(entity.getValorNuevo());
+        response.setEstadoProducto(entity.getEstadoProducto());
+        response.setActorId(entity.getActorId());
+        response.setCreatedAt(entity.getCreatedAt());
+        return response;
+    }
+
+    private void registrarCambiosActualizacion(
+            Long productoId,
+            ProductoSnapshot anterior,
+            ProductoFinanciableEntity actual,
+            UUID adminId) {
+        registrarCambioSiCambio(productoId, "ACTUALIZACION", "nombre", anterior.nombre(), actual.getNombre(), actual.getEstado(), adminId);
+        registrarCambioSiCambio(productoId, "ACTUALIZACION", "descripcion", anterior.descripcion(), actual.getDescripcion(), actual.getEstado(), adminId);
+        registrarCambioSiCambio(productoId, "ACTUALIZACION", "categoria", anterior.categoria(), actual.getCategoria(), actual.getEstado(), adminId);
+        registrarCambioSiCambio(productoId, "ACTUALIZACION", "proveedor", anterior.proveedor(), actual.getProveedor(), actual.getEstado(), adminId);
+        registrarCambioSiCambio(productoId, "ACTUALIZACION", "precio", anterior.precio(), actual.getPrecio(), actual.getEstado(), adminId);
+        registrarCambioSiCambio(productoId, "ACTUALIZACION", "moneda", anterior.moneda(), actual.getMoneda(), actual.getEstado(), adminId);
+        registrarCambioSiCambio(productoId, "ACTUALIZACION", "imagenUrl", anterior.imagenUrl(), actual.getImagenUrl(), actual.getEstado(), adminId);
+        registrarCambioSiCambio(productoId, "ACTUALIZACION", "tipoCreditoId", anterior.tipoCreditoId(), actual.getTipoCreditoId(), actual.getEstado(), adminId);
+        registrarCambioSiCambio(productoId, "ACTUALIZACION", "plazoMinimoMeses", anterior.plazoMinimoMeses(), actual.getPlazoMinimoMeses(), actual.getEstado(), adminId);
+        registrarCambioSiCambio(productoId, "ACTUALIZACION", "plazoMaximoMeses", anterior.plazoMaximoMeses(), actual.getPlazoMaximoMeses(), actual.getEstado(), adminId);
+        registrarCambioSiCambio(productoId, "ACTUALIZACION", "porcentajeColateral", anterior.porcentajeColateral(), actual.getPorcentajeColateral(), actual.getEstado(), adminId);
+        registrarCambioSiCambio(productoId, "ACTUALIZACION", "requiereAprobacionManual", anterior.requiereAprobacionManual(), actual.getRequiereAprobacionManual(), actual.getEstado(), adminId);
+    }
+
+    private void registrarCambioSiCambio(
+            Long productoId,
+            String tipoEvento,
+            String campo,
+            Object valorAnterior,
+            Object valorNuevo,
+            String estado,
+            UUID actorId) {
+        String anterior = normalizarValorHistorial(valorAnterior);
+        String nuevo = normalizarValorHistorial(valorNuevo);
+        if (!Objects.equals(anterior, nuevo)) {
+            registrarCambio(productoId, tipoEvento, campo, anterior, nuevo, estado, actorId);
+        }
+    }
+
+    private void registrarCambio(
+            Long productoId,
+            String tipoEvento,
+            String campo,
+            Object valorAnterior,
+            Object valorNuevo,
+            String estado,
+            UUID actorId) {
+        ProductoHistorialCambioEntity entity = new ProductoHistorialCambioEntity();
+        entity.setProductoId(productoId);
+        entity.setTipoEvento(tipoEvento);
+        entity.setCampo(campo);
+        entity.setValorAnterior(normalizarValorHistorial(valorAnterior));
+        entity.setValorNuevo(normalizarValorHistorial(valorNuevo));
+        entity.setEstadoProducto(estado);
+        entity.setActorId(actorId);
+        entity.setCreatedAt(LocalDateTime.now());
+        historialRepository.save(entity);
+    }
+
+    private String normalizarValorHistorial(Object valor) {
+        if (valor == null) {
+            return null;
+        }
+        if (valor instanceof BigDecimal decimal) {
+            return decimal.stripTrailingZeros().toPlainString();
+        }
+        String text = String.valueOf(valor);
+        return text.isBlank() ? null : text;
+    }
+
     private void quitarPrincipal(Long productoId) {
         imagenRepository.findByProductoIdAndActivaTrue(productoId).forEach(imagen -> {
             if (Boolean.TRUE.equals(imagen.getEsPrincipal())) {
@@ -395,6 +507,38 @@ public class GestionarProductosFinanciablesUseCase {
             slug = base + "-" + i++;
         }
         return slug;
+    }
+
+    private record ProductoSnapshot(
+            String nombre,
+            String descripcion,
+            String categoria,
+            String proveedor,
+            BigDecimal precio,
+            String moneda,
+            String imagenUrl,
+            Long tipoCreditoId,
+            Integer plazoMinimoMeses,
+            Integer plazoMaximoMeses,
+            BigDecimal porcentajeColateral,
+            Boolean requiereAprobacionManual) {
+
+        private static ProductoSnapshot from(ProductoFinanciableEntity entity) {
+            return new ProductoSnapshot(
+                entity.getNombre(),
+                entity.getDescripcion(),
+                entity.getCategoria(),
+                entity.getProveedor(),
+                entity.getPrecio(),
+                entity.getMoneda(),
+                entity.getImagenUrl(),
+                entity.getTipoCreditoId(),
+                entity.getPlazoMinimoMeses(),
+                entity.getPlazoMaximoMeses(),
+                entity.getPorcentajeColateral(),
+                entity.getRequiereAprobacionManual()
+            );
+        }
     }
 
     public static class ProductoNoEncontradoException extends RuntimeException {

--- a/backend/src/main/java/com/tufondo/productos/infrastructure/persistence/entity/ProductoHistorialCambioEntity.java
+++ b/backend/src/main/java/com/tufondo/productos/infrastructure/persistence/entity/ProductoHistorialCambioEntity.java
@@ -1,0 +1,48 @@
+package com.tufondo.productos.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "producto_historial_cambios")
+@Getter
+@Setter
+public class ProductoHistorialCambioEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "producto_id", nullable = false)
+    private Long productoId;
+
+    @Column(name = "tipo_evento", nullable = false, length = 40)
+    private String tipoEvento;
+
+    @Column(name = "campo", length = 80)
+    private String campo;
+
+    @Column(name = "valor_anterior", columnDefinition = "TEXT")
+    private String valorAnterior;
+
+    @Column(name = "valor_nuevo", columnDefinition = "TEXT")
+    private String valorNuevo;
+
+    @Column(name = "estado_producto", length = 20)
+    private String estadoProducto;
+
+    @Column(name = "actor_id")
+    private UUID actorId;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/tufondo/productos/infrastructure/persistence/jpa/ProductoHistorialCambioJpaRepository.java
+++ b/backend/src/main/java/com/tufondo/productos/infrastructure/persistence/jpa/ProductoHistorialCambioJpaRepository.java
@@ -1,0 +1,11 @@
+package com.tufondo.productos.infrastructure.persistence.jpa;
+
+import com.tufondo.productos.infrastructure.persistence.entity.ProductoHistorialCambioEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProductoHistorialCambioJpaRepository extends JpaRepository<ProductoHistorialCambioEntity, Long> {
+
+    List<ProductoHistorialCambioEntity> findByProductoIdOrderByCreatedAtDesc(Long productoId);
+}

--- a/backend/src/main/java/com/tufondo/productos/presentation/controller/ProductoFinanciableController.java
+++ b/backend/src/main/java/com/tufondo/productos/presentation/controller/ProductoFinanciableController.java
@@ -5,6 +5,7 @@ import com.tufondo.creditos.application.dto.SolicitudCreditoResponse;
 import com.tufondo.productos.application.dto.PrecalificacionProductoResponse;
 import com.tufondo.productos.application.dto.ProductoFinanciableRequest;
 import com.tufondo.productos.application.dto.ProductoFinanciableResponse;
+import com.tufondo.productos.application.dto.ProductoHistorialCambioResponse;
 import com.tufondo.productos.application.usecase.GestionarProductosFinanciablesUseCase;
 import com.tufondo.productos.infrastructure.storage.ProductoImagenStorageService;
 import jakarta.validation.Valid;
@@ -87,26 +88,43 @@ public class ProductoFinanciableController {
     @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
     public ResponseEntity<ProductoFinanciableResponse> actualizar(
             @PathVariable Long id,
-            @Valid @RequestBody ProductoFinanciableRequest request) {
-        return ResponseEntity.ok(useCase.actualizar(id, request));
+            @Valid @RequestBody ProductoFinanciableRequest request,
+            Authentication authentication) {
+        return ResponseEntity.ok(useCase.actualizar(id, request, extraerUserId(authentication)));
+    }
+
+    @GetMapping("/admin/productos/{id}/historial")
+    @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
+    public ResponseEntity<Map<String, Object>> listarHistorial(@PathVariable Long id) {
+        List<ProductoHistorialCambioResponse> historial = useCase.listarHistorial(id);
+        return ResponseEntity.ok(Map.of(
+            "historial", historial,
+            "total", historial.size()
+        ));
     }
 
     @PostMapping("/admin/productos/{id}/publicar")
     @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
-    public ResponseEntity<ProductoFinanciableResponse> publicar(@PathVariable Long id) {
-        return ResponseEntity.ok(useCase.cambiarEstado(id, "PUBLICADO"));
+    public ResponseEntity<ProductoFinanciableResponse> publicar(
+            @PathVariable Long id,
+            Authentication authentication) {
+        return ResponseEntity.ok(useCase.cambiarEstado(id, "PUBLICADO", extraerUserId(authentication)));
     }
 
     @PostMapping("/admin/productos/{id}/pausar")
     @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
-    public ResponseEntity<ProductoFinanciableResponse> pausar(@PathVariable Long id) {
-        return ResponseEntity.ok(useCase.cambiarEstado(id, "PAUSADO"));
+    public ResponseEntity<ProductoFinanciableResponse> pausar(
+            @PathVariable Long id,
+            Authentication authentication) {
+        return ResponseEntity.ok(useCase.cambiarEstado(id, "PAUSADO", extraerUserId(authentication)));
     }
 
     @PostMapping("/admin/productos/{id}/archivar")
     @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
-    public ResponseEntity<ProductoFinanciableResponse> archivar(@PathVariable Long id) {
-        return ResponseEntity.ok(useCase.cambiarEstado(id, "ARCHIVADO"));
+    public ResponseEntity<ProductoFinanciableResponse> archivar(
+            @PathVariable Long id,
+            Authentication authentication) {
+        return ResponseEntity.ok(useCase.cambiarEstado(id, "ARCHIVADO", extraerUserId(authentication)));
     }
 
     @PostMapping(value = "/admin/productos/{id}/imagen", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -135,16 +153,18 @@ public class ProductoFinanciableController {
     @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
     public ResponseEntity<ProductoFinanciableResponse> marcarImagenPrincipal(
             @PathVariable Long id,
-            @PathVariable Long imagenId) {
-        return ResponseEntity.ok(useCase.marcarImagenPrincipal(id, imagenId));
+            @PathVariable Long imagenId,
+            Authentication authentication) {
+        return ResponseEntity.ok(useCase.marcarImagenPrincipal(id, imagenId, extraerUserId(authentication)));
     }
 
     @DeleteMapping("/admin/productos/{id}/imagenes/{imagenId}")
     @PreAuthorize("hasAnyRole('ADMIN', 'SUPER_ADMIN')")
     public ResponseEntity<ProductoFinanciableResponse> eliminarImagen(
             @PathVariable Long id,
-            @PathVariable Long imagenId) {
-        return ResponseEntity.ok(useCase.desactivarImagen(id, imagenId));
+            @PathVariable Long imagenId,
+            Authentication authentication) {
+        return ResponseEntity.ok(useCase.desactivarImagen(id, imagenId, extraerUserId(authentication)));
     }
 
     @GetMapping("/productos/imagenes/{fecha}/{fileName}")

--- a/backend/src/main/resources/db/migration/V25__producto_historial_cambios.sql
+++ b/backend/src/main/resources/db/migration/V25__producto_historial_cambios.sql
@@ -1,0 +1,14 @@
+CREATE TABLE producto_historial_cambios (
+    id BIGSERIAL PRIMARY KEY,
+    producto_id BIGINT NOT NULL REFERENCES productos_financiables(id) ON DELETE CASCADE,
+    tipo_evento VARCHAR(40) NOT NULL,
+    campo VARCHAR(80),
+    valor_anterior TEXT,
+    valor_nuevo TEXT,
+    estado_producto VARCHAR(20),
+    actor_id UUID,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_producto_historial_producto_fecha
+    ON producto_historial_cambios(producto_id, created_at DESC);

--- a/frontend-web/src/app/(admin)/admin/productos/page.tsx
+++ b/frontend-web/src/app/(admin)/admin/productos/page.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
+  History,
   ImageIcon,
   Pencil,
   PackageOpen,
@@ -52,6 +53,17 @@ interface Producto {
   estado: string;
 }
 
+interface ProductoHistorialCambio {
+  id: number;
+  tipoEvento: string;
+  campo?: string | null;
+  valorAnterior?: string | null;
+  valorNuevo?: string | null;
+  estadoProducto?: string | null;
+  actorId?: string | null;
+  createdAt: string;
+}
+
 interface TipoCredito {
   id: number;
   nombre: string;
@@ -78,6 +90,18 @@ function formatMoney(value: number, currency: string) {
   return `${prefix} ${Number(value || 0).toLocaleString("es-VE", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 }
 
+function formatHistorialLabel(item: ProductoHistorialCambio) {
+  const labels: Record<string, string> = {
+    ACTUALIZACION: "Actualizacion",
+    CAMBIO_ESTADO: "Cambio de estado",
+    CREACION: "Creacion",
+    IMAGEN_AGREGADA: "Imagen agregada",
+    IMAGEN_ELIMINADA: "Imagen eliminada",
+    IMAGEN_PRINCIPAL: "Imagen principal",
+  };
+  return labels[item.tipoEvento] || item.tipoEvento;
+}
+
 export default function AdminProductosPage() {
   const [productos, setProductos] = useState<Producto[]>([]);
   const [tiposCredito, setTiposCredito] = useState<TipoCredito[]>([]);
@@ -86,6 +110,9 @@ export default function AdminProductosPage() {
   const [saving, setSaving] = useState(false);
   const [uploadingId, setUploadingId] = useState<number | null>(null);
   const [editingProduct, setEditingProduct] = useState<Producto | null>(null);
+  const [historyProductId, setHistoryProductId] = useState<number | null>(null);
+  const [historial, setHistorial] = useState<ProductoHistorialCambio[]>([]);
+  const [loadingHistorial, setLoadingHistorial] = useState(false);
 
   useEffect(() => {
     cargarDatos();
@@ -164,6 +191,9 @@ export default function AdminProductosPage() {
       }
       resetForm();
       await cargarDatos();
+      if (editingProduct && historyProductId === editingProduct.id) {
+        await cargarHistorial(editingProduct.id);
+      }
     } finally {
       setSaving(false);
     }
@@ -175,6 +205,29 @@ export default function AdminProductosPage() {
   ) => {
     await productosApi[action](producto.id);
     await cargarDatos();
+    if (historyProductId === producto.id) {
+      await cargarHistorial(producto.id);
+    }
+  };
+
+  const cargarHistorial = async (productoId: number) => {
+    setHistoryProductId(productoId);
+    setLoadingHistorial(true);
+    try {
+      const response = await productosApi.getHistorial(productoId);
+      setHistorial(response.data.historial || []);
+    } finally {
+      setLoadingHistorial(false);
+    }
+  };
+
+  const toggleHistorial = async (productoId: number) => {
+    if (historyProductId === productoId) {
+      setHistoryProductId(null);
+      setHistorial([]);
+      return;
+    }
+    await cargarHistorial(productoId);
   };
 
   const subirImagen = async (producto: Producto, file?: File) => {
@@ -187,6 +240,9 @@ export default function AdminProductosPage() {
           item.id === producto.id ? { ...item, ...response.data } : item,
         ),
       );
+      if (historyProductId === producto.id) {
+        await cargarHistorial(producto.id);
+      }
     } finally {
       setUploadingId(null);
     }
@@ -205,6 +261,9 @@ export default function AdminProductosPage() {
         item.id === producto.id ? { ...item, ...response.data } : item,
       ),
     );
+    if (historyProductId === producto.id) {
+      await cargarHistorial(producto.id);
+    }
   };
 
   const eliminarImagen = async (producto: Producto, imagen: ProductoImagen) => {
@@ -214,6 +273,9 @@ export default function AdminProductosPage() {
         item.id === producto.id ? { ...item, ...response.data } : item,
       ),
     );
+    if (historyProductId === producto.id) {
+      await cargarHistorial(producto.id);
+    }
   };
 
   return (
@@ -570,6 +632,14 @@ export default function AdminProductosPage() {
                         <Pencil className="mr-2 h-4 w-4" />
                         Editar
                       </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => void toggleHistorial(producto.id)}
+                      >
+                        <History className="mr-2 h-4 w-4" />
+                        Historial
+                      </Button>
                       {producto.estado !== "PUBLICADO" ? (
                         <Button
                           size="sm"
@@ -591,6 +661,93 @@ export default function AdminProductosPage() {
                       )}
                     </div>
                   </div>
+                  {historyProductId === producto.id && (
+                    <div className="mt-5 rounded-md border border-slate-200 bg-slate-50 p-4">
+                      <div className="mb-3 flex items-center justify-between gap-3">
+                        <div>
+                          <h3 className="text-sm font-semibold text-slate-950">
+                            Historial de cambios
+                          </h3>
+                          <p className="text-xs text-slate-500">
+                            Registro operativo del catalogo y sus imagenes.
+                          </p>
+                        </div>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => {
+                            setHistoryProductId(null);
+                            setHistorial([]);
+                          }}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                      {loadingHistorial ? (
+                        <div className="py-6 text-sm text-slate-500">
+                          Cargando historial...
+                        </div>
+                      ) : historial.length === 0 ? (
+                        <div className="py-6 text-sm text-slate-500">
+                          Este producto aun no tiene cambios registrados.
+                        </div>
+                      ) : (
+                        <div className="max-h-72 space-y-2 overflow-y-auto pr-1">
+                          {historial.map((item) => (
+                            <div
+                              key={item.id}
+                              className="rounded-md border border-slate-200 bg-white p-3"
+                            >
+                              <div className="flex flex-wrap items-center gap-2">
+                                <Badge variant="outline">
+                                  {formatHistorialLabel(item)}
+                                </Badge>
+                                {item.campo && (
+                                  <span className="text-xs font-medium text-slate-600">
+                                    {item.campo}
+                                  </span>
+                                )}
+                                {item.estadoProducto && (
+                                  <span className="text-xs text-slate-500">
+                                    Estado: {item.estadoProducto}
+                                  </span>
+                                )}
+                                <span className="ml-auto text-xs text-slate-500">
+                                  {new Date(item.createdAt).toLocaleString(
+                                    "es-VE",
+                                  )}
+                                </span>
+                              </div>
+                              {(item.valorAnterior || item.valorNuevo) && (
+                                <div className="mt-2 grid gap-2 text-xs text-slate-600 md:grid-cols-2">
+                                  <div className="min-w-0 rounded bg-slate-100 px-2 py-1">
+                                    <span className="font-medium">
+                                      Anterior:
+                                    </span>{" "}
+                                    <span className="break-words">
+                                      {item.valorAnterior || "Sin valor"}
+                                    </span>
+                                  </div>
+                                  <div className="min-w-0 rounded bg-emerald-50 px-2 py-1 text-emerald-900">
+                                    <span className="font-medium">Nuevo:</span>{" "}
+                                    <span className="break-words">
+                                      {item.valorNuevo || "Sin valor"}
+                                    </span>
+                                  </div>
+                                </div>
+                              )}
+                              {item.actorId && (
+                                <p className="mt-2 truncate text-xs text-slate-400">
+                                  Admin: {item.actorId}
+                                </p>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
                 </CardContent>
               </Card>
             ))

--- a/frontend-web/src/lib/api/client.ts
+++ b/frontend-web/src/lib/api/client.ts
@@ -175,6 +175,8 @@ export const productosApi = {
   solicitarFinanciamiento: (id: number) =>
     apiClient.post(`/v1/productos/${id}/solicitar-financiamiento`),
   getAdmin: () => apiClient.get("/v1/admin/productos"),
+  getHistorial: (id: number) =>
+    apiClient.get(`/v1/admin/productos/${id}/historial`),
   crear: (data: unknown) => apiClient.post("/v1/admin/productos", data),
   actualizar: (id: number, data: unknown) =>
     apiClient.put(`/v1/admin/productos/${id}`, data),


### PR DESCRIPTION
## Resumen
- agrega tabla, entidad, repositorio y DTO para historial de cambios de productos financiables
- registra creacion, actualizaciones de campos, cambios de estado y eventos de imagenes con actor administrador
- agrega endpoint admin y panel inline de historial en el catalogo de productos

## Pruebas
- npm.cmd run build (frontend-web)
- git diff --check

## Nota
- No pude ejecutar pruebas backend localmente porque esta maquina no tiene java/mvn en PATH y Docker no esta disponible desde la sesion.